### PR TITLE
Fix duplicate AnalyticsV2 test titles

### DIFF
--- a/frontend/src/analytics/v2/pages/AnalyticsV2Page.test.tsx
+++ b/frontend/src/analytics/v2/pages/AnalyticsV2Page.test.tsx
@@ -125,7 +125,7 @@ describe('AnalyticsV2Page', () => {
     });
   });
 
-  it('re-runs the preset when a live time range is selected', async () => {
+  it('re-runs the preset when a live time range is selected via the inspector chip', async () => {
     const chart = timeSeriesResult as unknown as ChartResult;
     mockRunAnalytics.mockResolvedValue({
       result: chart,
@@ -192,7 +192,7 @@ describe('AnalyticsV2Page', () => {
     });
   });
 
-  it('re-runs the preset when a live time range is selected', async () => {
+  it('re-runs the preset when a live time range is selected from the preset toolbar', async () => {
     const chart = timeSeriesResult as unknown as ChartResult;
     mockRunAnalytics.mockResolvedValue({
       result: chart,


### PR DESCRIPTION
## Summary
- rename duplicate AnalyticsV2Page preset rerun tests so each describe block has unique titles

## Testing
- pytest
- npm --prefix frontend run lint
- CI=true npm --prefix frontend test
- npm --prefix frontend run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918b7e3198c833086223076090d3ab8)