### PR TITLE
Align VRM KPI traffic and capacity semantics

### DIFF
--- a/docs/dashboard-v2-live-kpis.md
+++ b/docs/dashboard-v2-live-kpis.md
@@ -6,7 +6,7 @@
 
 ## Layout and header
 - The VRM KPI band renders a single layer of dark gradient tiles (no outer white card wrappers). Titles appear once per tile inside the gradient card.
-- The header shows `Site – Site ID`, `Last updated: Realtime`, `Status: OK`, and the local time label. A time-range dropdown, “Refresh data”, and “Reload manifest” buttons remain in the header for non-KPI widgets; the VRM tiles themselves use fixed windows.
+- The header shows `Site – Site ID`, `Last updated: Realtime`, `Status: OK`, and the local time label. Time-range, refresh, reload, and Site ID controls are hidden when the manifest renders the VRM KPI set; non-VRM dashboards still show them.
 
 ## Data flow
 - Manifests are fetched from `/api/dashboards/{dashboardId}` with `orgId` or `viewToken` query params. If loading fails, the page shows an error banner and stops rendering.
@@ -20,7 +20,7 @@
 - Traffic Distribution uses the last bucket per-camera counts to compute shares; Capacity Usage derives `(latest occupancy ÷ capacity) × 100`.
 
 ## KPI tile rendering behavior
-- `KpiTile` displays the primary series label as the card title, main value from `meta.summary.headlineValue` when provided (VRM sets this from the last bucket), optional unit, and a sparkline built from series data values. VRM compact mode hides raw/coverage/delta rows; delta chips are shown only when explicitly enabled.
+- `KpiTile` displays the primary series label as the card title for legacy dashboards. In VRM compact mode the label and unit chip are suppressed, the main value uses `meta.summary.headlineValue` (last bucket), deltas are hidden except Occupancy, and dwell KPIs render as whole minutes (e.g., `24 min`). Sparklines use the series values unless a traffic pie is rendered.
 - Colors default to the series color or `#2d6cdf`; sparklines are `AreaChart` (Recharts) without animation.
 
 ## Live KPI widgets (VRM override)

--- a/docs/dashboard-v2-vrm-implementation-plan.md
+++ b/docs/dashboard-v2-vrm-implementation-plan.md
@@ -3,7 +3,7 @@
 ## Live dashboard identification
 - **Route and surface:** `/dashboard` renders inside `VRMLayout`; the default experience gate points to `DashboardV2Page`, falling back to the legacy page only if the gate flips.
 - **Manifest-driven layout:** `DashboardV2Page` loads `dashboard-default` from `/api/dashboards/{id}` and renders KPI tiles from `manifest.layout.kpiBand` using `KpiTile` + `ChartRenderer`. `applyVRMOverrides` injects the seven VRM tiles and removes legacy KPI entries.
-- **Header controls:** The header shows `Site – Site ID`, `Last updated: Realtime`, `Status: OK`, local time, an optional time-range dropdown, and Refresh/Reload buttons. VRM KPIs keep a fixed 24h/15m window regardless of the dropdown; other widgets may still honor manifest time ranges.
+- **Header controls:** The header shows `Site – Site ID`, `Last updated: Realtime`, `Status: OK`, and local time. Time-range, refresh, reload, and Site ID controls are hidden when the manifest renders the VRM KPI set; non-VRM dashboards still surface them.
 
 ## VRM KPI set and semantics
 - All VRM tiles use a fixed 24h window with 15-minute buckets (96 points). The headline for every tile is the final bucket (last 15 minutes). Sparklines use the full series.
@@ -22,7 +22,7 @@
 
 ## Capacity usage rules
 - Capacity lookup uses the UI org/client identifier, not the BigQuery table name. Mapping: `client1 → 10`, `client2 → 100` (fallback 10 with a console warning).
-- Both the headline and “Peak today” calculation apply the same capacity. The series is converted to a single last-bucket usage point for the headline while keeping the 24h sparkline shape.
+- Both the headline and “Peak today” calculation apply the same capacity. The occupancy series is normalized to a percentage series for the full 24h/15m window so the sparkline and peak reuse the same capacity-aware values.
 
 ## Traffic distribution rules
 - Traffic Distribution uses per-camera event counts in the last bucket to compute shares: `share(cam) = events(cam) / total(last bucket) * 100`.

