### PR TITLE
Respect single value analytics buckets

### DIFF
--- a/backend/app/analytics/compiler.py
+++ b/backend/app/analytics/compiler.py
@@ -260,6 +260,20 @@ class SpecCompiler:
     ) -> CompiledQuery:
         time_window = spec["timeWindow"]
         timezone = time_window.get("timezone", context.timezone)
+        bucket = self._auto_bucket(
+            preferred=time_window.get("bucket", "RAW"),
+            start=time_window.get("from"),
+            end=time_window.get("to"),
+            chart_type=spec["chartType"],
+        )
+
+        use_calendar = self._should_render_calendar(
+            bucket=bucket,
+            start=time_window.get("from"),
+            end=time_window.get("to"),
+            chart_type=spec["chartType"],
+        )
+
         params: Dict[str, object] = {
             "start_ts": time_window["from"],
             "end_ts": time_window["to"],
@@ -275,9 +289,16 @@ class SpecCompiler:
         cte_registry: OrderedDict[str, str] = OrderedDict()
         select_statements: List[str] = []
         base_ctes = [self._render_scoped(context.table_name, filters_sql)]
+        if bucket != "RAW" and use_calendar:
+            base_ctes.append(self._render_calendar(bucket))
 
         for measure in measures:
-            compilation = self._render_single_value_measure(measure=measure, params=params)
+            compilation = self._render_single_value_measure(
+                measure=measure,
+                params=params,
+                bucket=bucket,
+                use_calendar=use_calendar,
+            )
             for fragment in compilation.ctes:
                 name = fragment.split(" AS", 1)[0].strip()
                 cte_registry[name] = fragment
@@ -287,10 +308,9 @@ class SpecCompiler:
             base_ctes=base_ctes,
             measure_ctes=cte_registry.values(),
             select_statements=select_statements,
-            order_by="measure_id",
         )
         measure_map = {measure["id"]: measure["aggregation"] for measure in measures}
-        return CompiledQuery(sql=sql, params=params, measures=measure_map, bucket="RAW")
+        return CompiledQuery(sql=sql, params=params, measures=measure_map, bucket=bucket)
 
     def _auto_bucket(
         self, *, preferred: str, start: object, end: object, chart_type: str
@@ -318,6 +338,9 @@ class SpecCompiler:
         else:
             recommended = "WEEK"
 
+        if chart_type == "single_value":
+            return preferred
+
         if _bucket_rank(preferred) < _bucket_rank(recommended):
             return preferred
         return recommended
@@ -325,7 +348,7 @@ class SpecCompiler:
     def _should_render_calendar(
         self, *, bucket: str, start: object, end: object, chart_type: str
     ) -> bool:
-        if bucket == "RAW" or chart_type == "single_value":
+        if bucket == "RAW":
             return False
 
         start_dt = _parse_iso8601(start)
@@ -812,7 +835,12 @@ class SpecCompiler:
         return MeasureCompilation(ctes=[counts_cte_sql, series], select_sql=select_sql)
 
     def _render_single_value_measure(
-        self, *, measure: Dict[str, object], params: Dict[str, object]
+        self,
+        *,
+        measure: Dict[str, object],
+        params: Dict[str, object],
+        bucket: str,
+        use_calendar: bool = True,
     ) -> MeasureCompilation:
         aggregation = measure["aggregation"]
         measure_id = measure["id"]
@@ -843,161 +871,19 @@ class SpecCompiler:
                 )
                 return MeasureCompilation(ctes=[cte], select_sql=select_sql)
 
-            filter_sql = ""
-            if event_types:
-                param_name = f"{measure_id}_event_types"
-                params[param_name] = event_types
-                filter_sql = f" WHERE scoped.event IN UNNEST(@{param_name})"
-
-            prefix = f"{measure_id}_count"
-            cte = dedent(
-                f"""
-                {prefix} AS (
-                    SELECT
-                        {bucket_start_expr} AS bucket_start,
-                        COUNT(*) AS raw_count,
-                        COUNT(*) AS event_count
-                    FROM scoped{filter_sql}
-                )
-                """
-            ).strip()
-            select_sql = dedent(
-                f"""
-                SELECT
-                    '{measure_id}' AS measure_id,
-                    bucket_start,
-                    event_count AS value,
-                    1.0 AS coverage,
-                    raw_count
-                FROM {prefix}
-                """
-            ).strip()
-            return MeasureCompilation(ctes=[cte], select_sql=select_sql)
+            return self._render_activity(
+                measure=measure, bucket=bucket, params=params, use_calendar=use_calendar
+            )
 
         if aggregation == "occupancy_recursion":
