### PR TITLE
Fix scoped analytics projection and add event_type regression tests

### DIFF
--- a/backend/app/analytics/compiler.py
+++ b/backend/app/analytics/compiler.py
@@ -281,12 +281,12 @@ class SpecCompiler:
             f"""
             scoped AS (
                 SELECT
-                    timestamp,
-                    event_type,
-                    IFNULL(index, 0) AS event_index,
                     site_id,
                     cam_id,
+                    IFNULL(index, 0) AS event_index,
                     track_no,
+                    event_type,
+                    timestamp,
                     COALESCE(sex, '{_UNKNOWN_DIMENSION_VALUE}') AS sex,
                     COALESCE(age_bucket, '{_UNKNOWN_DIMENSION_VALUE}') AS age_bucket
                 FROM `{table_name}`
@@ -646,7 +646,7 @@ class SpecCompiler:
                     timestamp AS entrance_ts,
                     ROW_NUMBER() OVER (
                         PARTITION BY site_id, cam_id, track_no
-                        ORDER BY timestamp, index
+                        ORDER BY timestamp, event_index
                     ) AS rn
                 FROM scoped
                 WHERE event_type = 1
@@ -664,7 +664,7 @@ class SpecCompiler:
                     timestamp AS exit_ts,
                     ROW_NUMBER() OVER (
                         PARTITION BY site_id, cam_id, track_no
-                        ORDER BY timestamp, index
+                        ORDER BY timestamp, event_index
                     ) AS rn
                 FROM scoped
                 WHERE event_type = 0
@@ -804,7 +804,7 @@ class SpecCompiler:
                     timestamp,
                     LAG(timestamp) OVER (
                         PARTITION BY site_id, track_no
-                        ORDER BY timestamp, index
+                        ORDER BY timestamp, event_index
                     ) AS prev_timestamp
                 FROM scoped
                 WHERE event_type = 1

--- a/backend/tests/test_analytics_compiler_event_fields.py
+++ b/backend/tests/test_analytics_compiler_event_fields.py
@@ -1,0 +1,100 @@
+"""Regression tests guarding event_type projection throughout compiler outputs."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.app.analytics.compiler import CompilerContext, SpecCompiler
+from backend.app.analytics.dashboard_catalogue import DASHBOARD_SPEC_CATALOGUE
+from backend.app.analytics.data_contract import (
+    Dimension,
+    Metric,
+    QueryContext,
+    compile_contract_query,
+)
+
+UTC = timezone.utc
+
+
+def _extract_ctes(sql: str) -> dict[str, str]:
+    pattern = re.compile(r"(\w+)\s+AS\s+\(")
+    ctes: dict[str, str] = {}
+    for match in pattern.finditer(sql):
+        name = match.group(1)
+        start = match.end()
+        depth = 1
+        idx = start
+        while idx < len(sql) and depth:
+            char = sql[idx]
+            if char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+            idx += 1
+        body = sql[start : idx - 1]
+        ctes[name] = body
+    return ctes
+
+
+def _assert_event_type_scope(sql: str) -> None:
+    ctes = _extract_ctes(sql)
+    assert "scoped" in ctes, "scoped CTE missing from compiled SQL"
+    scoped_body = ctes["scoped"]
+    assert "event_type" in scoped_body, "scoped CTE must project event_type"
+
+    for name, body in ctes.items():
+        if name == "scoped":
+            continue
+        if "event_type" not in body:
+            continue
+        assert (
+            "FROM scoped" in body
+            or "JOIN scoped" in body
+            or "scoped." in body
+        ), f"{name} references event_type without scoped context"
+
+
+def _context(bucket: str) -> QueryContext:
+    return QueryContext(
+        org_id="client0",
+        table_name="project.dataset.client0",
+        start=datetime(2024, 1, 1, tzinfo=UTC),
+        end=datetime(2024, 1, 2, tzinfo=UTC),
+        bucket=bucket,
+    )
+
+
+def test_dashboard_live_flow_preserves_event_type_scope() -> None:
+    spec = DASHBOARD_SPEC_CATALOGUE["dashboard.live_flow"]
+    compiler = SpecCompiler()
+    compiled = compiler.compile(spec, CompilerContext(table_name="project.dataset.client0"))
+    _assert_event_type_scope(compiled.sql)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [Metric.OCCUPANCY, Metric.ENTRANCES, Metric.EXITS],
+)
+def test_contract_activity_metrics_reference_event_type_from_scoped(metric: Metric) -> None:
+    ctx = _context(bucket="HOUR")
+    plan = compile_contract_query(metric, [Dimension.TIME], ctx)
+    _assert_event_type_scope(plan.sql)
+
+
+def test_dwell_pipeline_keeps_event_type_in_scope() -> None:
+    ctx = _context(bucket="HOUR")
+    plan = compile_contract_query(Metric.AVG_DWELL, [Dimension.TIME], ctx)
+    _assert_event_type_scope(plan.sql)
+
+
+def test_retention_pipeline_keeps_event_type_in_scope() -> None:
+    ctx = _context(bucket="WEEK")
+    plan = compile_contract_query(
+        Metric.RETENTION_RATE,
+        [Dimension.TIME, Dimension.RETENTION_LAG],
+        ctx,
+    )
+    _assert_event_type_scope(plan.sql)

--- a/backend/tests/test_data_contract.py
+++ b/backend/tests/test_data_contract.py
@@ -140,8 +140,8 @@ def test_scoped_cte_projects_canonical_columns() -> None:
     plan = compile_contract_query(Metric.OCCUPANCY, [Dimension.TIME], ctx)
     projection = _scoped_projection(plan.sql)
     expected = (
-        "timestamp, event_type, IFNULL(index, 0) AS event_index, site_id, cam_id, "
-        "track_no, COALESCE(sex, 'Unknown') AS sex, COALESCE(age_bucket, 'Unknown') AS age_bucket"
+        "site_id, cam_id, IFNULL(index, 0) AS event_index, track_no, event_type, timestamp, "
+        "COALESCE(sex, 'Unknown') AS sex, COALESCE(age_bucket, 'Unknown') AS age_bucket"
     )
     assert projection == " ".join(expected.split())
 


### PR DESCRIPTION
## Summary
- ensure the scoped events CTE always projects the full canonical schema so downstream SQL blocks can safely reference `event_type`
- fix dwell and retention pipelines to use the projected `event_index` column instead of a missing raw `index`
- add regression tests that parse compiled SQL for live flow, activity, dwell, and retention specs to verify that `event_type` only appears while `scoped` data is available

## Testing
- `pytest`
- `npm --prefix frontend run lint`
- `CI=true npm --prefix frontend test`
- `npm --prefix frontend run build`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6918f46a046c8333b13d465d51f63547)