### PR TITLE
Implement VRM KPI band and fixed 24h/15m widgets

### DIFF
--- a/docs/dashboard-v2-live-kpis.md
+++ b/docs/dashboard-v2-live-kpis.md
@@ -1,0 +1,38 @@
+# Dashboard v2 KPI Reference
+
+## Routing and surface
+- The React app (CRA) routes `/dashboard` through `App.tsx`, wrapping content in `VRMLayout` and choosing `DashboardV2Page` by default via `EXPERIENCE_GATES.dashboard.default` (defaults to `v2` in non-production). Legacy `DashboardPage` exists but is not rendered unless the flag is flipped.
+- `DashboardV2Page` is the live manifest-driven dashboard. It loads a dashboard manifest (default ID `dashboard-default`) and renders KPI tiles from `manifest.layout.kpiBand`. Other dashboards are legacy/unused unless explicitly routed.
+
+## Data flow
+- Manifests are fetched from `/api/dashboards/{dashboardId}` with `orgId` or `viewToken` query params. If loading fails, the page shows an error banner and stops rendering.
+- Each widget is executed by POSTing `/api/analytics/run` with a built `chart spec` (either inline or referenced). Specs can be run live or via fixtures depending on `ANALYTICS_V2_TRANSPORT` and widget `fixtureId`.
+- `buildWidgetSpec` clones the inline spec and optionally overrides `timeWindow` and timestamp dimension bucket using the selected manifest time range (duration/backfill from `now`, optional `timezone`).
+- Widget results are validated, then displayed through `ChartRenderer`, which renders KPI tiles for `single_value` chart types.
+
+## Time controls
+- `DashboardV2Page` pulls time range options from `manifest.timeControls.options` and sets `selectedTimeRangeId` to the manifest default (e.g., `all_time`) or the first option. Changing the dropdown triggers a full widget reload with the new time window applied through `buildWidgetSpec`.
+- When a time range is applied, `from` = `now - durationMinutes` (or epoch if `allTime`), `to` = `now`, and the bucket is set to the option’s `bucket`. Without a selection, inline `timeWindow` values remain (e.g., `{{TODAY_START}}` → now for “today” KPIs). All timestamps are treated as UTC unless the manifest supplies a different timezone.
+
+## KPI tile rendering behavior
+- `KpiTile` (analytics ChartRenderer primitive) displays the primary series label as the card title, main value from the latest data point, optional unit, raw count, coverage badge (from `coverage` on the latest point), delta badge (from `series.summary.delta`), and a sparkline built from series data values. No per-card spinners exist; the entire dashboard shows loading/error banners while data is fetched.
+- Colors default to the series color or `#2d6cdf`; sparklines are `AreaChart` (Recharts) without animation.
+
+## Live KPI widgets in the default manifest
+The default manifest (`dashboard_manifest_default.json`) defines six KPI widgets in the KPI band. Titles in the UI come from `widget.title`, while the card label comes from the series label.
+
+| Widget ID | Display title | Measure | Time window (inline before overrides) | Notes |
+| --- | --- | --- | --- | --- |
+| `kpi-activity-today` | Activity Today/Total | `count` of all events (`activity_total`) | `{{TODAY_START}}` → `{{NOW}}`, bucket `HOUR`, timezone `UTC` | Counts entrances + exits since local midnight. |
+| `kpi-entrances-today` | Entrances Today | `count` with `eventTypes: [1]` (`entrances`) | `{{TODAY_START}}` → `{{NOW}}`, bucket `HOUR`, timezone `UTC` | Entrances since local midnight. |
+| `kpi-exits-today` | Exits Today | `count` with `eventTypes: [0]` (`exits`) | `{{TODAY_START}}` → `{{NOW}}`, bucket `HOUR`, timezone `UTC` | Exits since local midnight. |
+| `kpi-live-occupancy` | Live Occupancy | `occupancy_recursion` (`live_occupancy`) | `{{NOW_MINUS_60_MIN}}` → `{{NOW}}`, bucket `5_MIN`, timezone `UTC` | Uses recursive occupancy aggregation over 5-minute buckets; mirrors last point in live flow. |
+| `kpi-avg-dwell` | Avg Dwell | `dwell_mean` (`avg_dwell`) | `{{TODAY_START}}` → `{{NOW}}`, bucket `HOUR`, timezone `UTC` | Average dwell duration today (minutes). |
+| `kpi-freshness` | Freshness Status | `count` with `options.metric: freshness` (`freshness_minutes`) | `{{NOW_MINUS_120_MIN}}` → `{{NOW}}`, bucket `5_MIN`, timezone `UTC` | Expects backend to emit freshness minutes; coverage/carry-forward on latest point. |
+
+## Update cadence and errors
+- Dashboard loads manifest on mount and when “Reload manifest” is clicked. Widgets reload on manifest load, time-range changes, or “Refresh data.” No background polling is implemented.
+- If some widgets fail, the page shows an error banner (“Some widgets failed to load”) and renders per-widget error states. Loading state applies to the whole dashboard via `aria-busy` and placeholders.
+
+## Layout/styling
+- KPI band rendered as a horizontal list within `.dashboard-v2__kpi-band`; each tile uses `.dashboard-v2__kpi-tile` with head/title and embedded `KpiTile` markup. The main layout uses CSS grid for charts (`gridTemplateColumns` from manifest columns, row height 96px). Styles live in `dashboard/v2/styles/DashboardV2Page.css`.

