### PR TITLE
Fix VRM traffic and tooltip formatting

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -94,24 +94,17 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
   };
 
   const formatLabel = (label?: string | number, payload?: unknown) => {
-    const parsedDate = parseLabelDate(label);
+    const tooltipEntries = Array.isArray(payload)
+      ? (payload as Array<{ payload?: { x?: string | number } }>)
+      : [];
+    const payloadLabel = tooltipEntries[0]?.payload?.x ?? label;
+    const parsedDate = parseLabelDate(payloadLabel);
+
     if (isVrm) {
       if (parsedDate) {
         return formatTimeOfDay(parsedDate, timezone);
       }
-
-      const tooltipEntries = Array.isArray(payload) ? (payload as Array<{ payload?: { index?: number } }>) : [];
-      const indexCandidate = tooltipEntries[0]?.payload?.index;
-      const index = typeof indexCandidate === "number" ? indexCandidate : null;
-      const totalPoints = sparklineData.length;
-      if (index === null || totalPoints === 0) {
-        return "";
-      }
-      const bucketMs = 15 * 60 * 1000;
-      const end = Date.now();
-      const start = end - Math.max(totalPoints - 1, 0) * bucketMs;
-      const reconstructed = new Date(start + index * bucketMs);
-      return formatTimeOfDay(reconstructed, timezone);
+      return "";
     }
 
     if (!parsedDate) {

--- a/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
@@ -9,6 +9,10 @@ export const TrafficDistribution = ({ result, series, height, className }: Chart
   const data = primary?.data ?? [];
   const summary = (result.meta?.summary as Record<string, unknown> | undefined) ?? {};
   const title = typeof summary.title === "string" ? (summary.title as string) : "Traffic by Camera";
+  const isVrmTraffic =
+    typeof summary.presentation === "string" &&
+    summary.presentation === "vrm" &&
+    summary.chartSubType === "traffic_distribution";
 
   if (!primary || data.length === 0) {
     return (
@@ -21,11 +25,17 @@ export const TrafficDistribution = ({ result, series, height, className }: Chart
     );
   }
 
-  const legend = data.map((point, index) => ({
-    label: String(point.x ?? `Cam ${index + 1}`),
-    value: typeof point.value === "number" ? point.value : typeof point.y === "number" ? point.y : 0,
-    color: sliceColors[index % sliceColors.length],
-  }));
+  const legend = data.map((point, index) => {
+    const rawCamera = point.x ?? `Cam ${index + 1}`;
+    const normalizedCameraId = String(rawCamera).replace(/^Cam\s*/i, "").trim();
+    const cameraId = normalizedCameraId !== "" ? normalizedCameraId : String(index + 1);
+    return {
+      label: `Cam ${cameraId}`,
+      camId: cameraId,
+      value: typeof point.value === "number" ? point.value : typeof point.y === "number" ? point.y : 0,
+      color: sliceColors[index % sliceColors.length],
+    };
+  });
 
   const topSlice = legend.reduce((winner, candidate) =>
     candidate.value >= winner.value ? candidate : winner,
@@ -49,6 +59,17 @@ export const TrafficDistribution = ({ result, series, height, className }: Chart
               innerRadius={40}
               outerRadius={60}
               paddingAngle={2}
+              label={
+                isVrmTraffic
+                  ? ({ payload, value }) => {
+                      const camId = (payload as { camId?: string })?.camId ?? (payload as { label?: string })?.label;
+                      const share = typeof value === "number" ? Math.round(value) : 0;
+                      const cameraLabel = camId ? `Cam ${camId.replace(/^Cam\s*/i, "").trim()}` : "Cam";
+                      return `${cameraLabel} ${share}%`;
+                    }
+                  : undefined
+              }
+              labelLine={isVrmTraffic ? false : undefined}
             >
               {legend.map((entry) => (
                 <Cell key={entry.label} fill={entry.color} />
@@ -59,19 +80,21 @@ export const TrafficDistribution = ({ result, series, height, className }: Chart
             </Pie>
           </PieChart>
         </ResponsiveContainer>
-        <div className="traffic-distribution__annotations" aria-label="Traffic by camera annotations">
-          {legend.map((entry) => (
-            <div className="traffic-distribution__annotation" key={entry.label}>
-              <span
-                className="traffic-distribution__annotation-swatch"
-                style={{ backgroundColor: entry.color }}
-                aria-hidden
-              />
-              <span className="traffic-distribution__annotation-label">{entry.label}</span>
-              <span className="traffic-distribution__annotation-value">{`${Math.round(entry.value)}%`}</span>
-            </div>
-          ))}
-        </div>
+        {!isVrmTraffic ? (
+          <div className="traffic-distribution__annotations" aria-label="Traffic by camera annotations">
+            {legend.map((entry) => (
+              <div className="traffic-distribution__annotation" key={entry.label}>
+                <span
+                  className="traffic-distribution__annotation-swatch"
+                  style={{ backgroundColor: entry.color }}
+                  aria-hidden
+                />
+                <span className="traffic-distribution__annotation-label">{entry.label}</span>
+                <span className="traffic-distribution__annotation-value">{`${Math.round(entry.value)}%`}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/frontend/src/dashboard/v2/utils/vrmDecorators.ts
+++ b/frontend/src/dashboard/v2/utils/vrmDecorators.ts
@@ -294,12 +294,15 @@ export const applyCapacityUsage = (result: ChartResult, orgId: string | undefine
   suppressDelta(next);
   ensureSummary(next);
   const series = next.series[0];
+  const uiClient = resolveUiClient(orgId);
   const capacity = lookupCapacity(orgId);
-  if (!series || !capacity) {
+  if (!series) {
     return next;
   }
 
   const summary = next.meta!.summary as Record<string, unknown>;
+  summary.vrmResolvedClient = uiClient ?? null;
+  summary.vrmCapacity = capacity;
 
   const occupancyPoints = [...series.data];
   const normalizedSeries: DataPoint[] = occupancyPoints.map((point) => {


### PR DESCRIPTION
## Summary
- add VRM-specific traffic distribution slice labels and hide the legend row for the VRM Traffic by Camera tile
- format VRM KPI sparkline tooltips using the actual bucket timestamps in the site timezone instead of placeholder times
- surface the resolved VRM capacity context alongside normalized capacity usage to avoid ambiguous client mapping

## Testing
- CI=true npm --prefix frontend test -- --watch=false --silent
- npm --prefix frontend run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69221519866c832895cbb9978d59648a)