### PR TITLE
Implement VRM-specific occupancy and dwell calculators

### DIFF
--- a/backend/app/analytics/compiler.py
+++ b/backend/app/analytics/compiler.py
@@ -627,6 +627,141 @@ class SpecCompiler:
             raise ValidationError("occupancy_recursion requires bucketed time series")
         measure_id = measure["id"]
         prefix = f"{measure_id}_occupancy"
+        options = measure.get("options", {}) if isinstance(measure.get("options"), dict) else {}
+
+        if options.get("vrmOccupancy"):
+            bucket_expr = _bucket_expression(bucket)
+            interval_expr = _bucket_interval_expression(bucket)
+            anchor = dedent(
+                f"""
+                {prefix}_anchor AS (
+                    SELECT
+                        CASE
+                            WHEN TIME(TIMESTAMP(@end_ts)) >= TIME(4, 0, 0) THEN TIMESTAMP_TRUNC(TIMESTAMP(@end_ts), DAY)
+                            ELSE TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP(@end_ts), DAY), INTERVAL 1 DAY)
+                        END + INTERVAL 4 HOUR AS anchor_ts
+                )
+                """
+            ).strip()
+            deltas = dedent(
+                f"""
+                {prefix}_deltas AS (
+                    SELECT
+                        {bucket_expr} AS bucket_start,
+                        COUNT(*) AS event_count,
+                        SUM(IF(event = 1, 1, -1)) AS delta
+                    FROM scoped
+                    GROUP BY bucket_start
+                )
+                """
+            ).strip()
+            if use_calendar:
+                bucketed = dedent(
+                    f"""
+                    {prefix}_bucketed AS (
+                        SELECT
+                            calendar.bucket_start,
+                            calendar.bucket_seconds,
+                            calendar.window_seconds,
+                            COALESCE(deltas.delta, 0) AS delta,
+                            COALESCE(deltas.event_count, 0) AS event_count
+                        FROM calendar
+                        LEFT JOIN {prefix}_deltas AS deltas
+                            ON deltas.bucket_start = calendar.bucket_start
+                        ORDER BY calendar.bucket_start
+                    )
+                    """
+                ).strip()
+            else:
+                bucketed = dedent(
+                    f"""
+                    {prefix}_bucketed AS (
+                        SELECT
+                            bucket_start,
+                            TIMESTAMP_DIFF(TIMESTAMP_ADD(bucket_start, {interval_expr}), bucket_start, SECOND) AS bucket_seconds,
+                            GREATEST(
+                                TIMESTAMP_DIFF(
+                                    LEAST(TIMESTAMP_ADD(bucket_start, {interval_expr}), TIMESTAMP(@end_ts)),
+                                    GREATEST(bucket_start, TIMESTAMP(@start_ts)),
+                                    SECOND
+                                ),
+                                0
+                            ) AS window_seconds,
+                            COALESCE(deltas.delta, 0) AS delta,
+                            COALESCE(deltas.event_count, 0) AS event_count
+                        FROM (
+                            SELECT DISTINCT {bucket_expr} AS bucket_start
+                            FROM scoped
+                        )
+                        LEFT JOIN {prefix}_deltas AS deltas
+                            ON deltas.bucket_start = bucket_start
+                        ORDER BY bucket_start
+                    )
+                    """
+                ).strip()
+
+            cumulative = dedent(
+                f"""
+                {prefix}_cumulative AS (
+                    SELECT
+                        bucket_start,
+                        bucket_seconds,
+                        window_seconds,
+                        event_count,
+                        delta,
+                        SUM(delta) OVER (ORDER BY bucket_start) AS running_sum
+                    FROM {prefix}_bucketed
+                )
+                """
+            ).strip()
+            reflected = dedent(
+                f"""
+                {prefix}_reflected AS (
+                    SELECT
+                        cumulative.bucket_start,
+                        cumulative.bucket_seconds,
+                        cumulative.window_seconds,
+                        cumulative.event_count,
+                        cumulative.delta,
+                        cumulative.running_sum,
+                        anchor.anchor_ts,
+                        CASE
+                            WHEN cumulative.bucket_start < anchor.anchor_ts THEN cumulative.running_sum - LEAST(0, MIN(cumulative.running_sum) OVER (
+                                ORDER BY cumulative.bucket_start ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                            ))
+                            ELSE cumulative.running_sum - LEAST(0, MIN(IF(cumulative.bucket_start >= anchor.anchor_ts, cumulative.running_sum, NULL)) OVER (
+                                ORDER BY cumulative.bucket_start ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                            ))
+                        END AS value
+                    FROM {prefix}_cumulative AS cumulative
+                    CROSS JOIN {prefix}_anchor AS anchor
+                )
+                """
+            ).strip()
+            series = dedent(
+                f"""
+                {prefix}_series AS (
+                    SELECT
+                        bucket_start,
+                        value,
+                        CASE
+                            WHEN bucket_seconds = 0 THEN 0.0
+                            WHEN event_count = 0 THEN 0.0
+                            ELSE SAFE_DIVIDE(window_seconds, bucket_seconds)
+                        END AS coverage,
+                        event_count AS raw_count
+                    FROM {prefix}_reflected
+                )
+                """
+            ).strip()
+
+            select_sql = (
+                f"SELECT '{measure_id}' AS measure_id, bucket_start, value, coverage, raw_count FROM {prefix}_series"
+            )
+            return MeasureCompilation(
+                ctes=[anchor, deltas, bucketed, cumulative, reflected, series],
+                select_sql=select_sql,
+            )
         ordered = dedent(
             f"""
             {prefix}_ordered AS (
@@ -967,6 +1102,10 @@ class SpecCompiler:
         aggregation = measure["aggregation"]
         measure_id = measure["id"]
         prefix = f"{measure_id}_dwell"
+        options = measure.get("options", {}) if isinstance(measure.get("options"), dict) else {}
+
+        partition_fields = "site_id, cam_id" if options.get("vrmDwellFifo") else "site_id, cam_id, track_id"
+        join_track_id = "" if options.get("vrmDwellFifo") else "AND e.track_id = x.track_id"
 
         entrances = dedent(
             f"""
@@ -977,7 +1116,7 @@ class SpecCompiler:
                     track_id,
                     timestamp AS entrance_ts,
                     ROW_NUMBER() OVER (
-                        PARTITION BY site_id, cam_id, track_id
+                        PARTITION BY {partition_fields}
                         ORDER BY timestamp, index
                     ) AS rn
                 FROM scoped
@@ -995,7 +1134,7 @@ class SpecCompiler:
                     track_id,
                     timestamp AS exit_ts,
                     ROW_NUMBER() OVER (
-                        PARTITION BY site_id, cam_id, track_id
+                        PARTITION BY {partition_fields}
                         ORDER BY timestamp, index
                     ) AS rn
                 FROM scoped
@@ -1018,8 +1157,8 @@ class SpecCompiler:
                 LEFT JOIN {prefix}_exits AS x
                     ON e.site_id = x.site_id
                     AND e.cam_id = x.cam_id
-                    AND e.track_id = x.track_id
                     AND e.rn = x.rn
+                    {join_track_id}
                 WHERE x.exit_ts IS NOT NULL
                     AND TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, MINUTE) BETWEEN 0 AND 360
             )

