### PR TITLE
Align VRM context and single-value bucketing

### DIFF
--- a/backend/tests/test_analytics_single_value.py
+++ b/backend/tests/test_analytics_single_value.py
@@ -16,6 +16,49 @@ class StubBigQueryClient:
         return self._frame
 
 
+class CalendarAwareStubClient:
+    def __init__(self, measure_id: str, bucket_seconds: int = 900):
+        self.measure_id = measure_id
+        self.bucket_seconds = bucket_seconds
+        self.calls = []
+
+    def query_dataframe(self, sql: str, params, job_context=None):
+        self.calls.append({"sql": sql, "params": params})
+        if "GENERATE_TIMESTAMP_ARRAY" not in sql:
+            return pd.DataFrame(
+                [
+                    {
+                        "measure_id": self.measure_id,
+                        "bucket_start": pd.to_datetime(params["end_ts"]),
+                        "value": 999,
+                        "coverage": 1.0,
+                        "raw_count": 999,
+                    }
+                ]
+            )
+
+        start = pd.to_datetime(params["start_ts"])
+        end = pd.to_datetime(params["end_ts"])
+        buckets = pd.date_range(
+            start=start,
+            end=end,
+            freq=pd.Timedelta(seconds=self.bucket_seconds),
+            inclusive="right",
+        )
+        data = [
+            {
+                "measure_id": self.measure_id,
+                "bucket_start": timestamp,
+                "value": index + 1,
+                "coverage": 1.0,
+                "raw_count": index + 1,
+            }
+            for index, timestamp in enumerate(buckets)
+        ]
+
+        return pd.DataFrame(data)
+
+
 def test_single_value_kpis_normalise_to_metric_series():
     spec = get_dashboard_spec("dashboard.kpi.activity_today")
     frame = pd.DataFrame(
@@ -136,3 +179,77 @@ def test_single_value_respects_bucketed_window():
 
     assert len(series) == 2
     assert series[-1]["value"] == 2
+
+
+def test_single_value_engine_returns_multiple_buckets_for_counts():
+    spec = {
+        "chartType": "single_value",
+        "dataset": "events",
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-01T01:00:00Z",
+            "bucket": "15_MIN",
+        },
+        "dimensions": [
+            {
+                "id": "timestamp",
+                "column": "timestamp",
+                "bucket": "15_MIN",
+                "sort": "asc",
+            }
+        ],
+        "measures": [
+            {"id": "vrm_count", "aggregation": "count", "eventTypes": [1]},
+        ],
+    }
+
+    stub_client = CalendarAwareStubClient("vrm_count")
+    engine = AnalyticsEngine(
+        table_router=TableRouter({"org": "project.dataset.table"}),
+        bigquery_client=stub_client,
+        cache=SpecCache(LocalCacheBackend()),
+    )
+
+    result = engine.execute(spec, organisation="org", bypass_cache=True)
+
+    series = result["series"][0]["data"]
+    assert len(series) == 4
+    assert series[-1]["value"] == 4
+    assert "GENERATE_TIMESTAMP_ARRAY" in stub_client.calls[0]["sql"]
+
+
+def test_single_value_engine_returns_multiple_buckets_for_occupancy():
+    spec = {
+        "chartType": "single_value",
+        "dataset": "events",
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-01T01:00:00Z",
+            "bucket": "15_MIN",
+        },
+        "dimensions": [
+            {
+                "id": "timestamp",
+                "column": "timestamp",
+                "bucket": "15_MIN",
+                "sort": "asc",
+            }
+        ],
+        "measures": [
+            {"id": "occupancy", "aggregation": "occupancy_recursion"},
+        ],
+    }
+
+    stub_client = CalendarAwareStubClient("occupancy")
+    engine = AnalyticsEngine(
+        table_router=TableRouter({"org": "project.dataset.table"}),
+        bigquery_client=stub_client,
+        cache=SpecCache(LocalCacheBackend()),
+    )
+
+    result = engine.execute(spec, organisation="org", bypass_cache=True)
+
+    series = result["series"][0]["data"]
+    assert len(series) == 4
+    assert series[-1]["value"] == 4
+    assert result["series"][0]["geometry"] == "metric"

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
@@ -433,7 +433,9 @@ describe("DashboardV2Page", () => {
     const manifestLoader = jest.fn(async () => cloneManifest());
     const widgetLoader = jest.fn(async (widget: DashboardWidget) => {
       if (widget.kind === "kpi") {
-        return buildChartResult([10, 15, 20]);
+        return buildChartResult([10, 15, 20], {
+          meta: { timezone: "UTC", summary: { widgetId: widget.id } },
+        });
       }
       return liveFlowChart;
     });
@@ -450,11 +452,13 @@ describe("DashboardV2Page", () => {
     });
     await flushEffects();
 
-    const subtitles = tree!
-      .root
-      .findAllByProps({ className: "dashboard-v2__kpi-secondary" })
-      .map((node: { children: (string | number)[] }) => node.children.join(" "));
-    expect(subtitles.some((text: string) => text.includes("Peak today:"))).toBe(true);
+    const subtitles = tree!.root.findAllByProps({ className: "dashboard-v2__kpi-secondary" });
+    expect(subtitles).toHaveLength(0);
+
+    const capacityResult = renderedResults.find(
+      (result) => (result.meta?.summary as Record<string, string> | undefined)?.widgetId === VRM_KPI_IDS.capacity,
+    );
+    expect(capacityResult?.meta?.summary?.secondaryText).toContain("Peak today:");
 
     const errorTiles = tree!.root.findAllByProps({ className: "dashboard-v2__error" });
     expect(errorTiles.length).toBe(0);
@@ -488,6 +492,42 @@ describe("DashboardV2Page", () => {
     expect(errorBanner.children.join(" ")).toContain("Some widgets failed to load");
   });
 
+  it("hides outer VRM captions while preserving summary metadata", async () => {
+    renderedResults.length = 0;
+    const manifestLoader = jest.fn(async () => cloneManifest());
+    const widgetLoader = jest.fn(async (widget: DashboardWidget) => {
+      if (widget.kind === "kpi") {
+        return buildChartResult([1, 2, 3], {
+          meta: {
+            timezone: "UTC",
+            summary: { headline: `headline-${widget.id}`, secondaryText: `secondary-${widget.id}` },
+          },
+        });
+      }
+      return liveFlowChart;
+    });
+
+    let tree: TestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <DashboardV2Page
+          credentials={{ username: "client1", password: "secret" }}
+          manifestLoader={manifestLoader}
+          widgetResultLoader={widgetLoader}
+        />,
+      );
+    });
+    await flushEffects();
+
+    expect(tree!.root.findAllByProps({ className: "dashboard-v2__kpi-subtitle" })).toHaveLength(0);
+    expect(tree!.root.findAllByProps({ className: "dashboard-v2__kpi-secondary" })).toHaveLength(0);
+
+    const headlines = renderedResults.flatMap((result) =>
+      Object.values(result.meta?.summary ?? {}).filter((value) => typeof value === "string" && value.startsWith("headline-")),
+    );
+    expect(headlines.length).toBeGreaterThan(0);
+  });
+
   it("renders empty states when manifest has no widgets", async () => {
     const manifestLoader = jest.fn(async () =>
       cloneManifest({
@@ -510,6 +550,41 @@ describe("DashboardV2Page", () => {
 
     const emptyMessages = tree!.root.findAllByProps({ className: "dashboard-v2__empty" });
     expect(emptyMessages).toHaveLength(1);
+  });
+
+  it("uses the org context for headers and capacity lookup", async () => {
+    renderedResults.length = 0;
+    const manifestLoader = jest.fn(async () => cloneManifest({ orgId: "client2" }));
+    const widgetLoader = jest.fn(async (widget: DashboardWidget) => {
+      if (widget.kind === "kpi") {
+        const values = widget.id === VRM_KPI_IDS.capacity ? [50, 60] : [1, 2, 3];
+        return buildChartResult(values, {
+          label: widget.id,
+          meta: { timezone: "UTC", summary: { widgetId: widget.id } },
+        });
+      }
+      return liveFlowChart;
+    });
+
+    let tree: TestRenderer;
+    await act(async () => {
+      tree = renderer.create(
+        <DashboardV2Page
+          credentials={{ username: "client2", password: "secret" }}
+          manifestLoader={manifestLoader}
+          widgetResultLoader={widgetLoader}
+        />,
+      );
+    });
+    await flushEffects();
+
+    const title = tree!.root.findByProps({ className: "dashboard-v2__title" });
+    expect(title.children.join(" ")).toContain("client2 – client2");
+
+    const capacityResult = renderedResults.find(
+      (result) => (result.meta?.summary as Record<string, string> | undefined)?.widgetId === VRM_KPI_IDS.capacity,
+    );
+    expect(lastBucketValue(capacityResult?.series?.[0])).toBeCloseTo(60);
   });
 
   it("derives VRM KPI headlines from the latest bucket values instead of 24h totals", () => {

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -81,6 +81,7 @@ const KpiTile = ({
   const summary = result?.meta?.summary ?? {};
   const headline = typeof summary.headline === "string" ? summary.headline : null;
   const secondary = typeof summary.secondaryText === "string" ? summary.secondaryText : null;
+  const isVrmWidget = (Object.values(VRM_KPI_IDS) as string[]).includes(state.widget.id);
   let content: JSX.Element;
   if (state.status === "loading") {
     content = renderLoading(title);
@@ -105,8 +106,12 @@ const KpiTile = ({
       <div className="dashboard-v2__kpi-head">
         <div className="dashboard-v2__kpi-title-block">
           <div className="dashboard-v2__kpi-title">{title}</div>
-          {headline ? <div className="dashboard-v2__kpi-subtitle">{headline}</div> : null}
-          {secondary ? <div className="dashboard-v2__kpi-secondary">{secondary}</div> : null}
+          {!isVrmWidget && headline ? (
+            <div className="dashboard-v2__kpi-subtitle">{headline}</div>
+          ) : null}
+          {!isVrmWidget && secondary ? (
+            <div className="dashboard-v2__kpi-secondary">{secondary}</div>
+          ) : null}
         </div>
         {showRemove ? (
           <button
@@ -341,6 +346,7 @@ const DashboardV2Page = ({
     const timezone = manifest.timeControls?.timezone;
 
     const run = async () => {
+      const decorateOrgId = manifest?.orgId ?? orgId;
       await Promise.all(
         manifest.widgets.map(async (widget) => {
           if (widget.id === VRM_KPI_IDS.traffic) {
@@ -366,7 +372,7 @@ const DashboardV2Page = ({
             if (controller.signal.aborted) {
               return;
             }
-            const decorated = decorateResult(widget.id, result, orgId);
+            const decorated = decorateResult(widget.id, result, decorateOrgId);
             setWidgetState((previous) => ({
               ...previous,
               [widget.id]: {
@@ -506,8 +512,9 @@ const DashboardV2Page = ({
     () => localTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
     [localTime],
   );
-  const siteLabel = manifest?.orgId ?? orgId ?? "Site";
-  const siteId = orgId ?? manifest?.orgId ?? "—";
+  const siteOrgId = manifest?.orgId ?? orgId;
+  const siteLabel = siteOrgId ?? "Site";
+  const siteId = siteOrgId ?? "—";
 
   return (
     <div className="dashboard-v2" aria-busy={status === "loading"}>

--- a/frontend/src/utils/org.test.ts
+++ b/frontend/src/utils/org.test.ts
@@ -6,8 +6,8 @@ describe('org utils', () => {
   });
 
   it('maps client usernames to their configured orgs', () => {
-    expect(determineOrgId({ username: 'client1' })).toBe('client0');
-    expect(determineOrgId({ username: 'client2' })).toBe('client1');
+    expect(determineOrgId({ username: 'client1' })).toBe('client1');
+    expect(determineOrgId({ username: 'client2' })).toBe('client2');
   });
 
   it('falls back to default org for unknown usernames', () => {

--- a/frontend/src/utils/org.ts
+++ b/frontend/src/utils/org.ts
@@ -4,8 +4,8 @@ const DEFAULT_ORG_ID = 'client0';
 
 const USERNAME_TO_ORG_MAP: Record<string, string> = {
   client0: 'client0',
-  client1: 'client0',
-  client2: 'client1',
+  client1: 'client1',
+  client2: 'client2',
   admin: 'client0',
 };
 


### PR DESCRIPTION
## Summary
- Align VRM dashboard context with client org IDs so headers and capacity usage use the same site identity, and suppress outer captions for VRM KPI tiles
- Update VRM rendering to decorate results with the manifest org ID, and extend frontend tests for client1/client2 capacity handling and caption removal
- Add backend regression tests to verify single-value specs return multi-bucket data when a 15-minute window is requested

## Testing
- PYTHONPATH=. pytest backend/tests/test_analytics_single_value.py
- CI=true npm test -- --runTestsByPath src/dashboard/v2/pages/DashboardV2Page.test.tsx src/dashboard/v2/utils/applyVRMOverrides.test.ts src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx --watch=false --silent
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921c83e81108323861bc8469d987e3f)