### PR TITLE
Ensure retention heatmap results are contract compliant

### DIFF
--- a/backend/app/analytics/engine.py
+++ b/backend/app/analytics/engine.py
@@ -396,9 +396,9 @@ class AnalyticsEngine:
         series: List[Dict[str, Any]] = []
         for measure_id, aggregation in measures.items():
             subset = frame[frame["measure_id"] == measure_id]
-            cohorts: List[str] = []
+            cell_map: Dict[tuple[str, int], tuple[Optional[float], Optional[float]]] = {}
+            cohorts: Dict[str, Any] = {}
             lags: List[int] = []
-            data_points: List[Dict[str, Any]] = []
 
             for record in subset.to_dict("records"):
                 bucket = record.get("bucket_start")
@@ -413,25 +413,38 @@ class AnalyticsEngine:
                 coverage_value = _coerce_number(record.get("coverage"))
 
                 bucket_iso = _to_iso(bucket)
-                cohorts.append(bucket_iso)
+                cohorts[bucket_iso] = bucket
                 lags.append(int(lag_value))
+                cell_map[(bucket_iso, int(lag_value))] = (value, coverage_value)
 
-                point: Dict[str, Any] = {
-                    "x": bucket_iso,
-                    "group": (
-                        f"Month {lag_value}" if compiled.bucket == "MONTH" else f"Week {lag_value}"
-                    ),
-                    "value": float(value) if value is not None else None,
-                }
-                if coverage_value is not None:
-                    point["coverage"] = float(coverage_value)
+            # Ensure a complete matrix for all observed cohorts and lags.
+            cohort_labels = [
+                _to_iso(value)
+                for value in sorted(set(cohorts.values()))
+                if value is not None and not (hasattr(pd, "isna") and pd.isna(value))
+            ]
+            lag_indexes = sorted(set(lags))
 
-                data_points.append(point)
+            data_points: List[Dict[str, Any]] = []
+            for lag_value in lag_indexes:
+                group_label = (
+                    f"Month {lag_value}" if compiled.bucket == "MONTH" else f"Week {lag_value}"
+                )
+                for cohort_label in cohort_labels:
+                    value, coverage_value = cell_map.get((cohort_label, lag_value), (None, None))
+                    point: Dict[str, Any] = {
+                        "x": cohort_label,
+                        "group": group_label,
+                        "value": float(value) if value is not None else None,
+                    }
+                    if coverage_value is not None:
+                        point["coverage"] = float(coverage_value)
 
-            data_points.sort(key=lambda item: (item["x"], item["group"]))
+                    data_points.append(point)
+
             summary = {
                 "points": len(data_points),
-                "cohorts": len(set(cohorts)),
+                "cohorts": len(cohort_labels),
                 "lags": len(set(lags)),
                 "measures": list(measures.keys()),
             }
