### PR TITLE
Improve VRM traffic tile and timeout handling

### DIFF
--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -13,6 +13,7 @@ import { fetchDashboardManifest, type FetchDashboardManifestOptions } from "../t
 import {
   loadWidgetResult,
   type LoadWidgetOptions,
+  isAbortError,
 } from "../transport/loadWidgetResult";
 import { unpinDashboardWidget } from "../transport/mutateDashboardManifest";
 import { determineOrgId } from "../../../utils/org";
@@ -393,6 +394,13 @@ const DashboardV2Page = ({
           } catch (err) {
             if (controller.signal.aborted) {
               return;
+            }
+            if (isAbortError(err)) {
+              const code = (err as { code?: string }).code;
+              if (code === "ABORTED") {
+                logInfo("dashboard.widgets", "ui_widget_cancelled", { widgetId: widget.id });
+                return;
+              }
             }
             encounteredError = true;
             const message = err instanceof Error ? err.message : "Unknown widget error";

--- a/frontend/src/dashboard/v2/transport/loadWidgetResult.ts
+++ b/frontend/src/dashboard/v2/transport/loadWidgetResult.ts
@@ -1,5 +1,4 @@
 import { API_BASE_URL, ANALYTICS_V2_TRANSPORT, type AnalyticsTransportMode } from "../../../config";
-import { createAbortSignal } from "../../../common/utils/abort";
 import { logError, logInfo, logWarn } from "../../../common/utils/logger";
 import type { ChartResult } from "../../../analytics/schemas/charting";
 import { validateChartResult } from "../../../analytics/components/ChartRenderer/validation";
@@ -17,6 +16,7 @@ export interface LoadWidgetOptions {
 }
 
 const DASHBOARD_RUN_ENDPOINT = "/api/analytics/run";
+const DASHBOARD_ANALYTICS_TIMEOUT_MS = 60_000;
 
 export const isAbortError = (error: unknown): boolean => {
   if (error instanceof DOMException) {
@@ -25,8 +25,41 @@ export const isAbortError = (error: unknown): boolean => {
   return typeof error === "object" && error !== null && (error as { name?: string }).name === "AbortError";
 };
 
-async function runLiveQuery(body: unknown, signal?: AbortSignal): Promise<ChartResult> {
-  const { signal: requestSignal, cleanup } = createAbortSignal({ parent: signal, timeoutMs: 45000 });
+async function runLiveQuery(
+  body: unknown,
+  options: { signal?: AbortSignal; widgetId?: string; orgId?: string; timeoutMs?: number } = {},
+): Promise<ChartResult> {
+  const { signal, widgetId, orgId, timeoutMs = DASHBOARD_ANALYTICS_TIMEOUT_MS } = options;
+  const start = Date.now();
+  let abortedByTimeout = false;
+  const parentSignal = signal;
+
+  const controller = new AbortController();
+  const handleParentAbort = () => {
+    controller.abort(parentSignal?.reason ?? new DOMException("Aborted", "AbortError"));
+  };
+  if (parentSignal) {
+    if (parentSignal.aborted) {
+      handleParentAbort();
+    } else {
+      parentSignal.addEventListener("abort", handleParentAbort);
+    }
+  }
+
+  const timeoutId = setTimeout(() => {
+    abortedByTimeout = true;
+    controller.abort(new DOMException("Timeout", "AbortError"));
+  }, timeoutMs);
+
+  const cleanup = () => {
+    clearTimeout(timeoutId);
+    if (parentSignal) {
+      parentSignal.removeEventListener("abort", handleParentAbort);
+    }
+  };
+
+  const requestSignal = controller.signal;
+
   try {
     const response = await fetch(`${API_BASE_URL}${DASHBOARD_RUN_ENDPOINT}`, {
       method: "POST",
@@ -40,11 +73,41 @@ async function runLiveQuery(body: unknown, signal?: AbortSignal): Promise<ChartR
       throw new Error(`Analytics run failed: ${response.status} ${text}`);
     }
 
+    logInfo("dashboard.widgets", "live_query_success", {
+      widgetId,
+      orgId,
+      durationMs: Date.now() - start,
+      timeoutMs,
+    });
+
     return (await response.json()) as ChartResult;
   } catch (error) {
+    const durationMs = Date.now() - start;
     if (isAbortError(error)) {
-      throw new Error("Analytics request timed out or was cancelled");
+      const code = abortedByTimeout ? "TIMEOUT" : "ABORTED";
+      const reason = requestSignal.reason;
+      logWarn("dashboard.widgets", "live_query_aborted", {
+        widgetId,
+        orgId,
+        durationMs,
+        timeoutMs,
+        code,
+        reason: reason instanceof Error ? reason.message : String(reason ?? ""),
+      });
+      const abortError = new Error(
+        abortedByTimeout ? "Analytics request timed out" : "Analytics request was cancelled",
+      );
+      abortError.name = "AbortError";
+      (abortError as { code?: string }).code = code;
+      throw abortError;
     }
+    logError("dashboard.widgets", "live_query_error", {
+      widgetId,
+      orgId,
+      durationMs,
+      timeoutMs,
+      message: error instanceof Error ? error.message : String(error),
+    });
     throw error instanceof Error ? error : new Error(String(error));
   } finally {
     cleanup();
@@ -82,11 +145,17 @@ export async function loadWidgetResult(
       result = await loadChartFixture(widget.fixtureId as ChartFixtureName);
     } else {
       const payload = viewToken ? { spec, viewToken } : { spec, orgId };
-      result = await runLiveQuery(payload, signal);
+      result = await runLiveQuery(payload, {
+        signal,
+        widgetId: widget.id,
+        orgId,
+        timeoutMs: DASHBOARD_ANALYTICS_TIMEOUT_MS,
+      });
     }
   } catch (error) {
     if (isAbortError(error)) {
-      logWarn("dashboard.widgets", "load_aborted", { widgetId: widget.id });
+      const code = (error as { code?: string }).code;
+      logWarn("dashboard.widgets", "load_aborted", { widgetId: widget.id, code });
     } else {
       logError("dashboard.widgets", "load_error", {
         widgetId: widget.id,

--- a/frontend/src/dashboard/v2/utils/vrmDecorators.test.ts
+++ b/frontend/src/dashboard/v2/utils/vrmDecorators.test.ts
@@ -1,4 +1,5 @@
-import { lookupCapacity, resolveUiClient } from "./vrmDecorators";
+import type { ChartResult } from "../../../analytics/schemas/charting";
+import { applyTrafficDistributionShare, lookupCapacity, resolveUiClient } from "./vrmDecorators";
 
 describe("vrm capacity mapping", () => {
   it("maps table client0 to ui client1 with capacity 10", () => {
@@ -13,5 +14,49 @@ describe("vrm capacity mapping", () => {
 
   it("throws for unknown clients", () => {
     expect(() => lookupCapacity("unknown-client")).toThrow("Unknown client for capacity usage");
+  });
+});
+
+describe("traffic distribution decorator", () => {
+  it("computes last-bucket shares and VRM metadata", () => {
+    const result: ChartResult = {
+      chartType: "composed_time",
+      xDimension: { id: "timestamp", type: "time" },
+      series: [
+        {
+          id: "cam-1",
+          label: "Events | camera_id=1",
+          geometry: "column",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: 10 },
+            { x: "2024-01-01T00:15:00Z", value: 30 },
+          ],
+        },
+        {
+          id: "cam-2",
+          label: "Events | camera_id=2",
+          geometry: "column",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: 20 },
+            { x: "2024-01-01T00:15:00Z", value: 10 },
+          ],
+        },
+      ],
+      meta: { timezone: "UTC" },
+    };
+
+    const decorated = applyTrafficDistributionShare(result);
+    const primarySeries = decorated.series[0];
+
+    expect(decorated.chartType).toBe("categorical");
+    expect(decorated.meta?.summary?.chartSubType).toBe("traffic_distribution");
+    expect(decorated.meta?.summary?.chartStyle).toBe("traffic_distribution");
+    expect(decorated.meta?.summary?.presentation).toBe("vrm");
+
+    expect(primarySeries.data.map((point) => point.x)).toEqual(["1", "2"]);
+    expect(primarySeries.data.map((point) => point.value ?? point.y)).toEqual([75, 25]);
+    expect(decorated.meta?.summary?.headlineValue).toBe(75);
   });
 });

--- a/frontend/src/dashboard/v2/utils/vrmDecorators.ts
+++ b/frontend/src/dashboard/v2/utils/vrmDecorators.ts
@@ -216,16 +216,6 @@ const deriveCameraLabel = (series: ChartSeries, index: number): string => {
   return (cleaned && cleaned.length > 0 ? cleaned : lastToken) || `Camera ${index + 1}`;
 };
 
-const deriveCameraLabel = (series: ChartSeries, index: number): string => {
-  const labelCandidate = series.label && series.label.toLowerCase() !== "events" ? series.label : null;
-  const source = labelCandidate ?? series.id ?? `Camera ${index + 1}`;
-  const normalized = String(source).trim();
-  const tokens = normalized.split(/\||:|=/);
-  const lastToken = tokens[tokens.length - 1]?.trim();
-  const cleaned = lastToken?.replace(/camera[_\s-]?id[:\s-]*/i, "").replace(/^cam\s*/i, "").trim();
-  return (cleaned && cleaned.length > 0 ? cleaned : lastToken) || `Camera ${index + 1}`;
-};
-
 export const applyTrafficDistributionShare = (result: ChartResult): ChartResult => {
   const trafficDistributionResult = cloneResult(result);
   markCompact(trafficDistributionResult);
@@ -245,26 +235,34 @@ export const applyTrafficDistributionShare = (result: ChartResult): ChartResult 
     return buildTrafficPlaceholderResult();
   }
 
+  const parseTimestamp = (value: unknown): Date | null => {
+    if (value instanceof Date) {
+      return value;
+    }
+    if (typeof value === "number") {
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.valueOf()) ? null : parsed;
+    }
+    if (typeof value === "string") {
+      const parsed = new Date(value);
+      return Number.isNaN(parsed.valueOf()) ? null : parsed;
+    }
+    return null;
+  };
+
   const hasTimestampBuckets = seriesList.some((series) =>
-    series.data.some((point) => {
-      if (!point?.x) {
-        return false;
-      }
-      const parsed = new Date(point.x as string | number);
-      return !Number.isNaN(parsed.valueOf());
-    }),
+    series.data.some((point) => parseTimestamp(point?.x ?? null) !== null),
   );
 
-  let latestTimestamp: string | null = null;
+  let latestTimestampMs: number | null = null;
   if (hasTimestampBuckets) {
     const allTimestamps = seriesList
-      .flatMap((series) => series.data.map((point) => point.x))
-      .filter((value): value is string => typeof value === "string")
-      .filter((value) => !Number.isNaN(new Date(value).valueOf()));
+      .flatMap((series) => series.data.map((point) => parseTimestamp(point.x)))
+      .filter((value): value is Date => value !== null)
+      .map((value) => value.valueOf())
+      .filter((value) => !Number.isNaN(value));
     if (allTimestamps.length > 0) {
-      allTimestamps.sort((a, b) => new Date(a).valueOf() - new Date(b).valueOf());
-      const lastTimestamp = allTimestamps[allTimestamps.length - 1];
-      latestTimestamp = typeof lastTimestamp === "string" ? lastTimestamp : new Date(lastTimestamp).toISOString();
+      latestTimestampMs = Math.max(...allTimestamps);
     }
   }
 
@@ -273,15 +271,18 @@ export const applyTrafficDistributionShare = (result: ChartResult): ChartResult 
     console.log("VRM traffic distribution: bucket discovery", {
       seriesCount: seriesList.length,
       hasTimestampBuckets,
-      latestTimestamp,
+      latestTimestamp: latestTimestampMs,
     });
   }
 
   const cameraShares = hasTimestampBuckets
     ? seriesList.map((series, index) => {
         let latestPoint: DataPoint | undefined;
-        if (latestTimestamp) {
-          latestPoint = series.data.find((point) => point.x === latestTimestamp);
+        if (latestTimestampMs !== null) {
+          latestPoint = series.data.find((point) => {
+            const parsed = parseTimestamp(point.x);
+            return parsed?.valueOf() === latestTimestampMs;
+          });
         }
         const resolvedPoint = latestPoint ?? series.data[series.data.length - 1];
         const raw = latestPoint?.value ?? latestPoint?.y ?? 0;


### PR DESCRIPTION
## Summary
- Make VRM traffic decorator resilient to timestamp formats and ensure traffic distribution metadata is set for rendering
- Handle dashboard analytics aborts vs. timeouts with clearer logging and messaging while extending timeout limits
- Add coverage for VRM traffic share calculation and prevent user-driven cancels from surfacing as widget errors

## Testing
- npm run lint
- CI=true npm test -- --watch=false --silent
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6922306d4d2883258f76a697983d6dfa)