--- a/docs/dashboard-v2-vrm-implementation-plan.md
+++ b/docs/dashboard-v2-vrm-implementation-plan.md
@@ -1,0 +1,143 @@
+# VRM-style KPI band plan for live Dashboard V2
+
+## Live dashboard identification (no legacy)
+- **Route and surface:** `/dashboard` renders inside `VRMLayout`; the default experience gate points to `DashboardV2Page`, falling back to the legacy page only if the gate flips. 【F:frontend/src/App.tsx†L205-L243】
+- **Manifest-driven layout:** `DashboardV2Page` loads `dashboard-default` from `/api/dashboards/{id}` and renders KPI tiles from `manifest.layout.kpiBand` using `KpiTile` + `ChartRenderer`. 【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L168-L189】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L15-L22】
+- **Time controls (current behaviour):** A dropdown in the header rewrites widget specs through `buildWidgetSpec`/`loadWidgetResult`; all widgets currently honor the selected manifest time range. 【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L260-L358】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L495】
+- **Widgets currently shown:** Six `single_value` KPIs (`kpi-activity-today`, `kpi-entrances-today`, `kpi-exits-today`, `kpi-live-occupancy`, `kpi-avg-dwell`, `kpi-freshness`) declared in the manifest’s `kpiBand`. 【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L15-L22】【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L56-L337】
+
+## Per-card analysis of the six live KPI tiles
+
+### Activity Today (Activity Total)
+| Field | Details |
+| --- | --- |
+| Display name | Activity Today (title), series label Activity Total. |
+| Meaning | Count of all events (entrances + exits) in the window. |
+| Time window | Inline: today’s start to now, bucket=HOUR, timezone UTC; currently overridden by the selected time range option. |
+| Data source | `/api/analytics/run` with dataset `events`, measure `count` id `activity_total`, hourly timestamp dimension. |
+| Computation | Backend counts all events; front-end takes the latest point for the headline, optional delta from summary, sparkline from the returned series. |
+| Granularity / chart | Hourly buckets by default; sparkline uses the returned series values. |
+| Timezone handling | Inline UTC; dropdown may change timezone via manifest time controls. |
+| Update behaviour | Reloads on page mount, Refresh data, Reload manifest, or time-range change; tile shows loading/error states from `DashboardV2Page`. |
+【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L56-L101】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L308-L362】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】
+
+### Entrances Today
+| Field | Details |
+| --- | --- |
+| Display name | Entrances Today. |
+| Meaning | Count of entrance events (`eventTypes: [1]`) in the window. |
+| Time window | Inline today start → now, bucket=HOUR UTC; can be overridden by the header dropdown. |
+| Data source | Same analytics run, measure `count` with `eventTypes` filter. |
+| Computation | Backend counts entrances; tile shows latest point, delta from summary if present, sparkline from series. |
+| Granularity / chart | Hourly buckets by default. |
+| Timezone handling | Inline UTC; can shift if time controls override. |
+| Update behaviour | Same lifecycle as Activity Today. |
+【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L102-L149】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L308-L362】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】
+
+### Exits Today
+| Field | Details |
+| --- | --- |
+| Display name | Exits Today. |
+| Meaning | Count of exit events (`eventTypes: [0]`). |
+| Time window | Inline today start → now, bucket=HOUR UTC; subject to dropdown override. |
+| Data source | Analytics run with measure `count` filtered to exits. |
+| Computation | Backend counts exits; tile uses latest point + sparkline. |
+| Granularity / chart | Hourly by default. |
+| Timezone handling | Inline UTC; overridable. |
+| Update behaviour | Same as other KPIs. |
+【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L150-L197】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L308-L362】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】
+
+### Live Occupancy
+| Field | Details |
+| --- | --- |
+| Display name | Live Occupancy. |
+| Meaning | Occupancy via `occupancy_recursion` (running entries minus exits). |
+| Time window | Inline last 60 minutes, bucket=5_MIN UTC; can be replaced by selected time range. |
+| Data source | Analytics run with measure `occupancy_recursion` on events dataset. |
+| Computation | Backend returns occupancy per bucket; tile takes last bucket as headline, sparkline over series. |
+| Granularity / chart | 5-minute buckets by default; sparkline shows series. |
+| Timezone handling | Inline UTC; dropdown may override. |
+| Update behaviour | Same lifecycle as other KPIs. |
+【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L198-L243】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L308-L362】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】
+
+### Avg Dwell
+| Field | Details |
+| --- | --- |
+| Display name | Avg Dwell. |
+| Meaning | Average dwell duration (minutes) via `dwell_mean`. |
+| Time window | Inline today start → now, bucket=HOUR UTC; subject to time-range override. |
+| Data source | Analytics run with measure `dwell_mean`. |
+| Computation | Backend computes dwell; tile shows latest value and sparkline. |
+| Granularity / chart | Hourly buckets by default. |
+| Timezone handling | Inline UTC; dropdown may override. |
+| Update behaviour | Same lifecycle as other KPIs. |
+【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L244-L288】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L308-L362】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】
+
+### Freshness Status
+| Field | Details |
+| --- | --- |
+| Display name | Freshness Status. |
+| Meaning | Minutes since last event, using `count` with `options.metric: freshness`. |
+| Time window | Inline last 120 minutes, bucket=5_MIN UTC; may be replaced by dropdown. |
+| Data source | Analytics run with freshness metric; expected to return freshness values per bucket. |
+| Computation | Tile displays latest freshness value, coverage/delta if provided, sparkline from series. |
+| Granularity / chart | 5-minute buckets by default. |
+| Timezone handling | Inline UTC; overridable. |
+| Update behaviour | Same lifecycle as other KPIs. |
+【F:frontend/src/dashboard/v2/examples/dashboard_manifest_default.json†L289-L337】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L308-L362】【F:frontend/src/dashboard/v2/pages/DashboardV2Page.tsx†L461-L520】
+
+## VRM card behaviour and mapping
+- Each VRM tile maps to a camOS metric with fixed windows: headline = last 15 minutes (use final bucket of a 24h series), sparkline = last 24h with 15-minute buckets (96 points). Time controls must not alter these. Tooltip on hover should show bucket time and value.
+
+| VRM card (camOS metric) | Target behaviour |
+| --- | --- |
+| Grid → Entrances | 24h/15m series of entrances (`eventTypes: [1]`); headline uses final bucket as “entrances in last 15 minutes”; sparkline uses full series. |
+| AC Load → Occupancy | 24h/15m occupancy series; headline = last bucket (current occupancy); sub-label = delta vs prior bucket (~15m ago); sparkline over series. |
+| Essential Load → Exits | 24h/15m exits series (`eventTypes: [0]`); headline = last bucket; sparkline over 24h. |
+| Total Consumption → Footfall | Derive entrances + exits per 15m bucket over 24h; headline = last bucket total events; mini KPI = sum of all 24h buckets; sparkline shows summed series. |
+| Temperature → Avg Dwell | `dwell_mean` over last 24h in 15m buckets (if backend supports); headline = last bucket; sparkline = series; format minutes into human-readable duration. |
+| PV Inverter → Traffic Distribution | Count events per camera over last 24h; compute share per camera = camera_total / site_total; headline = top camera label + share%; chart = horizontal bars with shares (single 100% bar today because one camera). |
+| Battery SOC → Capacity Usage | Use 24h/15m occupancy series + static capacity (client1=100, client2=1000). Headline = (last occupancy / capacity)*100; sub-label = “Peak today: X%” from max occupancy since midnight; expose occupancy delta vs 15m ago for central state logic. |
+
+## Mapping table: live camOS cards/data → VRM cards
+| VRM card | Target camOS metric | Existing live data to reuse | Front-end calculations | Backend gaps |
+| --- | --- | --- | --- | --- |
+| Grid | Entrances | Entrances Today widget spec (`eventTypes:[1]` count). | Fix per-widget timeWindow to 24h/15m; use last bucket as headline. | None. |
+| AC Load | Occupancy | Live Occupancy widget (`occupancy_recursion`). | Fix window to 24h/15m; compute delta vs previous bucket for ± label. | None. |
+| Essential Load | Exits | Exits Today widget (`eventTypes:[0]`). | Fix window to 24h/15m; headline = last bucket. | None. |
+| Total Consumption | Footfall (entrances + exits) | Entrances + Exits series from existing measures; or Activity Today (all events). | Build derived series summing entrances + exits per bucket; compute 24h total. | None. |
+| Temperature | Avg Dwell | Avg Dwell widget (`dwell_mean`). | Set window to 24h/15m; headline last bucket; format duration. | Assumes backend supports 15m buckets for dwell_mean. |
+| PV Inverter | Traffic Distribution | Events dataset with camera dimension (if supported). | Aggregate counts per camera over 24h; compute shares; fallback to single 100% bar if camera dimension unavailable. | Camera dimension availability uncertain (no backend change). |
+| Battery SOC | Capacity Usage | Occupancy series; client/org identifier for capacity lookup. | Compute % = occupancy/capacity; derive peak today from buckets midnight→now; surface delta vs 15m for central state. | Need static capacity map in frontend (client1=100, client2=1000). |
+
+## Front-end implementation plan (live view only)
+- **Manifest updates:** Edit the dashboard manifest (default `dashboard-default` via API/fixture) so the six KPI widgets have fixed per-widget `timeWindow` {from: NOW-24h, to: NOW, bucket: 15m} and ignore `selectedTimeRange`. Add comments noting the override. Keep other widgets using the dropdown.
+- **DashboardV2Page adjustments:**
+  - Prevent the time-range dropdown from altering KPI-band widgets (e.g., bypass `timeRange` when invoking `widgetResultLoader` for KPI IDs, or clone manifest with fixed windows before load).
+  - Keep dropdown for non-KPI widgets.
+  - Update header copy to VRM spec: left = “Site name – Site ID” (reuse org/site info); right chips = “Last updated: Realtime” (static), “Status: OK” (static), “Local time: <current>” (existing clock).
+- **KpiTile / ChartRenderer enhancements:**
+  - Ensure sparkline supports hover tooltips (time label + metric/value). If missing, refactor to reuse shared tooltip primitives used in other charts.
+  - Accept metadata (metric label/unit) for tooltip labelling.
+- **VRM card-specific wiring:**
+  - Grid/Entrances: reuse entrances count measure; fix window; show final bucket; sparkline from series.
+  - AC Load/Occupancy: reuse occupancy series; compute delta = last – previous bucket; show ± in subtitle.
+  - Essential Load/Exits: reuse exits series; final bucket headline.
+  - Total Consumption/Footfall: request entrances + exits measures; sum per bucket client-side; derive 24h total for mini KPI.
+  - Temperature/Dwell: request `dwell_mean` with 15m bucket; headline = last bucket formatted; sparkline from series (or flat if backend returns single value).
+  - PV Inverter/Traffic Distribution: request counts dimensioned by camera; compute shares and top camera text; render horizontal bar chart. If dimension unavailable, fall back to single 100% bar but keep code structured for future dimension use.
+  - Battery SOC/Capacity Usage: load occupancy series; look up capacity (client1→100, client2→1000) from org/client context; compute current % (last bucket) and peak today % (max bucket from midnight); expose occupancy delta vs 15m ago for central node state logic.
+- **Central node state (camos logo area):** Use capacity_usage_now and Δoccupancy_15m from Capacity Usage wiring to derive state: ≥90% → Near capacity; Δ≥+10 → Getting busier; Δ≤−10 → Quietening down; else Stable.
+- **Layout/styling:** Re-skin KPI band to VRM dark look via Dashboard V2 CSS and KpiTile styles; ensure six tiles remain in band. No changes to legacy dashboard.
+
+## Open questions / assumptions
+- Camera-dimension support for analytics is assumed; if unavailable, Traffic Distribution will temporarily show a single 100% bar using site totals until backend/spec change.
+- `dwell_mean` is assumed to support 15-minute buckets; if not, display constant headline from available aggregation and document limitation.
+- Capacity lookup relies on a client/org identifier already available in dashboard context (e.g., orgId from credentials); confirm IDs beyond `client1`/`client2` before extending mapping.
+- The fixed 24h/15m window for KPI band intentionally ignores the manifest time-range dropdown; other widgets continue to respect it.
+
+## Test approach (after implementation)
+- Load `/dashboard` with dashboard V2 enabled; verify the six KPI tiles always show 15m headline/24h sparkline regardless of time-range dropdown changes.
+- Hover each sparkline to see tooltip with time + metric value.
+- Confirm Traffic Distribution shows top camera share (currently one camera → 100% bar) and Capacity Usage shows current % plus peak today subtitle.
+- Validate header shows “Site name – Site ID”, “Last updated: Realtime”, “Status: OK”, and current local time using existing clock logic.

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -3,6 +3,7 @@ import {
   ResponsiveContainer,
   AreaChart,
   Area,
+  Tooltip,
 } from "recharts";
 import type { ChartPrimitiveProps } from "./types";
 import { formatCoverage, formatValue, shouldShowRawCount } from "../utils/format";