@@ -458,7 +471,7 @@ class AnalyticsEngine:
         }
 
         return {
-            "chartType": "heatmap",
+            "chartType": "retention",
             "xDimension": x_dimension,
             "series": series,
             "meta": meta,

--- a/backend/app/analytics/generate_expected.py
+++ b/backend/app/analytics/generate_expected.py
@@ -227,19 +227,23 @@ def build_demographics(events: pd.DataFrame) -> Dict:
 
 def build_retention(events: pd.DataFrame) -> Dict:
     matrix = retention_matrix(events)
+    cohorts = sorted(matrix.keys())
+    lag_indexes = sorted({lag for lags in matrix.values() for lag in lags.keys()})
     data_points: List[Dict] = []
-    for cohort, lags in sorted(matrix.items()):
-        for lag, rate in sorted(lags.items()):
+    for lag in lag_indexes:
+        group_label = f"Week {lag}"
+        for cohort in cohorts:
+            value = matrix.get(cohort, {}).get(lag)
             data_points.append(
                 {
                     "x": cohort,
-                    "group": f"Week {lag}",
-                    "value": _round(rate),
+                    "group": group_label,
+                    "value": _round(value) if value is not None else None,
                 }
             )
 
     return {
-        "chartType": "heatmap",
+        "chartType": "retention",
         "xDimension": {"id": "cohort_week", "type": "matrix", "label": "Cohort week"},
         "series": [
             {
@@ -248,7 +252,8 @@ def build_retention(events: pd.DataFrame) -> Dict:
                 "geometry": "heatmap",
                 "data": data_points,
                 "summary": {
-                    "cohorts": len(matrix),
+                    "cohorts": len(cohorts),
+                    "lags": len(lag_indexes),
                 },
             }
         ],

--- a/backend/tests/test_analytics_engine_phase2.py
+++ b/backend/tests/test_analytics_engine_phase2.py
@@ -304,11 +304,14 @@ def test_engine_normalises_retention_heatmap():
     spec = {
         "id": "retention-heatmap",
         "dataset": "events",
-        "chartType": "heatmap",
+        "chartType": "retention",
         "measures": [
             {"id": "retention", "aggregation": "retention_rate"},
         ],
-        "dimensions": [{"id": "cohort", "column": "timestamp", "bucket": "WEEK"}],
+        "dimensions": [
+            {"id": "cohort_week", "column": "cohort_week", "bucket": "WEEK", "sort": "asc"}
+        ],
+        "splits": [{"id": "retention_lag", "column": "lag_weeks", "sort": "asc"}],
         "timeWindow": {
             "from": "2024-01-01T00:00:00Z",
             "to": "2024-02-12T00:00:00Z",
@@ -346,10 +349,11 @@ def test_engine_normalises_retention_heatmap():
     )
 
     result = engine.execute(spec, organisation="client0", bypass_cache=True)
-    assert result["chartType"] == "heatmap"
+    assert result["chartType"] == "retention"
     series = result["series"][0]
     assert series["geometry"] == "heatmap"
     assert series["unit"] == "rate"
+    assert series["data"][0]["group"] == "Week 0"
     assert series["data"][1]["group"] == "Week 1"
     assert series["data"][1]["coverage"] == 0.8
     assert "rawCount" not in series["data"][0]
@@ -361,11 +365,14 @@ def test_engine_handles_missing_retention_lag_values():
     spec = {
         "id": "retention-heatmap",
         "dataset": "events",
-        "chartType": "heatmap",
+        "chartType": "retention",
         "measures": [
             {"id": "retention_rate", "aggregation": "retention_rate"},
         ],
-        "dimensions": [{"id": "cohort", "column": "timestamp", "bucket": "WEEK"}],
+        "dimensions": [
+            {"id": "cohort_week", "column": "cohort_week", "bucket": "WEEK", "sort": "asc"}
+        ],
+        "splits": [{"id": "retention_lag", "column": "lag_weeks", "sort": "asc"}],
         "timeWindow": {
             "from": "2024-01-01T00:00:00Z",
             "to": "2024-02-12T00:00:00Z",

--- a/backend/tests/test_retention_heatmap_contract.py
+++ b/backend/tests/test_retention_heatmap_contract.py
@@ -19,11 +19,14 @@ def _retention_spec() -> dict:
     return {
         "id": "retention-heatmap",
         "dataset": "events",
-        "chartType": "heatmap",
+        "chartType": "retention",
         "measures": [
             {"id": "retention_rate", "aggregation": "retention_rate"},
         ],
-        "dimensions": [{"id": "cohort", "column": "timestamp", "bucket": "WEEK"}],
+        "dimensions": [
+            {"id": "cohort_week", "column": "cohort_week", "bucket": "WEEK", "sort": "asc"}
+        ],
+        "splits": [{"id": "retention_lag", "column": "lag_weeks", "sort": "asc"}],
         "timeWindow": {
             "from": "2024-01-01T00:00:00Z",
             "to": "2024-02-12T00:00:00Z",
@@ -54,8 +57,8 @@ def test_retention_heatmap_chartresult_passes_validator():
                 "measure_id": "retention_rate",
                 "bucket_start": pd.Timestamp("2024-01-08T00:00:00Z"),
                 "lag_weeks": 0,
-                "value": 1.0,
-                "coverage": 1.0,
+                "value": 0.75,
+                "coverage": 0.95,
             },
         ]
     )
@@ -72,6 +75,95 @@ def test_retention_heatmap_chartresult_passes_validator():
 
     validate_chart_result(result)
     series = result["series"][0]
+    assert result["chartType"] == "retention"
     assert series["summary"]["cohorts"] == 2
     assert series["summary"]["lags"] == 2
+    assert len(series["data"]) == 4
+    # Ensure missing cohort/lag combinations are still represented with null values.
+    assert any(point["value"] is None for point in series["data"] if point["group"] == "Week 1")
     assert all("rawCount" not in point for point in series["data"])
+
+
+def test_retention_heatmap_all_time_range_fills_matrix():
+    spec = _retention_spec()
+    spec["timeWindow"] = {
+        "from": "2023-01-01T00:00:00Z",
+        "to": "2024-02-12T00:00:00Z",
+        "bucket": "WEEK",
+        "timezone": "UTC",
+    }
+
+    frame = pd.DataFrame(
+        [
+            {
+                "measure_id": "retention_rate",
+                "bucket_start": pd.Timestamp("2023-12-25T00:00:00Z"),
+                "lag_weeks": 0,
+                "value": 1.0,
+                "coverage": 1.0,
+            },
+            {
+                "measure_id": "retention_rate",
+                "bucket_start": pd.Timestamp("2023-12-25T00:00:00Z"),
+                "lag_weeks": 1,
+                "value": 0.55,
+                "coverage": 0.8,
+            },
+            {
+                "measure_id": "retention_rate",
+                "bucket_start": pd.Timestamp("2023-12-25T00:00:00Z"),
+                "lag_weeks": 2,
+                "value": 0.25,
+                "coverage": 0.7,
+            },
+            {
+                "measure_id": "retention_rate",
+                "bucket_start": pd.Timestamp("2024-01-01T00:00:00Z"),
+                "lag_weeks": 0,
+                "value": 1.0,
+                "coverage": 1.0,
+            },
+            {
+                "measure_id": "retention_rate",
+                "bucket_start": pd.Timestamp("2024-01-01T00:00:00Z"),
+                "lag_weeks": 2,
+                "value": 0.4,
+                "coverage": 0.65,
+            },
+            {
+                "measure_id": "retention_rate",
+                "bucket_start": pd.Timestamp("2024-01-08T00:00:00Z"),
+                "lag_weeks": 0,
+                "value": 1.0,
+                "coverage": 0.9,
+            },
+        ]
+    )
+
+    stub = StubBigQueryClient(frame)
+    cache = SpecCache(LocalCacheBackend(), default_ttl=60)
+    engine = AnalyticsEngine(
+        table_router=TableRouter({"client0": "nigzsu.dataset.client0"}),
+        bigquery_client=stub,
+        cache=cache,
+    )
+
+    result = engine.execute(spec, organisation="client0", bypass_cache=True)
+
+    validate_chart_result(result)
+    series = result["series"][0]
+    cohorts = {"2023-12-25T00:00:00Z", "2024-01-01T00:00:00Z", "2024-01-08T00:00:00Z"}
+    groups = {"Week 0", "Week 1", "Week 2"}
+
+    assert len(series["data"]) == len(cohorts) * len(groups)
+    assert {point["x"] for point in series["data"]} == cohorts
+    assert {point["group"] for point in series["data"]} == groups
+    assert series["summary"]["cohorts"] == 3
+    assert series["summary"]["lags"] == 3
+    assert (
+        next(
+            (point for point in series["data"] if point["x"] == "2024-01-08T00:00:00Z" and point["group"] == "Week 1"),
+            {},
+        ).get("value")
+        is None
+    )

--- a/frontend/src/analytics/examples/golden_retention_heatmap.json
+++ b/frontend/src/analytics/examples/golden_retention_heatmap.json
@@ -1,5 +1,5 @@
 {
-  "chartType": "heatmap",
+  "chartType": "retention",
   "xDimension": {
     "id": "cohort_week",
     "type": "matrix",
@@ -10,23 +10,31 @@
       "id": "retention_rate",
       "label": "Weekly retention",
       "geometry": "heatmap",
-      "unit": "percentage",
       "data": [
-        { "x": "2023-12-26T00:00:00Z", "group": "Week 0", "value": 1.0 },
-        { "x": "2024-01-02T00:00:00Z", "group": "Week 0", "value": 0.86 },
-        { "x": "2024-01-09T00:00:00Z", "group": "Week 0", "value": 0.68 },
-        { "x": "2024-01-16T00:00:00Z", "group": "Week 0", "value": 0.53 },
-        { "x": "2023-12-26T00:00:00Z", "group": "Week 1", "value": 1.0 },
-        { "x": "2024-01-02T00:00:00Z", "group": "Week 1", "value": 0.82 },
-        { "x": "2024-01-09T00:00:00Z", "group": "Week 1", "value": 0.63 },
-        { "x": "2024-01-16T00:00:00Z", "group": "Week 1", "value": 0.49 },
-        { "x": "2023-12-26T00:00:00Z", "group": "Week 2", "value": 1.0 },
-        { "x": "2024-01-02T00:00:00Z", "group": "Week 2", "value": 0.74 },
-        { "x": "2024-01-09T00:00:00Z", "group": "Week 2", "value": 0.55 },
-        { "x": "2024-01-16T00:00:00Z", "group": "Week 2", "value": 0.42 }
+        {
+          "x": "2023-12-26T00:00:00Z",
+          "group": "Week 0",
+          "value": 1.0
+        },
+        {
+          "x": "2024-01-02T00:00:00Z",
+          "group": "Week 0",
+          "value": 1.0
+        },
+        {
+          "x": "2023-12-26T00:00:00Z",
+          "group": "Week 1",
+          "value": null
+        },
+        {
+          "x": "2024-01-02T00:00:00Z",
+          "group": "Week 1",
+          "value": 1.0
+        }
       ],
       "summary": {
-        "cohorts": 3
+        "cohorts": 2,
+        "lags": 2
       }
     }
   ],

--- a/shared/analytics/examples/golden_retention_heatmap.json
+++ b/shared/analytics/examples/golden_retention_heatmap.json
@@ -1,5 +1,5 @@
 {
-  "chartType": "heatmap",
+  "chartType": "retention",
   "xDimension": {
     "id": "cohort_week",
     "type": "matrix",
@@ -22,13 +22,19 @@
           "value": 1.0
         },
         {
+          "x": "2023-12-26T00:00:00Z",
+          "group": "Week 1",
+          "value": null
+        },
+        {
           "x": "2024-01-02T00:00:00Z",
           "group": "Week 1",
           "value": 1.0
         }
       ],
       "summary": {
-        "cohorts": 2
+        "cohorts": 2,
+        "lags": 2
       }
     }
   ],


### PR DESCRIPTION
## Summary
- reshape the retention heatmap normaliser to emit full cohort/lag matrices and label results as retention charts
- update golden retention fixtures and generator to the rectangular grid format expected by the contract
- add preset-style retention heatmap tests covering missing lag cells and all-time ranges

## Testing
- pytest
- npm --prefix frontend run lint
- CI=true npm --prefix frontend test -- --watch=false --silent
- npm --prefix frontend run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691a1b91c6f4832a88e4b8e292f2811a)