### PR TITLE
Align VRM KPI band with 15-minute headlines

### DIFF
--- a/docs/dashboard-v2-live-kpis.md
+++ b/docs/dashboard-v2-live-kpis.md
@@ -36,3 +36,9 @@ The default manifest (`dashboard_manifest_default.json`) defines six KPI widgets
 
 ## Layout/styling
 - KPI band rendered as a horizontal list within `.dashboard-v2__kpi-band`; each tile uses `.dashboard-v2__kpi-tile` with head/title and embedded `KpiTile` markup. The main layout uses CSS grid for charts (`gridTemplateColumns` from manifest columns, row height 96px). Styles live in `dashboard/v2/styles/DashboardV2Page.css`.
+
+## VRM KPI band semantics
+- VRM overrides inject seven KPI tiles (Entrances, Occupancy, Exits, Footfall, Dwell Time, Traffic Distribution, Capacity Usage) with a fixed 24h/15m time window. The headline number for every tile is **always the latest 15-minute bucket**; sparklines and totals use the full 24-hour series.
+- Footfall = entrances + exits; the subtitle shows the 24h total while the headline is the most recent 15-minute bucket.
+- Traffic Distribution is currently frontend-only: one camera renders `100%` with the subtitle `Camera – 100% of events`, still interpreted as a last-15-minutes share.
+- Capacity Usage reuses occupancy data; headline = `(latest occupancy ÷ capacity) × 100`, subtitle = `Peak today: <percent>`. Capacity map: `client1 → 10`, `client2 → 100` (fallback 10 with a console warning).

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
@@ -54,17 +54,30 @@ describe("KpiTile", () => {
     expect(text).not.toContain("coverage:");
   });
 