@@ -17,7 +18,7 @@ function formatDelta(delta: number | null | undefined): { text: string; tone: "p
   return { text: `${symbol} ${percent}`, tone };
 }
 
-export const KpiTile = ({ series, height, className }: ChartPrimitiveProps) => {
+export const KpiTile = ({ series, height, className, result }: ChartPrimitiveProps) => {
   const primarySeries = series[0];
   const sparklineData = useMemo(() => {
     if (!primarySeries) {
@@ -43,6 +44,22 @@ export const KpiTile = ({ series, height, className }: ChartPrimitiveProps) => {
   const formattedDelta = formatDelta(delta);
   const coverageInfo = formatCoverage(coverage);
   const showRaw = shouldShowRawCount(rawCount);
+  const secondaryText =
+    typeof result.meta?.summary?.secondaryText === "string"
+      ? (result.meta?.summary?.secondaryText as string)
+      : undefined;
+
+  const formatLabel = (label?: string | number) => {
+    if (!label) {
+      return "";
+    }
+    const date = new Date(label);
+    const timePart = date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const now = new Date();
+    const includeDate = date.toDateString() !== now.toDateString();
+    const datePart = includeDate ? `${date.toLocaleDateString()} ` : "";
+    return `${datePart}${timePart}`;
+  };
 
   return (
     <div className={`kpi-tile ${className ?? ""}`} style={{ minHeight: height }}>
@@ -56,6 +73,7 @@ export const KpiTile = ({ series, height, className }: ChartPrimitiveProps) => {
       {showRaw ? (
         <div className="kpi-meta">raw: {rawCount}</div>
       ) : null}
+      {secondaryText ? <div className="kpi-meta">{secondaryText}</div> : null}
       {coverageInfo.label !== "—" ? (
         <div className={`kpi-coverage ${coverageInfo.tone}`}>
           coverage: {coverageInfo.label}
@@ -68,6 +86,13 @@ export const KpiTile = ({ series, height, className }: ChartPrimitiveProps) => {
         <div className="kpi-sparkline">
           <ResponsiveContainer width="100%" height={48}>
             <AreaChart data={sparklineData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
+              <Tooltip
+                formatter={(tooltipValue) => [
+                  formatValue(tooltipValue as number, primarySeries.unit),
+                  primarySeries.label ?? primarySeries.id ?? "",
+                ]}
+                labelFormatter={(label) => formatLabel(label as string | number)}
+              />
               <Area
                 type="monotone"
                 dataKey="value"

--- a/frontend/src/analytics/examples/golden_dashboard_kpi_traffic_distribution.json
+++ b/frontend/src/analytics/examples/golden_dashboard_kpi_traffic_distribution.json
@@ -1,0 +1,24 @@
+{
+  "chartType": "categorical",
+  "xDimension": {
+    "id": "camera_id",
+    "type": "category",
+    "label": "Camera"
+  },
+  "series": [
+    {
+      "id": "events",
+      "label": "Events",
+      "geometry": "bar",
+      "color": "#2d6cdf",
+      "data": [
+        { "x": "Camera 1", "y": 120 },
+        { "x": "Camera 2", "y": 80 }
+      ]
+    }
+  ],
+  "meta": {
+    "timezone": "UTC",
+    "summary": {}
+  }
+}

--- a/frontend/src/analytics/utils/loadChartFixture.ts
+++ b/frontend/src/analytics/utils/loadChartFixture.ts
@@ -29,6 +29,10 @@ const FIXTURE_MODULES: Record<string, () => Promise<ChartResult>> = {
     import("../examples/golden_dashboard_kpi_freshness.json").then(
       (module) => module.default as unknown as ChartResult
     ),
+  "golden_dashboard_kpi_traffic_distribution": () =>
+    import("../examples/golden_dashboard_kpi_traffic_distribution.json").then(
+      (module) => module.default as unknown as ChartResult,
+    ),
   "golden_dwell_by_camera": () =>
     import("../examples/golden_dwell_by_camera.json").then(
       (module) => module.default as unknown as ChartResult

--- a/frontend/src/dashboard/v2/examples/dashboard_manifest_default.json
+++ b/frontend/src/dashboard/v2/examples/dashboard_manifest_default.json
@@ -13,12 +13,13 @@
       }
     },
     "kpiBand": [
-      "kpi-activity-today",
-      "kpi-entrances-today",
-      "kpi-exits-today",
-      "kpi-live-occupancy",
-      "kpi-avg-dwell",
-      "kpi-freshness"
+      "kpi-vrm-entrances",
+      "kpi-vrm-occupancy",
+      "kpi-vrm-exits",
+      "kpi-vrm-footfall",
+      "kpi-vrm-dwell",
+      "kpi-vrm-traffic",
+      "kpi-vrm-capacity"
     ]
   },
   "orgId": "storybook",
@@ -55,60 +56,15 @@
   },
   "widgets": [
     {
-      "chartSpecId": "dashboard.kpi.activity_today",
-      "fixtureId": "golden_dashboard_kpi_activity",
-      "id": "kpi-activity-today",
-      "inlineSpec": {
-        "chartType": "single_value",
-        "dataset": "events",
-        "dimensions": [
-          {
-            "bucket": "HOUR",
-            "column": "timestamp",
-            "id": "timestamp",
-            "sort": "asc"
-          }
-        ],
-        "displayHints": {
-          "carryForward": true
-        },
-        "id": "dashboard.kpi.activity_today",
-        "interactions": {
-          "export": [
-            "png",
-            "csv"
-          ]
-        },
-        "measures": [
-          {
-            "aggregation": "count",
-            "id": "activity_total"
-          }
-        ],
-        "notes": [
-          "Activity across entrances + exits"
-        ],
-        "timeWindow": {
-          "bucket": "HOUR",
-          "from": "{{TODAY_START}}",
-          "timezone": "UTC",
-          "to": "{{NOW}}"
-        }
-      },
-      "kind": "kpi",
-      "title": "Activity Today",
-      "locked": true
-    },
-    {
-      "chartSpecId": "dashboard.kpi.entrances_today",
+      "chartSpecId": "dashboard.kpi.vrm.entrances",
       "fixtureId": "golden_dashboard_kpi_entrances",
-      "id": "kpi-entrances-today",
+      "id": "kpi-vrm-entrances",
       "inlineSpec": {
         "chartType": "single_value",
         "dataset": "events",
         "dimensions": [
           {
-            "bucket": "HOUR",
+            "bucket": "15_MIN",
             "column": "timestamp",
             "id": "timestamp",
             "sort": "asc"
@@ -117,7 +73,7 @@
         "displayHints": {
           "carryForward": true
         },
-        "id": "dashboard.kpi.entrances_today",
+        "id": "dashboard.kpi.vrm.entrances",
         "interactions": {
           "export": [
             "png",
@@ -130,33 +86,39 @@
             "eventTypes": [
               1
             ],
-            "id": "entrances"
+            "id": "entrances",
+            "label": "Entrances"
           }
         ],
         "notes": [
-          "Entrances since local midnight"
+          "Entrances every 15 minutes"
         ],
         "timeWindow": {
-          "bucket": "HOUR",
-          "from": "{{TODAY_START}}",
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
           "timezone": "UTC",
           "to": "{{NOW}}"
         }
       },
       "kind": "kpi",
-      "title": "Entrances Today",
-      "locked": true
+      "title": "Grid",
+      "subtitle": "Entrances",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
     },
     {
-      "chartSpecId": "dashboard.kpi.exits_today",
-      "fixtureId": "golden_dashboard_kpi_exits",
-      "id": "kpi-exits-today",
+      "chartSpecId": "dashboard.kpi.vrm.occupancy",
+      "fixtureId": "golden_dashboard_kpi_live_occupancy",
+      "id": "kpi-vrm-occupancy",
       "inlineSpec": {
         "chartType": "single_value",
         "dataset": "events",
         "dimensions": [
           {
-            "bucket": "HOUR",
+            "bucket": "15_MIN",
             "column": "timestamp",
             "id": "timestamp",
             "sort": "asc"
@@ -165,7 +127,58 @@
         "displayHints": {
           "carryForward": true
         },
-        "id": "dashboard.kpi.exits_today",
+        "id": "dashboard.kpi.vrm.occupancy",
+        "interactions": {
+          "export": [
+            "png",
+            "csv"
+          ]
+        },
+        "measures": [
+          {
+            "aggregation": "occupancy_recursion",
+            "id": "occupancy",
+            "label": "Occupancy"
+          }
+        ],
+        "notes": [
+          "Occupancy per 15 minutes"
+        ],
+        "timeWindow": {
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
+          "timezone": "UTC",
+          "to": "{{NOW}}"
+        }
+      },
+      "kind": "kpi",
+      "title": "AC Load",
+      "subtitle": "Occupancy",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
+    },
+    {
+      "chartSpecId": "dashboard.kpi.vrm.exits",
+      "fixtureId": "golden_dashboard_kpi_exits",
+      "id": "kpi-vrm-exits",
+      "inlineSpec": {
+        "chartType": "single_value",
+        "dataset": "events",
+        "dimensions": [
+          {
+            "bucket": "15_MIN",
+            "column": "timestamp",
+            "id": "timestamp",
+            "sort": "asc"
+          }
+        ],
+        "displayHints": {
+          "carryForward": true
+        },
+        "id": "dashboard.kpi.vrm.exits",
         "interactions": {
           "export": [
             "png",
@@ -178,33 +191,39 @@
             "eventTypes": [
               0
             ],
-            "id": "exits"
+            "id": "exits",
+            "label": "Exits"
           }
         ],
         "notes": [
-          "Exits since local midnight"
+          "Exits every 15 minutes"
         ],
         "timeWindow": {
-          "bucket": "HOUR",
-          "from": "{{TODAY_START}}",
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
           "timezone": "UTC",
           "to": "{{NOW}}"
         }
       },
       "kind": "kpi",
-      "title": "Exits Today",
-      "locked": true
+      "title": "Essential Load",
+      "subtitle": "Exits",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
     },
     {
-      "chartSpecId": "dashboard.kpi.live_occupancy",
-      "fixtureId": "golden_dashboard_kpi_live_occupancy",
-      "id": "kpi-live-occupancy",
+      "chartSpecId": "dashboard.kpi.vrm.footfall",
+      "fixtureId": "golden_dashboard_kpi_activity",
+      "id": "kpi-vrm-footfall",
       "inlineSpec": {
         "chartType": "single_value",
         "dataset": "events",
         "dimensions": [
           {
-            "bucket": "5_MIN",
+            "bucket": "15_MIN",
             "column": "timestamp",
             "id": "timestamp",
             "sort": "asc"
@@ -213,98 +232,7 @@
         "displayHints": {
           "carryForward": true
         },
-        "id": "dashboard.kpi.live_occupancy",
-        "interactions": {
-          "export": [
-            "png",
-            "csv"
-          ]
-        },
-        "measures": [
-          {
-            "aggregation": "occupancy_recursion",
-            "id": "live_occupancy",
-            "label": "Live occupancy"
-          }
-        ],
-        "notes": [
-          "Live occupancy mirrors final Live Flow point"
-        ],
-        "timeWindow": {
-          "bucket": "5_MIN",
-          "from": "{{NOW_MINUS_60_MIN}}",
-          "timezone": "UTC",
-          "to": "{{NOW}}"
-        }
-      },
-      "kind": "kpi",
-      "title": "Live Occupancy",
-      "locked": true
-    },
-    {
-      "chartSpecId": "dashboard.kpi.avg_dwell_today",
-      "fixtureId": "golden_dashboard_kpi_avg_dwell",
-      "id": "kpi-avg-dwell",
-      "inlineSpec": {
-        "chartType": "single_value",
-        "dataset": "events",
-        "dimensions": [
-          {
-            "bucket": "HOUR",
-            "column": "timestamp",
-            "id": "timestamp",
-            "sort": "asc"
-          }
-        ],
-        "displayHints": {
-          "carryForward": true
-        },
-        "id": "dashboard.kpi.avg_dwell_today",
-        "interactions": {
-          "export": [
-            "png",
-            "csv"
-          ]
-        },
-        "measures": [
-          {
-            "aggregation": "dwell_mean",
-            "id": "avg_dwell"
-          }
-        ],
-        "notes": [
-          "Average dwell duration today"
-        ],
-        "timeWindow": {
-          "bucket": "HOUR",
-          "from": "{{TODAY_START}}",
-          "timezone": "UTC",
-          "to": "{{NOW}}"
-        }
-      },
-      "kind": "kpi",
-      "title": "Avg Dwell",
-      "locked": true
-    },
-    {
-      "chartSpecId": "dashboard.kpi.freshness_status",
-      "fixtureId": "golden_dashboard_kpi_freshness",
-      "id": "kpi-freshness",
-      "inlineSpec": {
-        "chartType": "single_value",
-        "dataset": "events",
-        "dimensions": [
-          {
-            "bucket": "5_MIN",
-            "column": "timestamp",
-            "id": "timestamp",
-            "sort": "asc"
-          }
-        ],
-        "displayHints": {
-          "carryForward": true
-        },
-        "id": "dashboard.kpi.freshness_status",
+        "id": "dashboard.kpi.vrm.footfall",
         "interactions": {
           "export": [
             "png",
@@ -314,26 +242,180 @@
         "measures": [
           {
             "aggregation": "count",
-            "id": "freshness_minutes",
-            "label": "Minutes since last event",
-            "options": {
-              "metric": "freshness"
-            }
+            "id": "footfall",
+            "label": "Footfall"
           }
         ],
         "notes": [
-          "Backend emits freshness value + thresholds"
+          "Footfall (entrances + exits) every 15 minutes"
         ],
         "timeWindow": {
-          "bucket": "5_MIN",
-          "from": "{{NOW_MINUS_120_MIN}}",
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
           "timezone": "UTC",
           "to": "{{NOW}}"
         }
       },
       "kind": "kpi",
-      "title": "Freshness Status",
-      "locked": true
+      "title": "Total Consumption",
+      "subtitle": "Footfall",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
+    },
+    {
+      "chartSpecId": "dashboard.kpi.vrm.dwell",
+      "fixtureId": "golden_dashboard_kpi_avg_dwell",
+      "id": "kpi-vrm-dwell",
+      "inlineSpec": {
+        "chartType": "single_value",
+        "dataset": "events",
+        "dimensions": [
+          {
+            "bucket": "15_MIN",
+            "column": "timestamp",
+            "id": "timestamp",
+            "sort": "asc"
+          }
+        ],
+        "displayHints": {
+          "carryForward": true
+        },
+        "id": "dashboard.kpi.vrm.dwell",
+        "interactions": {
+          "export": [
+            "png",
+            "csv"
+          ]
+        },
+        "measures": [
+          {
+            "aggregation": "dwell_mean",
+            "id": "avg_dwell",
+            "label": "Avg dwell"
+          }
+        ],
+        "notes": [
+          "Average dwell by 15-minute bucket"
+        ],
+        "timeWindow": {
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
+          "timezone": "UTC",
+          "to": "{{NOW}}"
+        }
+      },
+      "kind": "kpi",
+      "title": "Temperature",
+      "subtitle": "Dwell Time",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
+    },
+    {
+      "chartSpecId": "dashboard.kpi.vrm.traffic_distribution",
+      "fixtureId": "golden_dashboard_kpi_traffic_distribution",
+      "id": "kpi-vrm-traffic",
+      "inlineSpec": {
+        "chartType": "categorical",
+        "dataset": "events",
+        "dimensions": [
+          {
+            "column": "camera_id",
+            "id": "camera_id",
+            "sort": "desc"
+          }
+        ],
+        "displayHints": {
+          "carryForward": true
+        },
+        "id": "dashboard.kpi.vrm.traffic_distribution",
+        "interactions": {
+          "export": [
+            "png",
+            "csv"
+          ]
+        },
+        "measures": [
+          {
+            "aggregation": "count",
+            "id": "events",
+            "label": "Events"
+          }
+        ],
+        "notes": [
+          "Distribution of events by camera"
+        ],
+        "timeWindow": {
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
+          "timezone": "UTC",
+          "to": "{{NOW}}"
+        }
+      },
+      "kind": "kpi",
+      "title": "PV Inverter",
+      "subtitle": "Traffic Distribution",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
+    },
+    {
+      "chartSpecId": "dashboard.kpi.vrm.capacity_usage",
+      "fixtureId": "golden_dashboard_kpi_live_occupancy",
+      "id": "kpi-vrm-capacity",
+      "inlineSpec": {
+        "chartType": "single_value",
+        "dataset": "events",
+        "dimensions": [
+          {
+            "bucket": "15_MIN",
+            "column": "timestamp",
+            "id": "timestamp",
+            "sort": "asc"
+          }
+        ],
+        "displayHints": {
+          "carryForward": true
+        },
+        "id": "dashboard.kpi.vrm.capacity_usage",
+        "interactions": {
+          "export": [
+            "png",
+            "csv"
+          ]
+        },
+        "measures": [
+          {
+            "aggregation": "occupancy_recursion",
+            "id": "capacity_usage",
+            "label": "Capacity usage"
+          }
+        ],
+        "notes": [
+          "Capacity usage derived from occupancy"
+        ],
+        "timeWindow": {
+          "bucket": "15_MIN",
+          "from": "{{NOW_MINUS_24_HOURS}}",
+          "timezone": "UTC",
+          "to": "{{NOW}}"
+        }
+      },
+      "kind": "kpi",
+      "title": "Battery SOC",
+      "subtitle": "Capacity Usage",
+      "locked": true,
+      "fixedTimeWindow": {
+        "bucket": "15_MIN",
+        "durationMinutes": 1440
+      }
     },
     {
       "chartSpecId": "dashboard.live_flow",
@@ -400,7 +482,6 @@
         }
       },
       "kind": "chart",
-      "subtitle": "Live occupancy, entrances, exits and throughput",
       "title": "Live Flow",
       "locked": true
     }

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "../../../analytics/components/Card";
 import { ChartRenderer } from "../../../analytics/components/ChartRenderer";
+import type { ChartResult, ChartSeries, DataPoint } from "../../../analytics/schemas/charting";
 import ErrorBoundary from "../../../common/components/ErrorBoundary";
 import { logError, logInfo } from "../../../common/utils/logger";
 import type {
@@ -21,6 +22,186 @@ import { Credentials } from "../../../types/credentials";
 import "../styles/DashboardV2Page.css";
 
 const GRID_ROW_HEIGHT = 96;
+
+const VRM_KPI_IDS = {
+  entrances: "kpi-vrm-entrances",
+  occupancy: "kpi-vrm-occupancy",
+  exits: "kpi-vrm-exits",
+  footfall: "kpi-vrm-footfall",
+  dwell: "kpi-vrm-dwell",
+  traffic: "kpi-vrm-traffic",
+  capacity: "kpi-vrm-capacity",
+};
+
+const FIXED_KPI_IDS = new Set(Object.values(VRM_KPI_IDS));
+
+const CAPACITY_MAP: Record<string, number> = {
+  client0: 100,
+  client1: 100,
+  client2: 1000,
+};
+
+const cloneResult = (result: ChartResult): ChartResult =>
+  JSON.parse(JSON.stringify(result)) as ChartResult;
+
+const ensureSummary = (result: ChartResult) => {
+  if (!result.meta) {
+    result.meta = { timezone: "UTC" } as ChartResult["meta"];
+  }
+  result.meta.summary = result.meta.summary ?? {};
+};
+
+const addSummaryText = (result: ChartResult, key: string, value?: string) => {
+  if (!value) {
+    return;
+  }
+  ensureSummary(result);
+  result.meta.summary![key] = value;
+};
+
+const sumSeries = (series?: ChartSeries) => {
+  if (!series) {
+    return 0;
+  }
+  return series.data.reduce((total, point) => {
+    const value = point.value ?? point.y ?? 0;
+    return total + (typeof value === "number" ? value : 0);
+  }, 0);
+};
+
+const getLastTwoValues = (series?: ChartSeries): { last: number | null; previous: number | null } => {
+  if (!series || !series.data.length) {
+    return { last: null, previous: null };
+  }
+  const lastPoint = series.data[series.data.length - 1];
+  const previousPoint = series.data[series.data.length - 2];
+  const last = (lastPoint?.value ?? lastPoint?.y ?? null) as number | null;
+  const previous = (previousPoint?.value ?? previousPoint?.y ?? null) as number | null;
+  return { last, previous };
+};
+
+const formatDeltaText = (value: number | null) => {
+  if (value === null) {
+    return undefined;
+  }
+  const sign = value > 0 ? "+" : value < 0 ? "" : "±";
+  return `${sign}${Math.round(value)}`;
+};
+
+const getStartOfToday = () => {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now;
+};
+
+const applyTrafficDistributionShare = (result: ChartResult): ChartResult => {
+  const next = cloneResult(result);
+  const series = next.series[0];
+  ensureSummary(next);
+  if (!series) {
+    return next;
+  }
+  const total = sumSeries(series);
+  let topCamera = "";
+  let topShare = 0;
+  series.data = series.data.map((point) => {
+    const raw = point.value ?? point.y ?? 0;
+    const share = total > 0 ? (Number(raw) / total) * 100 : 0;
+    if (share >= topShare) {
+      topShare = share;
+      topCamera = String(point.x ?? "Camera");
+    }
+    return { ...point, value: share, y: share } as DataPoint;
+  });
+  addSummaryText(next, "headline", `${topCamera} – ${Math.round(topShare)}% of events`);
+  return next;
+};
+
+const applyCapacityUsage = (result: ChartResult, orgId: string | undefined): ChartResult => {
+  const next = cloneResult(result);
+  ensureSummary(next);
+  const series = next.series[0];
+  const capacity = CAPACITY_MAP[orgId ?? "client0"] ?? 100;
+  if (!series || !capacity) {
+    return next;
+  }
+
+  series.unit = "%";
+  series.data = series.data.map((point) => {
+    const raw = point.value ?? point.y ?? 0;
+    const pct = (Number(raw) / capacity) * 100;
+    return { ...point, value: pct, y: pct } as DataPoint;
+  });
+
+  const { last, previous } = getLastTwoValues(series);
+  const deltaOccupancy = typeof last === "number" && typeof previous === "number" ? last - previous : null;
+  const currentUsage = typeof last === "number" ? last : null;
+
+  const startOfDay = getStartOfToday();
+  const peakToday = series.data.reduce((peak, point) => {
+    const timestamp = point.x ? new Date(point.x) : null;
+    const withinDay = timestamp ? timestamp >= startOfDay : true;
+    if (!withinDay) {
+      return peak;
+    }
+    const value = point.value ?? point.y ?? 0;
+    return Math.max(peak, Number(value));
+  }, 0);
+
+  if (!next.meta.summary) {
+    next.meta.summary = {};
+  }
+
+  next.meta.summary.capacity_usage_now = currentUsage;
+  next.meta.summary.peak_capacity_usage_today = peakToday;
+  next.meta.summary.occupancy_delta_15m = deltaOccupancy;
+
+  addSummaryText(next, "secondaryText", `Peak today: ${Math.round(peakToday)}%`);
+  return next;
+};
+
+const applyFootfallTotal = (result: ChartResult): ChartResult => {
+  const next = cloneResult(result);
+  ensureSummary(next);
+  const primary = next.series[0];
+  const total = sumSeries(primary);
+  addSummaryText(next, "secondaryText", `24h total: ${Math.round(total)}`);
+  return next;
+};
+
+const applyOccupancyDelta = (result: ChartResult): ChartResult => {
+  const next = cloneResult(result);
+  const series = next.series[0];
+  const { last, previous } = getLastTwoValues(series);
+  const deltaText = formatDeltaText(
+    typeof last === "number" && typeof previous === "number" ? last - previous : null,
+  );
+  addSummaryText(next, "secondaryText", deltaText ? `Δ vs 15m ago: ${deltaText}` : undefined);
+  return next;
+};
+
+const decorateResult = (
+  widgetId: string,
+  result: ChartResult,
+  orgId: string | undefined,
+): ChartResult => {
+  if (!FIXED_KPI_IDS.has(widgetId)) {
+    return result;
+  }
+  if (widgetId === VRM_KPI_IDS.traffic) {
+    return applyTrafficDistributionShare(result);
+  }
+  if (widgetId === VRM_KPI_IDS.capacity) {
+    return applyCapacityUsage(result, orgId);
+  }
+  if (widgetId === VRM_KPI_IDS.footfall) {
+    return applyFootfallTotal(result);
+  }
+  if (widgetId === VRM_KPI_IDS.occupancy) {
+    return applyOccupancyDelta(result);
+  }
+  return result;
+};
 
 type ManifestLoader = (
   orgId: string | undefined,
@@ -70,6 +251,9 @@ const KpiTile = ({
   locked?: boolean;
   onRemove?: () => void;
 }) => {
+  const summary = result?.meta?.summary ?? {};
+  const headline = typeof summary.headline === "string" ? summary.headline : null;
+  const secondary = typeof summary.secondaryText === "string" ? summary.secondaryText : null;
   let content: JSX.Element;
   if (state.status === "loading") {
     content = renderLoading(title);
@@ -92,7 +276,11 @@ const KpiTile = ({
   return (
     <div className="dashboard-v2__kpi-tile" data-state={state.status}>
       <div className="dashboard-v2__kpi-head">
-        <div className="dashboard-v2__kpi-title">{title}</div>
+        <div className="dashboard-v2__kpi-title-block">
+          <div className="dashboard-v2__kpi-title">{title}</div>
+          {headline ? <div className="dashboard-v2__kpi-subtitle">{headline}</div> : null}
+          {secondary ? <div className="dashboard-v2__kpi-secondary">{secondary}</div> : null}
+        </div>
         {showRemove ? (
           <button
             type="button"
@@ -185,7 +373,13 @@ const DashboardV2Page = ({
   const [error, setError] = useState<string | null>(null);
   const [selectedTimeRangeId, setSelectedTimeRangeId] = useState<string | null>(null);
   const [runNonce, setRunNonce] = useState(0);
+  const [localTime, setLocalTime] = useState<Date>(() => new Date());
   const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    const interval = setInterval(() => setLocalTime(new Date()), 60_000);
+    return () => clearInterval(interval);
+  }, []);
 
   const loadManifest = useCallback(async () => {
     setStatus("loading");
@@ -322,11 +516,12 @@ const DashboardV2Page = ({
             if (controller.signal.aborted) {
               return;
             }
+            const decorated = decorateResult(widget.id, result, orgId);
             setWidgetState((previous) => ({
               ...previous,
               [widget.id]: {
                 widget,
-                result,
+                result: decorated,
                 status: "ready",
               },
             }));
@@ -457,18 +652,26 @@ const DashboardV2Page = ({
   );
 
   const gridColumns = manifest?.layout.grid.columns ?? 12;
+  const localTimeLabel = useMemo(
+    () => localTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+    [localTime],
+  );
+  const siteLabel = manifest?.orgId ?? orgId ?? "Site";
+  const siteId = orgId ?? manifest?.orgId ?? "—";
 
   return (
     <div className="dashboard-v2" aria-busy={status === "loading"}>
       <header className="dashboard-v2__header">
-        <div>
-          <h1>Dashboard</h1>
-          <p className="dashboard-v2__subtitle">
-            Manifest-driven dashboard powered by the shared analytics engine and live manifests.
-          </p>
+        <div className="dashboard-v2__title-block">
+          <h1 className="dashboard-v2__title">{`${siteLabel} – ${siteId}`}</h1>
+          <div className="dashboard-v2__meta-row">
+            <span>Last updated: Realtime</span>
+            <span>• Status: OK</span>
+            <span>• Local time: {localTimeLabel}</span>
+          </div>
         </div>
         <div className="dashboard-v2__controls">
-          <div className="dashboard-v2__org">Organisation: {orgId}</div>
+          <div className="dashboard-v2__org">Site ID: {siteId}</div>
           <div className="dashboard-v2__control-group">
             {manifest?.timeControls?.options?.length ? (
               <label className="dashboard-v2__control">

--- a/frontend/src/dashboard/v2/stories/DashboardV2Page.stories.tsx
+++ b/frontend/src/dashboard/v2/stories/DashboardV2Page.stories.tsx
@@ -10,6 +10,7 @@ import exitsResult from "../../../analytics/examples/golden_dashboard_kpi_exits.
 import dwellResult from "../../../analytics/examples/golden_dashboard_kpi_avg_dwell.json";
 import occupancyResult from "../../../analytics/examples/golden_dashboard_kpi_live_occupancy.json";
 import freshnessResult from "../../../analytics/examples/golden_dashboard_kpi_freshness.json";
+import trafficDistributionResult from "../../../analytics/examples/golden_dashboard_kpi_traffic_distribution.json";
 import liveFlowResult from "../../../analytics/examples/golden_dashboard_live_flow.json";
 import { Credentials } from "../../../types/credentials";
 
@@ -22,6 +23,7 @@ const fixtureResults: Record<string, ChartResult> = {
   golden_dashboard_kpi_avg_dwell: dwellResult as unknown as ChartResult,
   golden_dashboard_kpi_live_occupancy: occupancyResult as unknown as ChartResult,
   golden_dashboard_kpi_freshness: freshnessResult as unknown as ChartResult,
+  golden_dashboard_kpi_traffic_distribution: trafficDistributionResult as unknown as ChartResult,
   golden_dashboard_live_flow: liveFlowResult as unknown as ChartResult,
 };
 

--- a/frontend/src/dashboard/v2/styles/DashboardV2Page.css
+++ b/frontend/src/dashboard/v2/styles/DashboardV2Page.css
@@ -15,8 +15,24 @@
   gap: 16px;
 }
 
-.dashboard-v2__subtitle {
-  margin: 4px 0 0;
+.dashboard-v2__title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.dashboard-v2__title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--vrm-text-primary, #1f2937);
+}
+
+.dashboard-v2__meta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
   color: var(--vrm-text-subtle, #5f6b7a);
 }
 
@@ -124,6 +140,22 @@
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--vrm-text-primary, #1f2937);
+}
+
+.dashboard-v2__kpi-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dashboard-v2__kpi-subtitle {
+  font-size: 0.85rem;
+  color: var(--vrm-text-subtle, #5f6b7a);
+}
+
+.dashboard-v2__kpi-secondary {
+  font-size: 0.8rem;
+  color: var(--vrm-text-subtle, #5f6b7a);
 }
 
 .dashboard-v2__kpi-renderer .kpi-tile {

--- a/frontend/src/dashboard/v2/types.ts
+++ b/frontend/src/dashboard/v2/types.ts
@@ -12,6 +12,11 @@ export interface DashboardWidget {
   inlineSpec?: ChartSpec;
   layout?: DashboardWidgetLayout;
   locked?: boolean;
+  /**
+   * When present, the widget ignores global time-range controls and instead
+   * always runs with the provided fixed window (relative to "now").
+   */
+  fixedTimeWindow?: { durationMinutes: number; bucket: TimeBucket };
 }
 
 export interface DashboardGridPlacement {

--- a/frontend/src/dashboard/v2/utils/buildWidgetSpec.ts
+++ b/frontend/src/dashboard/v2/utils/buildWidgetSpec.ts
@@ -51,6 +51,36 @@ function applyTimeRange(
   }
 }
 
+function applyFixedTimeWindow(
+  spec: ChartSpec,
+  durationMinutes: number,
+  bucket: ChartSpec["timeWindow"]["bucket"],
+  timezone: string | undefined,
+  anchor: Date,
+): void {
+  const timeWindow: ChartSpec["timeWindow"] = { ...(spec.timeWindow ?? { from: "", to: "" }) };
+  const to = anchor.toISOString();
+  const from = new Date(anchor.getTime() - durationMinutes * MINUTE_IN_MS).toISOString();
+  timeWindow.from = from;
+  timeWindow.to = to;
+  timeWindow.bucket = bucket;
+  if (timezone) {
+    timeWindow.timezone = timezone;
+  }
+  spec.timeWindow = timeWindow;
+
+  if (Array.isArray(spec.dimensions)) {
+    spec.dimensions = spec.dimensions.map((dimension) => {
+      if ((dimension as { id?: string }).id === TIMESTAMP_DIMENSION_ID) {
+        const nextDimension = { ...dimension } as ChartSpec["dimensions"][number];
+        (nextDimension as ChartDimension).bucket = bucket;
+        return nextDimension;
+      }
+      return dimension;
+    });
+  }
+}
+
 export function buildWidgetSpec(
   widget: DashboardWidget,
   options: BuildWidgetSpecOptions = {},
@@ -61,7 +91,15 @@ export function buildWidgetSpec(
 
   const spec = cloneSpec(widget.inlineSpec);
 
-  if (options.timeRange) {
+  if (widget.fixedTimeWindow) {
+    applyFixedTimeWindow(
+      spec,
+      widget.fixedTimeWindow.durationMinutes,
+      widget.fixedTimeWindow.bucket,
+      options.timezone,
+      options.anchor ?? new Date(),
+    );
+  } else if (options.timeRange) {
     applyTimeRange(spec, options.timeRange, options.timezone, options.anchor ?? new Date());
   }
 


### PR DESCRIPTION
## Summary
- replace the dashboard-default manifest KPI band with seven VRM-mapped widgets that use fixed 24h/15m windows and remove the old freshness tile from the band
- add front-end handling for fixed time windows, VRM header metadata, and KPI-specific result decoration (footfall totals, capacity usage percentages, traffic distribution shares)
- enhance KPI sparkline tooltips and stories/fixtures, including a traffic distribution example fixture

## Testing
- npm test -- --runTestsByPath src/dashboard/v2/pages/DashboardV2Page.test.tsx (from `frontend/`)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921836c66888331b54bbd2ebd040ee7)