-            prefix = f"{measure_id}_single"
-            deltas = dedent(
-                f"""
-                {prefix}_deltas AS (
-                    SELECT
-                        timestamp,
-                        index,
-                        CASE WHEN event = 1 THEN 1 ELSE -1 END AS delta
-                    FROM scoped
-                )
-                """
-            ).strip()
-            cumulative = dedent(
-                f"""
-                {prefix}_cumulative AS (
-                    SELECT
-                        SUM(delta) OVER (ORDER BY timestamp, index ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS occupancy,
-                        ROW_NUMBER() OVER (ORDER BY timestamp DESC, index DESC) AS rn
-                    FROM {prefix}_deltas
-                )
-                """
-            ).strip()
-            latest = dedent(
-                f"""
-                {prefix}_latest AS (
-                    SELECT
-                        {bucket_start_expr} AS bucket_start,
-                        COALESCE((SELECT occupancy FROM {prefix}_cumulative WHERE rn = 1), 0) AS value,
-                        raw_count,
-                        CASE WHEN raw_count = 0 THEN 0.0 ELSE 1.0 END AS coverage
-                    FROM (
-                        SELECT (SELECT COUNT(*) FROM {prefix}_cumulative) AS raw_count
-                    )
-                )
-                """
-            ).strip()
-            select_sql = (
-                f"SELECT '{measure_id}' AS measure_id, bucket_start, value, coverage, raw_count FROM {prefix}_latest"
+            return self._render_occupancy(
+                measure=measure, bucket=bucket, params=params, use_calendar=use_calendar
             )
-            return MeasureCompilation(ctes=[deltas, cumulative, latest], select_sql=select_sql)
 
         if aggregation in {"dwell_mean", "dwell_p90", "sessions"}:
-            prefix = f"{measure_id}_dwell_single"
-            entrances = dedent(
-                f"""
-                {prefix}_entrances AS (
-                    SELECT
-                        site_id,
-                        cam_id,
-                        track_id,
-                        timestamp AS entrance_ts,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY site_id, cam_id, track_id
-                            ORDER BY timestamp, index
-                        ) AS rn
-                    FROM scoped
-                    WHERE event = 1
-                )
-                """
-            ).strip()
-            exits = dedent(
-                f"""
-                {prefix}_exits AS (
-                    SELECT
-                        site_id,
-                        cam_id,
-                        track_id,
-                        timestamp AS exit_ts,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY site_id, cam_id, track_id
-                            ORDER BY timestamp, index
-                        ) AS rn
-                    FROM scoped
-                    WHERE event = 0
-                )
-                """
-            ).strip()
-            sessions = dedent(
-                f"""
-                {prefix}_sessions AS (
-                    SELECT
-                        e.site_id,
-                        e.cam_id,
-                        e.track_id,
-                        e.entrance_ts,
-                        x.exit_ts,
-                        TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, SECOND) / 60.0 AS dwell_minutes
-                    FROM {prefix}_entrances AS e
-                    LEFT JOIN {prefix}_exits AS x
-                        ON e.site_id = x.site_id
-                        AND e.cam_id = x.cam_id
-                        AND e.track_id = x.track_id
-                        AND e.rn = x.rn
-                    WHERE x.exit_ts IS NOT NULL
-                        AND TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, MINUTE) BETWEEN 0 AND 360
-                )
-                """
-            ).strip()
-            aggregates = dedent(
-                f"""
-                {prefix}_aggregate AS (
-                    SELECT
-                        {bucket_start_expr} AS bucket_start,
-                        COUNT(*) AS session_count,
-                        AVG(dwell_minutes) AS dwell_mean,
-                        APPROX_QUANTILES(dwell_minutes, 101)[OFFSET(90)] AS dwell_p90
-                    FROM {prefix}_sessions
-                )
-                """
-            ).strip()
-            value_expr = "dwell_mean" if aggregation == "dwell_mean" else "dwell_p90"
-            select_sql = dedent(
-                f"""
-                SELECT
-                    '{measure_id}' AS measure_id,
-                    bucket_start,
-                    {value_expr} AS value,
-                    CASE WHEN session_count = 0 THEN 0.0 ELSE 1.0 END AS coverage,
-                    session_count AS raw_count
-                FROM {prefix}_aggregate
-                """
-            ).strip()
-            return MeasureCompilation(ctes=[entrances, exits, sessions, aggregates], select_sql=select_sql)
+            return self._render_dwell(
+                measure=measure, bucket=bucket, params=params, use_calendar=use_calendar
+            )
 
         raise UnsupportedMeasureError(aggregation)
 

--- a/backend/tests/test_analytics_single_value.py
+++ b/backend/tests/test_analytics_single_value.py
@@ -3,6 +3,7 @@ import pytest
 
 from backend.app.analytics.cache import LocalCacheBackend, SpecCache
 from backend.app.analytics.dashboard_catalogue import get_dashboard_spec
+from backend.app.analytics.compiler import CompilerContext, SpecCompiler
 from backend.app.analytics.engine import AnalyticsEngine, UnsupportedChartExecution
 from backend.app.analytics.router import TableRouter
 
@@ -72,3 +73,66 @@ def test_single_value_rejects_multiple_measures():
 
     with pytest.raises(UnsupportedChartExecution):
         engine.execute(spec, organisation="org", bypass_cache=True)
+
+
+def test_single_value_respects_bucketed_window():
+    spec = {
+        "chartType": "single_value",
+        "dataset": "events",
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-02T00:00:00Z",
+            "bucket": "15_MIN",
+        },
+        "dimensions": [
+            {
+                "id": "timestamp",
+                "column": "timestamp",
+                "bucket": "15_MIN",
+                "sort": "asc",
+            }
+        ],
+        "measures": [
+            {"id": "vrm_count", "aggregation": "count", "eventTypes": [1]},
+        ],
+    }
+
+    compiled = SpecCompiler().compile(
+        spec,
+        CompilerContext(table_name="project.dataset.table"),
+    )
+
+    assert compiled.bucket == "15_MIN"
+    assert "GENERATE_TIMESTAMP_ARRAY" in compiled.sql
+
+    frame = pd.DataFrame(
+        [
+            {
+                "measure_id": "vrm_count",
+                "bucket_start": pd.Timestamp("2024-01-01T00:15:00Z"),
+                "value": 4,
+                "coverage": 1.0,
+                "raw_count": 4,
+            },
+            {
+                "measure_id": "vrm_count",
+                "bucket_start": pd.Timestamp("2024-01-02T00:00:00Z"),
+                "value": 2,
+                "coverage": 1.0,
+                "raw_count": 2,
+            },
+        ]
+    )
+
+    engine = AnalyticsEngine(
+        table_router=TableRouter({"org": "project.dataset.table"}),
+        bigquery_client=StubBigQueryClient(frame),
+        cache=SpecCache(LocalCacheBackend()),
+    )
+
+    result = engine.execute(spec, organisation="org", bypass_cache=True)
+
+    series = result["series"][0]["data"]
+
+    assert len(series) == 2
+    assert series[-1]["value"] == 2


### PR DESCRIPTION
## Summary
- reuse time-series bucketing/calendar logic when compiling single-value specs and route VRM measures through bucketed renderers
- keep requested buckets for single-value charts and use calendar generation so the final slice reflects the window end rather than a total
- add a regression test covering a 24h/15m single-value VRM count to assert multiple buckets and the correct last bucket value

## Testing
- PYTHONPATH=. pytest backend/tests/test_analytics_single_value.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921c96022188323b9a7865f576ce2d5)