-  it("formats percentage units with a % suffix", () => {
-    const props = buildProps();
-    props.series = [
-      {
-        id: "primary",
-        label: "Primary",
-        geometry: "metric",
-        unit: "percentage",
-        data: [{ x: "2024-01-01T00:00:00Z", value: 37 }],
-      },
-    ];
+  it("shows numeric-only KPI values with uppercase unit label", () => {
+    const tree = renderer.create(<KpiTile {...buildProps()} />).root;
+    const valueNode = tree.findByProps({ className: "kpi-value" });
+    const unitNode = tree.findByProps({ className: "kpi-unit" });
+    expect(valueNode.children.join(" ")).toBe("12");
+    expect(unitNode.children.join(" ")).toBe("EVENTS");
+    expect(valueNode.children.join(" ")).not.toContain("events");
+  });
+
+  it("renders minutes KPIs without repeating the unit", () => {
+    const props = buildProps({
+      series: [
+        {
+          id: "primary",
+          label: "Dwell",
+          geometry: "metric",
+          unit: "minutes",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: 20 },
+            { x: "2024-01-01T00:15:00Z", value: 23.87 },
+          ],
+        },
+      ],
+    });
     props.result = {
       chartType: "single_value",
       series: props.series,
@@ -74,6 +87,35 @@ describe("KpiTile", () => {
 
     const tree = renderer.create(<KpiTile {...props} />).root;
     const valueNode = tree.findByProps({ className: "kpi-value" });
-    expect(valueNode.children.join(" ")).toContain("%");
+    const unitNode = tree.findByProps({ className: "kpi-unit" });
+    expect(valueNode.children.join(" ")).toBe("23.87");
+    expect(unitNode.children.join(" ")).toBe("MINUTES");
+    expect(valueNode.children.join(" ")).not.toContain("minutes");
+  });
+
+  it("formats percentage KPIs with a % suffix and uppercase label", () => {
+    const props = buildProps({
+      series: [
+        {
+          id: "primary",
+          label: "Capacity usage",
+          geometry: "metric",
+          unit: "percentage",
+          data: [{ x: "2024-01-01T00:15:00Z", value: 53 }],
+        },
+      ],
+    });
+    props.result = {
+      chartType: "single_value",
+      series: props.series,
+      xDimension: { id: "time", type: "time", bucket: "15_MIN", timezone: "UTC" },
+      meta: { timezone: "UTC" },
+    } as ChartResult;
+
+    const tree = renderer.create(<KpiTile {...props} />).root;
+    const valueNode = tree.findByProps({ className: "kpi-value" });
+    const unitNode = tree.findByProps({ className: "kpi-unit" });
+    expect(valueNode.children.join(" ")).toBe("53%");
+    expect(unitNode.children.join(" ")).toBe("PERCENTAGE");
   });
 });

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -6,7 +6,17 @@ import {
   Tooltip,
 } from "recharts";
 import type { ChartPrimitiveProps } from "./types";
-import { formatCoverage, formatValue, shouldShowRawCount } from "../utils/format";
+import { formatCoverage, formatNumeric, formatValue, shouldShowRawCount } from "../utils/format";
+
+const formatKpiValue = (value: number | null | undefined, unit?: string) => {
+  const numeric = formatNumeric(value);
+  if (numeric === "—") {
+    return numeric;
+  }
+  return unit === "percentage" ? `${numeric}%` : numeric;
+};
+
+const formatUnitLabel = (unit?: string | null) => (unit ? unit.toUpperCase() : null);
 
 function formatDelta(delta: number | null | undefined): { text: string; tone: "positive" | "negative" | "neutral" } {
   if (delta === null || delta === undefined) {
@@ -68,11 +78,11 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
     <div className={`kpi-tile ${className ?? ""}`} style={{ minHeight: height }}>
       <div className="kpi-header">
         <div className="kpi-label">{primarySeries?.label ?? primarySeries?.id}</div>
-        {primarySeries?.unit ? (
-          <div className="kpi-unit">{primarySeries.unit}</div>
+        {formatUnitLabel(primarySeries?.unit) ? (
+          <div className="kpi-unit">{formatUnitLabel(primarySeries?.unit)}</div>
         ) : null}
       </div>
-      <div className="kpi-value">{formatValue(value, primarySeries?.unit)}</div>
+      <div className="kpi-value">{formatKpiValue(value, primarySeries?.unit)}</div>
       {showRaw ? <div className="kpi-meta">raw: {rawCount}</div> : null}
       {secondaryText ? <div className="kpi-meta">{secondaryText}</div> : null}
       {!compact && coverageInfo.label !== "—" ? (

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
@@ -4,7 +4,7 @@ import renderer, { act } from "react-test-renderer";
 import type { TestRenderer } from "react-test-renderer";
 import type { ChartResult } from "../../../analytics/schemas/charting";
 import type { DashboardManifest, DashboardWidget } from "../types";
-import DashboardV2Page from "./DashboardV2Page";
+import DashboardV2Page, { lookupCapacity } from "./DashboardV2Page";
 import liveFlowResult from "../../../analytics/examples/golden_dashboard_live_flow.json";
 import type { FetchDashboardManifestOptions } from "../transport/fetchDashboardManifest";
 import type { LoadWidgetOptions } from "../transport/loadWidgetResult";
@@ -137,6 +137,20 @@ async function flushEffects(times = 3) {
     });
   }
 }
+
+describe("lookupCapacity", () => {
+  it("returns configured capacity for known clients", () => {
+    expect(lookupCapacity("client1")).toBe(10);
+    expect(lookupCapacity("client2")).toBe(100);
+  });
+
+  it("falls back to 10 and logs a warning for unknown clients", () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    expect(lookupCapacity("unknown-client")).toBe(10);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
 
 describe("DashboardV2Page", () => {
   it("loads manifest and renders widgets", async () => {

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -26,10 +26,21 @@ const GRID_ROW_HEIGHT = 96;
 
 const FIXED_KPI_IDS = new Set<string>(Object.values(VRM_KPI_IDS));
 
-const CAPACITY_MAP: Record<string, number> = {
-  client0: 100,
-  client1: 100,
-  client2: 1000,
+const CAPACITY_BY_CLIENT: Record<string, number> = {
+  client1: 10,
+  client2: 100,
+};
+
+export const lookupCapacity = (orgId: string | undefined): number => {
+  const capacity = orgId ? CAPACITY_BY_CLIENT[orgId] : undefined;
+  if (capacity !== undefined) {
+    return capacity;
+  }
+  // VRM capacity usage assumes a known site capacity; fall back to 10 to avoid
+  // divide-by-zero while keeping the widget usable.
+  // eslint-disable-next-line no-console
+  console.warn("Unknown client for capacity usage, falling back to 10", { orgId });
+  return 10;
 };
 
 const cloneResult = (result: ChartResult): ChartResult =>
@@ -47,6 +58,11 @@ const markCompact = (result: ChartResult) => {
   result.meta.summary!.compact = 1 as unknown as string | number | null;
 };
 
+// VRM KPI band semantics:
+// - All headline KPI values are taken from the latest 15-minute bucket within a 24h/15m
+//   series (or the derived "now" occupancy point for capacity usage).
+// - Sparklines and totals can use the full 24-hour series, but the main number is always
+//   the most recent bucket.
 const addSummaryText = (result: ChartResult, key: string, value?: string) => {
   if (!value) {
     return;
@@ -136,7 +152,7 @@ const applyCapacityUsage = (result: ChartResult, orgId: string | undefined): Cha
   const next = cloneResult(result);
   markCompact(next);
   const series = next.series[0];
-  const capacity = CAPACITY_MAP[orgId ?? "client0"] ?? 100;
+  const capacity = lookupCapacity(orgId);
   if (!series || !capacity) {
     return next;
   }

--- a/frontend/src/dashboard/v2/utils/applyVRMOverrides.ts
+++ b/frontend/src/dashboard/v2/utils/applyVRMOverrides.ts
@@ -117,7 +117,9 @@ const vrmWidgets: DashboardWidget[] = [
     fixtureId: "golden_dashboard_kpi_activity",
     inlineSpec: singleValueSpec({
       id: "dashboard.kpi.vrm.footfall",
-      measures: [{ aggregation: "count", id: "footfall", label: "Footfall" }],
+      measures: [
+        { aggregation: "count", id: "footfall", label: "Footfall", eventTypes: [0, 1] },
+      ],
       notes: ["Footfall (entrances + exits) every 15 minutes"],
     }),
     fixedTimeWindow: fixedWindow,


### PR DESCRIPTION
## Summary
- derive VRM KPI headline values from the latest 15-minute bucket, including updated capacity usage mapping and fallback handling
- simplify KPI tile formatting to show numeric-only headline values with uppercase unit labels and expand unit coverage tests
- clarify VRM KPI semantics in documentation and align footfall measurement with entrance/exit event types

## Testing
- CI=true npm test -- --runTestsByPath src/dashboard/v2/pages/DashboardV2Page.test.tsx src/dashboard/v2/utils/applyVRMOverrides.test.ts src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx --watch=false --silent
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921a8cd704c8321aeb64379ae168dfa)