--- a/frontend/src/analytics/components/ChartRenderer/ChartRenderer.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/ChartRenderer.tsx
@@ -134,8 +134,8 @@ export const ChartRenderer = ({
   };
 
   const summary = result.meta?.summary as { presentation?: string; chartStyle?: string } | undefined;
-  const isVrmTraffic =
-    summary?.presentation === "vrm" && summary?.chartStyle === "traffic_distribution";
+  const isTrafficDistribution =
+    summary?.chartStyle === "traffic_distribution" || result.meta?.summary?.chartSubType === "traffic_distribution";
 
   if (validationIssues.length > 0) {
     return (
@@ -156,14 +156,11 @@ export const ChartRenderer = ({
     );
   }
 
-  if (isVrmTraffic) {
-    return <KpiTile {...chartProps} />;
+  if (isTrafficDistribution) {
+    return <TrafficDistribution {...chartProps} height={height} />;
   }
 
   if (result.chartType === "single_value") {
-    if (result.meta?.summary?.chartSubType === "traffic_distribution") {
-      return <TrafficDistribution {...chartProps} height={height} />;
-    }
     return <KpiTile {...chartProps} />;
   }
 
@@ -172,9 +169,6 @@ export const ChartRenderer = ({
   }
 
   if (result.chartType === "categorical") {
-    if (result.meta?.summary?.chartSubType === "traffic_distribution") {
-      return <TrafficDistribution {...chartProps} height={height} />;
-    }
     return <BarChart {...chartProps} />;
   }
 

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -69,6 +69,9 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
       ? (result.meta?.summary?.tertiaryText as string)
       : undefined;
   const hideDelta = Boolean(result.meta?.summary?.hideDelta);
+  const headerLabel = isVrm
+    ? (typeof summary.title === "string" ? (summary.title as string) : null)
+    : primarySeries?.label ?? primarySeries?.id;
 
   const formatLabel = (label?: string | number) => {
     if (!label) {
@@ -99,6 +102,30 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
     delta !== null ? (
       <div className={`kpi-delta tone-${formattedDelta.tone}`}>{formattedDelta.text}</div>
     ) : null;
+  const showHeaderDelta = isVrm && !isTraffic && !hideDelta && delta !== null;
+
+  const trafficRows =
+    isTraffic && primarySeries?.data?.length
+      ? primarySeries.data.map((point, index) => {
+          const label = String(point.x ?? `Cam ${index + 1}`);
+          const share =
+            typeof point.value === "number"
+              ? point.value
+              : typeof point.y === "number"
+              ? point.y
+              : 0;
+          const width = Math.max(0, Math.min(100, Number(share)));
+          return (
+            <div className="kpi-traffic-row" key={`${label}-${index}`}>
+              <div className="kpi-traffic-label">{label}</div>
+              <div className="kpi-traffic-bar">
+                <span style={{ width: `${width}%` }} />
+              </div>
+              <div className="kpi-traffic-value">{`${Math.round(Number(share))}%`}</div>
+            </div>
+          );
+        })
+      : [];
 
   return (
     <div
@@ -106,9 +133,9 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
       style={{ minHeight: height }}
     >
       <div className="kpi-header">
-        <div className="kpi-label">{primarySeries?.label ?? primarySeries?.id}</div>
+        {headerLabel ? <div className="kpi-label">{headerLabel}</div> : <div className="kpi-label" />}
         <div className="kpi-header-right">
-          {isVrm ? deltaChip : null}
+          {showHeaderDelta ? deltaChip : null}
           {showUnit ? <div className="kpi-unit">{unitLabel}</div> : null}
         </div>
       </div>
@@ -121,10 +148,15 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
           coverage: {coverageInfo.label}
         </div>
       ) : null}
-      {!hideDelta && delta !== null ? (
+      {!isVrm && !hideDelta && delta !== null ? (
         <div className={`kpi-delta tone-${formattedDelta.tone}`}>{formattedDelta.text}</div>
       ) : null}
-      {sparklineData.length > 1 ? (
+      {trafficRows.length > 0 ? (
+        <div className="kpi-traffic" aria-label="Traffic distribution rows">
+          {trafficRows}
+        </div>
+      ) : null}
+      {!isTraffic && sparklineData.length > 1 ? (
         <div className="kpi-sparkline">
           <ResponsiveContainer width="100%" height={48}>
             <AreaChart data={sparklineData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
@@ -442,7 +442,7 @@ describe("DashboardV2Page", () => {
     );
     expect(
       (capacityResult?.meta?.summary as Record<string, string> | undefined)?.secondaryText ?? "",
-    ).toContain("Peak today:");
+    ).toContain("Today’s peak:");
 
     const errorTiles = tree!.root.findAllByProps({ className: "dashboard-v2__error" });
     expect(errorTiles.length).toBe(0);

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -79,8 +79,16 @@ const KpiTile = ({
 }) => {
   const summary = result?.meta?.summary ?? {};
   const headline = typeof summary.headline === "string" ? summary.headline : null;
-  const secondary = typeof summary.secondaryText === "string" ? summary.secondaryText : null;
-  const isVrmWidget = (Object.values(VRM_KPI_IDS) as string[]).includes(state.widget.id);
+  const renderedResult = result
+    ? ({
+        ...result,
+        meta: {
+          ...(result.meta ?? { timezone: "UTC" }),
+          summary: { ...(result.meta?.summary ?? {}), title },
+        },
+      } as Parameters<typeof ChartRenderer>[0]["result"])
+    : result;
+
   let content: JSX.Element;
   if (state.status === "loading") {
     content = renderLoading(title);
@@ -91,7 +99,7 @@ const KpiTile = ({
   } else {
     content = (
       <ChartRenderer
-        result={result}
+        result={renderedResult!}
         height={168}
         className="dashboard-v2__kpi-renderer"
       />
@@ -207,7 +215,7 @@ const DashboardV2Page = ({
   }, []);
 
   const clientContextId = useMemo(
-    () => manifest?.orgId ?? credentials.orgId ?? credentials.username ?? orgId,
+    () => credentials.orgId ?? credentials.username ?? manifest?.orgId ?? orgId,
     [manifest?.orgId, credentials.orgId, credentials.username, orgId],
   );
 
@@ -339,7 +347,6 @@ const DashboardV2Page = ({
     const timezone = manifest.timeControls?.timezone;
 
     const run = async () => {
-      const decorateOrgId = orgId ?? manifest?.orgId;
       await Promise.all(
         manifest.widgets.map(async (widget) => {
           try {

--- a/frontend/src/dashboard/v2/utils/applyVRMOverrides.test.ts
+++ b/frontend/src/dashboard/v2/utils/applyVRMOverrides.test.ts
@@ -202,7 +202,7 @@ describe("applyVRMOverrides", () => {
     expect(capacityHeadline.currentUsage).toBe(90);
     expect(capacityHeadline.peakToday).toBe(100);
     expect(capacityResult.meta?.summary?.headlineValue).toBe(90);
-    expect(capacityResult.meta?.summary?.secondaryText).toContain("Peak today:");
+    expect(capacityResult.meta?.summary?.secondaryText).toContain("Today’s peak:");
     expect(capacityResult.meta?.summary?.hideDelta).toBeTruthy();
   });
 

--- a/frontend/src/dashboard/v2/utils/vrmDecorators.ts
+++ b/frontend/src/dashboard/v2/utils/vrmDecorators.ts
@@ -2,20 +2,38 @@ import type { ChartResult, ChartSeries, DataPoint } from "../../../analytics/sch
 import { VRM_KPI_IDS } from "./applyVRMOverrides";
 
 const CAPACITY_BY_CLIENT: Record<string, number> = {
-  client0: 10,
   client1: 10,
   client2: 100,
 };
 
+const TABLE_TO_UI_CLIENT: Record<string, string> = {
+  client0: "client1",
+  client1: "client2",
+};
+
+const normalizeOrgId = (orgId: string | undefined) => orgId?.replace(/_compat$/, "");
+
+export const resolveUiClient = (orgId: string | undefined): string | undefined => {
+  const normalized = normalizeOrgId(orgId);
+  if (!normalized) {
+    return undefined;
+  }
+  if (CAPACITY_BY_CLIENT[normalized] !== undefined) {
+    return normalized;
+  }
+  return TABLE_TO_UI_CLIENT[normalized] ?? normalized;
+};
+
 export const lookupCapacity = (orgId: string | undefined): number => {
-  const capacity = orgId ? CAPACITY_BY_CLIENT[orgId] : undefined;
+  const uiClient = resolveUiClient(orgId);
+  const capacity = uiClient ? CAPACITY_BY_CLIENT[uiClient] : undefined;
   if (capacity !== undefined) {
     return capacity;
   }
   // VRM capacity usage assumes a known site capacity; fall back to 10 to avoid
   // divide-by-zero while keeping the widget usable.
   // eslint-disable-next-line no-console
-  console.warn("Unknown client for capacity usage, falling back to 10", { orgId });
+  console.warn("Unknown client for capacity usage, falling back to 10", { orgId, uiClient });
   return 10;
 };
 
@@ -182,8 +200,10 @@ export const buildTrafficPlaceholderResult = (): ChartResult => ({
   meta: {
     summary: {
       headline: "Camera – 100% of events",
+      presentation: "vrm",
       compact: 1 as unknown as number,
       hideDelta: 1 as unknown as number,
+      chartStyle: "traffic_distribution",
       chartSubType: "traffic_distribution",
     },
     timezone: "UTC",
@@ -206,22 +226,38 @@ export const applyTrafficDistributionShare = (result: ChartResult): ChartResult 
   markCompact(trafficDistributionResult);
   suppressDelta(trafficDistributionResult);
   ensureSummary(trafficDistributionResult);
-  const series = trafficDistributionResult.series[0];
-  if (!series) {
+  const seriesList = trafficDistributionResult.series ?? [];
+  if (seriesList.length === 0) {
     return buildTrafficPlaceholderResult();
   }
 
-  const latestTimestamp = getLatestTimestamp(seriesList);
-  if (!latestTimestamp) {
+  const hasTimestampBuckets = seriesList.some((series) =>
+    series.data.some((point) => {
+      if (!point?.x) {
+        return false;
+      }
+      const parsed = new Date(point.x as string | number);
+      return !Number.isNaN(parsed.valueOf());
+    }),
+  );
+
+  const latestTimestamp = hasTimestampBuckets ? getLatestTimestamp(seriesList) : null;
+
+  if (hasTimestampBuckets && !latestTimestamp) {
     return buildTrafficPlaceholderResult();
   }
 
-  const cameraShares = seriesList.map((series) => {
-    const latestPoint =
-      series.data.find((point) => point.x === latestTimestamp) ?? series.data[series.data.length - 1];
-    const raw = latestPoint?.value ?? latestPoint?.y ?? 0;
-    return { camera: series.label ?? series.id, value: Number(raw) };
-  });
+  const cameraShares = hasTimestampBuckets
+    ? seriesList.map((series) => {
+        const latestPoint =
+          series.data.find((point) => point.x === latestTimestamp) ?? series.data[series.data.length - 1];
+        const raw = latestPoint?.value ?? latestPoint?.y ?? 0;
+        return { camera: series.label ?? series.id, value: Number(raw) };
+      })
+    : seriesList[0].data.map((point, index) => ({
+        camera: String(point.x ?? seriesList[0].label ?? `Camera ${index + 1}`),
+        value: Number(point.value ?? point.y ?? 0),
+      }));
 
   const total = cameraShares.reduce((sum, { value }) => sum + value, 0);
   let topCamera = cameraShares[0]?.camera ?? "Camera";
@@ -235,10 +271,23 @@ export const applyTrafficDistributionShare = (result: ChartResult): ChartResult 
     }
     return { x: camera, value: share, y: share } as DataPoint;
   });
+
+  trafficDistributionResult.chartType = "categorical";
+  trafficDistributionResult.xDimension = { id: "camera", type: "category" } as ChartResult["xDimension"];
+  trafficDistributionResult.series = [
+    {
+      id: "traffic_share",
+      label: "Traffic distribution",
+      geometry: "bar",
+      unit: "percentage",
+      data: shareData,
+    },
+  ];
   setHeadlineValue(trafficDistributionResult, topShare);
   addSummaryText(trafficDistributionResult, "headline", `${topCamera} – ${Math.round(topShare)}% of events`);
   addSummaryText(trafficDistributionResult, "chartSubType", "traffic_distribution");
   addSummaryText(trafficDistributionResult, "legendTitle", "Camera");
+  addSummaryText(trafficDistributionResult, "chartStyle", "traffic_distribution");
   return trafficDistributionResult;
 };
 
@@ -246,18 +295,40 @@ export const applyCapacityUsage = (result: ChartResult, orgId: string | undefine
   const next = cloneResult(result);
   markCompact(next);
   suppressDelta(next);
+  ensureSummary(next);
   const series = next.series[0];
   const capacity = lookupCapacity(orgId);
   if (!series || !capacity) {
     return next;
   }
 
+  const summary = next.meta!.summary as Record<string, unknown>;
+
   const occupancyPoints = [...series.data];
-  const { last, previous } = getLastTwoValues(series);
-  const deltaOccupancy = typeof last === "number" && typeof previous === "number" ? last - previous : null;
-  const occupancyNow = typeof last === "number" ? last : null;
+  const normalizedSeries: DataPoint[] = occupancyPoints.map((point) => {
+    const raw = point.value ?? point.y ?? 0;
+    const usage = capacity > 0 ? (Number(raw) / capacity) * 100 : 0;
+    return { ...point, value: usage, y: usage } as DataPoint;
+  });
+
+  series.unit = "percentage";
+  series.label = "Capacity usage";
+  series.data = normalizedSeries;
+
+  const { last, previous } = getLastTwoValues({ ...series, data: normalizedSeries });
+  const deltaUsage = typeof last === "number" && typeof previous === "number" ? last - previous : null;
+  const usageNow = typeof last === "number" ? last : null;
 
   const startOfDay = getStartOfToday();
+  const peakUsage = normalizedSeries.reduce((peak, point) => {
+    const timestamp = point.x ? new Date(point.x) : null;
+    const withinDay = timestamp ? timestamp >= startOfDay : true;
+    const value = point.value ?? point.y ?? null;
+    if (!withinDay || typeof value !== "number") {
+      return peak;
+    }
+    return Math.max(peak, value);
+  }, 0);
 
   const peakOccupancy = occupancyPoints.reduce((peak, point) => {
     const timestamp = point.x ? new Date(point.x) : null;
@@ -269,39 +340,14 @@ export const applyCapacityUsage = (result: ChartResult, orgId: string | undefine
     return Math.max(peak, Number(value));
   }, 0);
 
-  const currentUsage =
-    typeof occupancyNow === "number" && capacity > 0 ? (occupancyNow / capacity) * 100 : null;
-  const peakToday = capacity > 0 ? (peakOccupancy / capacity) * 100 : 0;
+  summary.capacity_usage_now = usageNow;
+  summary.peak_capacity_usage_today = peakUsage;
+  summary.occupancy_delta_15m = deltaUsage;
+  summary.peak_occupancy_today = peakOccupancy;
 
-  const lastPoint = occupancyPoints[occupancyPoints.length - 1];
-  const lastUsagePoint: DataPoint | undefined = lastPoint
-    ? ({ x: lastPoint.x, value: currentUsage, y: currentUsage } as DataPoint)
-    : undefined;
-
-  series.unit = "percentage";
-  series.label = "Capacity usage";
-  series.data = lastUsagePoint ? [lastUsagePoint] : [];
-
-  if (!next.meta.summary) {
-    next.meta.summary = {};
-  }
-
-  next.meta.summary.capacity_usage_now = currentUsage;
-  next.meta.summary.peak_capacity_usage_today = peakToday;
-  next.meta.summary.occupancy_delta_15m = deltaOccupancy;
-
-  const peakWithinDay = occupancyPoints
-    .filter((point) => {
-      const ts = point.x ? new Date(point.x) : null;
-      return ts ? ts >= startOfDay : true;
-    })
-    .reduce((peak, point) => Math.max(peak, Number(point.value ?? point.y ?? 0)), 0);
-
-  next.meta.summary.peak_occupancy_today = peakWithinDay;
-
-  addSummaryText(next, "secondaryText", `Peak today: ${Math.round(peakToday)}%`);
-  setHeadlineValue(next, currentUsage);
-  logVrmDebug(VRM_KPI_IDS.capacity, series, currentUsage);
+  addSummaryText(next, "secondaryText", `Today’s peak: ${Math.round(peakUsage)}%`);
+  setHeadlineValue(next, usageNow);
+  logVrmDebug(VRM_KPI_IDS.capacity, series, usageNow);
   return next;
 };
 


### PR DESCRIPTION
## Summary
- compute traffic distribution shares from the latest bucket and route VRM traffic KPIs through the pie+legend renderer
- normalize capacity usage to UI client mappings with percentage series, last-bucket headlines, and peak-today summaries
- simplify VRM KPI presentation (titles, deltas) and refresh VRM documentation to match the live behavior

## Testing
- npm test -- --watch=false --silent
- npm run build
- docker build --no-cache -t portal-app . *(fails in this environment: docker not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921f1d5e9f483208051c7d6a097c9c6)