--- a/backend/tests/test_vrm_kpis.py
+++ b/backend/tests/test_vrm_kpis.py
@@ -1,0 +1,122 @@
+import copy
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.analytics import SpecCompiler
+from backend.app.analytics.compiler import CompilerContext
+
+
+def test_vrm_occupancy_compiles_soft_anchor_pipeline():
+    spec = {
+        "id": "dashboard.kpi.vrm.occupancy",
+        "dataset": "events",
+        "chartType": "single_value",
+        "measures": [
+            {
+                "id": "occupancy",
+                "aggregation": "occupancy_recursion",
+                "options": {"vrmOccupancy": True},
+            }
+        ],
+        "dimensions": [
+            {"id": "timestamp", "column": "timestamp", "bucket": "15_MIN"},
+        ],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-02T00:00:00Z",
+            "bucket": "15_MIN",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled = compiler.compile(spec, context)
+
+    sql = compiled.sql
+    assert "occupancy_occupancy_anchor" in sql
+    assert "occupancy_occupancy_deltas" in sql
+    assert "MIN(IF(cumulative.bucket_start >= anchor.anchor_ts" in sql
+    assert "seeded_by_exit" not in sql
+
+
+def test_standard_occupancy_remains_unchanged():
+    spec = {
+        "id": "live-flow",
+        "dataset": "events",
+        "chartType": "composed_time",
+        "measures": [
+            {"id": "occupancy", "aggregation": "occupancy_recursion"},
+        ],
+        "dimensions": [{"id": "timestamp", "column": "timestamp", "bucket": "HOUR"}],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-01T06:00:00Z",
+            "bucket": "HOUR",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled = compiler.compile(spec, context)
+
+    sql = compiled.sql
+    assert "seeded_by_exit" in sql
+    assert "occupancy_occupancy_anchor" not in sql
+
+
+def test_vrm_dwell_fifo_compiles_without_track_matching():
+    vrm_spec = {
+        "id": "dashboard.kpi.vrm.dwell",
+        "dataset": "events",
+        "chartType": "single_value",
+        "measures": [
+            {
+                "id": "dwell",
+                "aggregation": "dwell_mean",
+                "options": {"vrmDwellFifo": True},
+            }
+        ],
+        "dimensions": [{"id": "timestamp", "column": "timestamp", "bucket": "15_MIN"}],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-01T06:00:00Z",
+            "bucket": "15_MIN",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled_vrm = compiler.compile(vrm_spec, context)
+
+    sql = compiled_vrm.sql
+    assert "PARTITION BY site_id, cam_id" in sql
+    assert (
+        "PARTITION BY site_id, cam_id, track_id\n                        ORDER BY timestamp, index\n                    ) AS rn\n                FROM scoped\n                WHERE event = 1"
+        not in sql
+    )
+    assert "AND e.track_id = x.track_id" not in sql
+
+    standard_spec = copy.deepcopy(vrm_spec)
+    standard_spec["measures"][0]["options"] = {}
+    compiled_standard = compiler.compile(standard_spec, context)
+    standard_sql = compiled_standard.sql
+    assert "PARTITION BY site_id, cam_id, track_id" in standard_sql
+    assert "AND e.track_id = x.track_id" in standard_sql
+
+
+def test_reflection_helper_never_negative():
+    deltas = pd.Series([-5, 2, 2, -3, 4])
+    running_sum = deltas.cumsum()
+    running_min = running_sum.cummin().clip(upper=0)
+    reflected = running_sum - running_min
+
+    assert reflected.min() >= 0
+    assert list(reflected) == [0, 2, 4, 1, 5]
+

--- a/frontend/src/dashboard/v2/utils/applyVRMOverrides.ts
+++ b/frontend/src/dashboard/v2/utils/applyVRMOverrides.ts
@@ -89,7 +89,14 @@ const vrmWidgets: DashboardWidget[] = [
     fixtureId: "golden_dashboard_kpi_live_occupancy",
     inlineSpec: singleValueSpec({
       id: "dashboard.kpi.vrm.occupancy",
-      measures: [{ aggregation: "occupancy_recursion", id: "occupancy", label: "Occupancy" }],
+      measures: [
+        {
+          aggregation: "occupancy_recursion",
+          id: "occupancy",
+          label: "Occupancy",
+          options: { vrmOccupancy: true },
+        },
+      ],
       notes: ["Occupancy per 15 minutes"],
     }),
     fixedTimeWindow: fixedWindow,
@@ -133,7 +140,14 @@ const vrmWidgets: DashboardWidget[] = [
     fixtureId: "golden_dashboard_kpi_average_dwell_time",
     inlineSpec: singleValueSpec({
       id: "dashboard.kpi.vrm.dwell",
-      measures: [{ aggregation: "dwell_mean", id: "dwell", label: "Avg dwell" }],
+      measures: [
+        {
+          aggregation: "dwell_mean",
+          id: "dwell",
+          label: "Avg dwell",
+          options: { vrmDwellFifo: true },
+        },
+      ],
       notes: ["Average dwell by 15-minute bucket"],
     }),
     fixedTimeWindow: fixedWindow,


### PR DESCRIPTION
## Summary
- gate VRM occupancy and dwell KPI measures with widget-specific options
- implement soft-anchored bounded occupancy recursion for VRM requests only
- add VRM FIFO dwell pairing logic and regression tests

## Testing
- pytest backend/tests/test_vrm_kpis.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692325723a348322873d1b1ed67544b9)