### PR TITLE
Handle misaligned split time-series buckets

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/__tests__/validation.test.ts
+++ b/frontend/src/analytics/components/ChartRenderer/__tests__/validation.test.ts
@@ -107,4 +107,70 @@ describe("validateChartResult", () => {
     const issues = validateChartResult(heatmap);
     expect(issues.some((issue) => issue.code === "heatmap_grid_gap")).toBe(true);
   });
+
+  it("flags bucket mismatches for non-split time series", () => {
+    const result: ChartResult = {
+      chartType: "composed_time",
+      xDimension: { id: "timestamp", type: "time", bucket: "15_MIN", timezone: "UTC" },
+      series: [
+        {
+          id: "entrances",
+          label: "Entrances",
+          geometry: "line",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:00:00Z", y: 5 },
+            { x: "2024-01-01T00:15:00Z", y: 10 },
+          ],
+        },
+        {
+          id: "exits",
+          label: "Exits",
+          geometry: "line",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:15:00Z", y: 3 },
+            { x: "2024-01-01T00:30:00Z", y: 2 },
+          ],
+        },
+      ],
+      meta: { timezone: "UTC" },
+    };
+
+    const issues = validateChartResult(result);
+    expect(issues.some((issue) => issue.code === "bucket_mismatch")).toBe(true);
+  });
+
+  it("allows misaligned buckets for split time-series traffic charts", () => {
+    const result: ChartResult = {
+      chartType: "composed_time",
+      xDimension: { id: "timestamp", type: "time", bucket: "15_MIN", timezone: "UTC" },
+      series: [
+        {
+          id: "cam-1",
+          label: "Events | camera_id=1",
+          geometry: "column",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:00:00Z", y: 10 },
+            { x: "2024-01-01T00:30:00Z", y: 15 },
+          ],
+        },
+        {
+          id: "cam-2",
+          label: "Events | camera_id=2",
+          geometry: "column",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:15:00Z", y: 20 },
+          ],
+        },
+      ],
+      meta: { timezone: "UTC" },
+    };
+
+    const issues = validateChartResult(result);
+    expect(issues.some((issue) => issue.code === "bucket_mismatch")).toBe(false);
+    expect(issues.some((issue) => issue.code === "duplicate_bucket")).toBe(false);
+  });
 });

--- a/frontend/src/analytics/components/ChartRenderer/validation.ts
+++ b/frontend/src/analytics/components/ChartRenderer/validation.ts
@@ -16,7 +16,42 @@ const SUPPORTED_UNITS = new Set<ChartSeries["unit"] | undefined | null>([
   null,
 ]);
 
-function validateSeriesData(series: ChartSeries[], chartType: ChartType): ValidationIssue[] {
+interface ValidationOptions {
+  allowMisalignedBuckets?: boolean;
+}
+
+const getSeriesBaseLabel = (series: ChartSeries): string => {
+  const labelSource = series.label ?? series.id ?? "";
+  const [base] = labelSource.split("|");
+  return base.trim().toLowerCase();
+};
+
+// Split time-series (e.g., per-camera traffic) render one series per category and buckets may be sparse
+// or misaligned across series. We only consider a result to be a split time-series when:
+// - The x-dimension is time-based.
+// - There are multiple series.
+// - All series share the same base label/id prefix (before any "|" split annotation).
+// - All series share the same unit.
+// This is intentionally conservative to avoid relaxing validation for unrelated multi-measure charts.
+const isSplitTimeSeries = (result: ChartResult): boolean => {
+  if (!result?.series || result.series.length <= 1) {
+    return false;
+  }
+  if (result.xDimension?.type !== "time") {
+    return false;
+  }
+
+  const baseLabels = new Set(result.series.map((entry) => getSeriesBaseLabel(entry)));
+  const units = new Set(result.series.map((entry) => entry.unit ?? null));
+
+  return baseLabels.size === 1 && units.size === 1;
+};
+
+function validateSeriesData(
+  series: ChartSeries[],
+  chartType: ChartType,
+  options: ValidationOptions = {},
+): ValidationIssue[] {
   if (series.length === 0) {
     return [
       {
@@ -30,6 +65,7 @@ function validateSeriesData(series: ChartSeries[], chartType: ChartType): Valida
 
   const referenceOrder = series[0]?.data.map((point) => point.x) ?? [];
   const seenBuckets = new Set(referenceOrder);
+  const allowMisalignedBuckets = options.allowMisalignedBuckets ?? false;
 
   series.forEach((seriesItem) => {
     if (!SUPPORTED_UNITS.has(seriesItem.unit)) {
@@ -81,7 +117,7 @@ function validateSeriesData(series: ChartSeries[], chartType: ChartType): Valida
       }
     });
 
-    if (chartType !== "heatmap" && chartType !== "retention") {
+    if (chartType !== "heatmap" && chartType !== "retention" && !allowMisalignedBuckets) {
       if (referenceOrder.length !== seriesItem.data.length) {
         issues.push({
           code: "bucket_mismatch",
@@ -104,7 +140,7 @@ function validateSeriesData(series: ChartSeries[], chartType: ChartType): Valida
     });
   });
 
-  if (chartType !== "heatmap" && chartType !== "retention") {
+  if (chartType !== "heatmap" && chartType !== "retention" && !allowMisalignedBuckets) {
     if (referenceOrder.length !== seenBuckets.size) {
       issues.push({
         code: "duplicate_bucket",
@@ -179,7 +215,9 @@ export function validateChartResult(result: ChartResult): ValidationIssue[] {
     ];
   }
 
-  const issues = validateSeriesData(result.series, result.chartType);
+  const issues = validateSeriesData(result.series, result.chartType, {
+    allowMisalignedBuckets: isSplitTimeSeries(result),
+  });
 
   if (result.chartType === "heatmap" || result.chartType === "retention") {
     issues.push(...validateHeatmap(result.series));


### PR DESCRIPTION
## Summary
- Detect split time-series traffic charts and allow misaligned buckets while keeping other chart validation strict
- Extend validation tests to cover non-split misalignment failures and split-series allowances

## Testing
- npm run lint
- CI=true npm test -- --watch=false --silent
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6922f3e159dc8328b21ffd4b046ba47e)