### PR TITLE
Update VRM capacity mapping and KPI decorator behavior

### DIFF
--- a/backend/app/analytics/compiler.py
+++ b/backend/app/analytics/compiler.py
@@ -627,6 +627,141 @@ class SpecCompiler:
             raise ValidationError("occupancy_recursion requires bucketed time series")
         measure_id = measure["id"]
         prefix = f"{measure_id}_occupancy"
+        options = measure.get("options", {}) if isinstance(measure.get("options"), dict) else {}
+
+        if options.get("vrmOccupancy"):
+            bucket_expr = _bucket_expression(bucket)
+            interval_expr = _bucket_interval_expression(bucket)
+            anchor = dedent(
+                f"""
+                {prefix}_anchor AS (
+                    SELECT
+                        CASE
+                            WHEN TIME(TIMESTAMP(@end_ts)) >= TIME(4, 0, 0) THEN TIMESTAMP_TRUNC(TIMESTAMP(@end_ts), DAY)
+                            ELSE TIMESTAMP_SUB(TIMESTAMP_TRUNC(TIMESTAMP(@end_ts), DAY), INTERVAL 1 DAY)
+                        END + INTERVAL 4 HOUR AS anchor_ts
+                )
+                """
+            ).strip()
+            deltas = dedent(
+                f"""
+                {prefix}_deltas AS (
+                    SELECT
+                        {bucket_expr} AS bucket_start,
+                        COUNT(*) AS event_count,
+                        SUM(IF(event = 1, 1, -1)) AS delta
+                    FROM scoped
+                    GROUP BY bucket_start
+                )
+                """
+            ).strip()
+            if use_calendar:
+                bucketed = dedent(
+                    f"""
+                    {prefix}_bucketed AS (
+                        SELECT
+                            calendar.bucket_start,
+                            calendar.bucket_seconds,
+                            calendar.window_seconds,
+                            COALESCE(deltas.delta, 0) AS delta,
+                            COALESCE(deltas.event_count, 0) AS event_count
+                        FROM calendar
+                        LEFT JOIN {prefix}_deltas AS deltas
+                            ON deltas.bucket_start = calendar.bucket_start
+                        ORDER BY calendar.bucket_start
+                    )
+                    """
+                ).strip()
+            else:
+                bucketed = dedent(
+                    f"""
+                    {prefix}_bucketed AS (
+                        SELECT
+                            bucket_start,
+                            TIMESTAMP_DIFF(TIMESTAMP_ADD(bucket_start, {interval_expr}), bucket_start, SECOND) AS bucket_seconds,
+                            GREATEST(
+                                TIMESTAMP_DIFF(
+                                    LEAST(TIMESTAMP_ADD(bucket_start, {interval_expr}), TIMESTAMP(@end_ts)),
+                                    GREATEST(bucket_start, TIMESTAMP(@start_ts)),
+                                    SECOND
+                                ),
+                                0
+                            ) AS window_seconds,
+                            COALESCE(deltas.delta, 0) AS delta,
+                            COALESCE(deltas.event_count, 0) AS event_count
+                        FROM (
+                            SELECT DISTINCT {bucket_expr} AS bucket_start
+                            FROM scoped
+                        )
+                        LEFT JOIN {prefix}_deltas AS deltas
+                            ON deltas.bucket_start = bucket_start
+                        ORDER BY bucket_start
+                    )
+                    """
+                ).strip()
+
+            cumulative = dedent(
+                f"""
+                {prefix}_cumulative AS (
+                    SELECT
+                        bucket_start,
+                        bucket_seconds,
+                        window_seconds,
+                        event_count,
+                        delta,
+                        SUM(delta) OVER (ORDER BY bucket_start) AS running_sum
+                    FROM {prefix}_bucketed
+                )
+                """
+            ).strip()
+            reflected = dedent(
+                f"""
+                {prefix}_reflected AS (
+                    SELECT
+                        cumulative.bucket_start,
+                        cumulative.bucket_seconds,
+                        cumulative.window_seconds,
+                        cumulative.event_count,
+                        cumulative.delta,
+                        cumulative.running_sum,
+                        anchor.anchor_ts,
+                        CASE
+                            WHEN cumulative.bucket_start < anchor.anchor_ts THEN cumulative.running_sum - LEAST(0, MIN(cumulative.running_sum) OVER (
+                                ORDER BY cumulative.bucket_start ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                            ))
+                            ELSE cumulative.running_sum - LEAST(0, MIN(IF(cumulative.bucket_start >= anchor.anchor_ts, cumulative.running_sum, NULL)) OVER (
+                                ORDER BY cumulative.bucket_start ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                            ))
+                        END AS value
+                    FROM {prefix}_cumulative AS cumulative
+                    CROSS JOIN {prefix}_anchor AS anchor
+                )
+                """
+            ).strip()
+            series = dedent(
+                f"""
+                {prefix}_series AS (
+                    SELECT
+                        bucket_start,
+                        value,
+                        CASE
+                            WHEN bucket_seconds = 0 THEN 0.0
+                            WHEN event_count = 0 THEN 0.0
+                            ELSE SAFE_DIVIDE(window_seconds, bucket_seconds)
+                        END AS coverage,
+                        event_count AS raw_count
+                    FROM {prefix}_reflected
+                )
+                """
+            ).strip()
+
+            select_sql = (
+                f"SELECT '{measure_id}' AS measure_id, bucket_start, value, coverage, raw_count FROM {prefix}_series"
+            )
+            return MeasureCompilation(
+                ctes=[anchor, deltas, bucketed, cumulative, reflected, series],
+                select_sql=select_sql,
+            )
         ordered = dedent(
             f"""
             {prefix}_ordered AS (
@@ -967,64 +1102,183 @@ class SpecCompiler:
         aggregation = measure["aggregation"]
         measure_id = measure["id"]
         prefix = f"{measure_id}_dwell"
+        options = measure.get("options", {}) if isinstance(measure.get("options"), dict) else {}
 
-        entrances = dedent(
-            f"""
-            {prefix}_entrances AS (
-                SELECT
-                    site_id,
-                    cam_id,
-                    track_id,
-                    timestamp AS entrance_ts,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY site_id, cam_id, track_id
-                        ORDER BY timestamp, index
-                    ) AS rn
-                FROM scoped
-                WHERE event = 1
-            )
-            """
-        ).strip()
+        if options.get("vrmDwellFifo"):
+            events = dedent(
+                f"""
+                {prefix}_events AS (
+                    SELECT
+                        site_id,
+                        cam_id,
+                        track_id,
+                        timestamp,
+                        event,
+                        index,
+                        SUM(IF(event = 1, 1, 0)) OVER (
+                            PARTITION BY site_id, cam_id
+                            ORDER BY timestamp, index
+                        ) AS entrance_count,
+                        SUM(IF(event = 0, 1, 0)) OVER (
+                            PARTITION BY site_id, cam_id
+                            ORDER BY timestamp, index
+                        ) AS exit_count
+                    FROM scoped
+                )
+                """
+            ).strip()
 
-        exits = dedent(
-            f"""
-            {prefix}_exits AS (
-                SELECT
-                    site_id,
-                    cam_id,
-                    track_id,
-                    timestamp AS exit_ts,
-                    ROW_NUMBER() OVER (
-                        PARTITION BY site_id, cam_id, track_id
-                        ORDER BY timestamp, index
-                    ) AS rn
-                FROM scoped
-                WHERE event = 0
-            )
-            """
-        ).strip()
+            entrances = dedent(
+                f"""
+                {prefix}_entrances AS (
+                    SELECT
+                        site_id,
+                        cam_id,
+                        timestamp AS entrance_ts,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY site_id, cam_id
+                            ORDER BY timestamp, index
+                        ) AS entrance_seq
+                    FROM scoped
+                    WHERE event = 1
+                )
+                """
+            ).strip()
 
-        sessions = dedent(
-            f"""
-            {prefix}_sessions AS (
-                SELECT
-                    e.site_id,
-                    e.cam_id,
-                    e.track_id,
-                    e.entrance_ts,
-                    x.exit_ts,
-                    TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, SECOND) / 60.0 AS dwell_minutes
-                FROM {prefix}_entrances AS e
-                LEFT JOIN {prefix}_exits AS x
-                    ON e.site_id = x.site_id
-                    AND e.cam_id = x.cam_id
-                    AND e.track_id = x.track_id
-                    AND e.rn = x.rn
-                WHERE x.exit_ts IS NOT NULL
-                    AND TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, MINUTE) BETWEEN 0 AND 360
-            )
-            """
-        ).strip()
+            exits = dedent(
+                f"""
+                {prefix}_exits AS (
+                    SELECT
+                        site_id,
+                        cam_id,
+                        timestamp AS exit_ts,
+                        index,
+                        entrance_count,
+                        exit_count,
+                        MIN(entrance_count - exit_count) OVER (
+                            PARTITION BY site_id, cam_id
+                            ORDER BY timestamp, index
+                            ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                        ) AS min_balance,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY site_id, cam_id
+                            ORDER BY timestamp, index
+                        ) AS exit_seq,
+                        exit_count + LEAST(
+                            MIN(entrance_count - exit_count) OVER (
+                                PARTITION BY site_id, cam_id
+                                ORDER BY timestamp, index
+                                ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                            ),
+                            0
+                        ) AS matched_seq
+                    FROM {prefix}_events
+                    WHERE event = 0
+                )
+                """
+            ).strip()
+
+            filtered_exits = dedent(
+                f"""
+                {prefix}_filtered_exits AS (
+                    SELECT
+                        site_id,
+                        cam_id,
+                        exit_ts,
+                        matched_seq
+                    FROM (
+                        SELECT
+                            *,
+                            LAG(matched_seq, 1, 0) OVER (
+                                PARTITION BY site_id, cam_id
+                                ORDER BY exit_ts, index
+                            ) AS prev_matched_seq
+                        FROM {prefix}_exits
+                    )
+                    WHERE matched_seq > prev_matched_seq
+                )
+                """
+            ).strip()
+
+            sessions = dedent(
+                f"""
+                {prefix}_sessions AS (
+                    SELECT
+                        e.site_id,
+                        e.cam_id,
+                        entrance.entrance_ts,
+                        e.exit_ts,
+                        TIMESTAMP_DIFF(e.exit_ts, entrance.entrance_ts, SECOND) / 60.0 AS dwell_minutes
+                    FROM {prefix}_filtered_exits AS e
+                    JOIN {prefix}_entrances AS entrance
+                        ON entrance.site_id = e.site_id
+                        AND entrance.cam_id = e.cam_id
+                        AND entrance.entrance_seq = e.matched_seq
+                    WHERE TIMESTAMP_DIFF(e.exit_ts, entrance.entrance_ts, MINUTE) BETWEEN 0 AND 360
+                )
+                """
+            ).strip()
+        else:
+            partition_fields = "site_id, cam_id, track_id"
+            join_track_id = "AND e.track_id = x.track_id"
+
+            entrances = dedent(
+                f"""
+                {prefix}_entrances AS (
+                    SELECT
+                        site_id,
+                        cam_id,
+                        track_id,
+                        timestamp AS entrance_ts,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY {partition_fields}
+                            ORDER BY timestamp, index
+                        ) AS rn
+                    FROM scoped
+                    WHERE event = 1
+                )
+                """
+            ).strip()
+
+            exits = dedent(
+                f"""
+                {prefix}_exits AS (
+                    SELECT
+                        site_id,
+                        cam_id,
+                        track_id,
+                        timestamp AS exit_ts,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY {partition_fields}
+                            ORDER BY timestamp, index
+                        ) AS rn
+                    FROM scoped
+                    WHERE event = 0
+                )
+                """
+            ).strip()
+
+            sessions = dedent(
+                f"""
+                {prefix}_sessions AS (
+                    SELECT
+                        e.site_id,
+                        e.cam_id,
+                        e.track_id,
+                        e.entrance_ts,
+                        x.exit_ts,
+                        TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, SECOND) / 60.0 AS dwell_minutes
+                    FROM {prefix}_entrances AS e
+                    LEFT JOIN {prefix}_exits AS x
+                        ON e.site_id = x.site_id
+                        AND e.cam_id = x.cam_id
+                        AND e.rn = x.rn
+                        {join_track_id}
+                    WHERE x.exit_ts IS NOT NULL
+                        AND TIMESTAMP_DIFF(x.exit_ts, e.entrance_ts, MINUTE) BETWEEN 0 AND 360
+                )
+                """
+            ).strip()
 
         if use_calendar:
             bucketed = dedent(
@@ -1108,8 +1362,12 @@ class SpecCompiler:
         select_sql = (
             f"SELECT '{measure_id}' AS measure_id, bucket_start, value, coverage, raw_count FROM {prefix}_series"
         )
+        ctes = [entrances, exits, sessions, bucketed, series]
+        if options.get("vrmDwellFifo"):
+            ctes = [events, entrances, exits, filtered_exits, sessions, bucketed, series]
+
         return MeasureCompilation(
-            ctes=[entrances, exits, sessions, bucketed, series],
+            ctes=ctes,
             select_sql=select_sql,
         )
 

--- a/backend/tests/test_vrm_kpis.py
+++ b/backend/tests/test_vrm_kpis.py
@@ -1,0 +1,206 @@
+import copy
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from backend.app.analytics import SpecCompiler
+from backend.app.analytics.compiler import CompilerContext
+
+
+def test_vrm_occupancy_compiles_soft_anchor_pipeline():
+    spec = {
+        "id": "dashboard.kpi.vrm.occupancy",
+        "dataset": "events",
+        "chartType": "single_value",
+        "measures": [
+            {
+                "id": "occupancy",
+                "aggregation": "occupancy_recursion",
+                "options": {"vrmOccupancy": True},
+            }
+        ],
+        "dimensions": [
+            {"id": "timestamp", "column": "timestamp", "bucket": "15_MIN"},
+        ],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-02T00:00:00Z",
+            "bucket": "15_MIN",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled = compiler.compile(spec, context)
+
+    sql = compiled.sql
+    assert "occupancy_occupancy_anchor" in sql
+    assert "occupancy_occupancy_deltas" in sql
+    assert "MIN(IF(cumulative.bucket_start >= anchor.anchor_ts" in sql
+    assert "seeded_by_exit" not in sql
+
+
+def test_standard_occupancy_remains_unchanged():
+    spec = {
+        "id": "live-flow",
+        "dataset": "events",
+        "chartType": "composed_time",
+        "measures": [
+            {"id": "occupancy", "aggregation": "occupancy_recursion"},
+        ],
+        "dimensions": [{"id": "timestamp", "column": "timestamp", "bucket": "HOUR"}],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-01T06:00:00Z",
+            "bucket": "HOUR",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled = compiler.compile(spec, context)
+
+    sql = compiled.sql
+    assert "seeded_by_exit" in sql
+    assert "occupancy_occupancy_anchor" not in sql
+
+
+def test_vrm_dwell_fifo_compiles_without_track_matching():
+    vrm_spec = {
+        "id": "dashboard.kpi.vrm.dwell",
+        "dataset": "events",
+        "chartType": "single_value",
+        "measures": [
+            {
+                "id": "dwell",
+                "aggregation": "dwell_mean",
+                "options": {"vrmDwellFifo": True},
+            }
+        ],
+        "dimensions": [{"id": "timestamp", "column": "timestamp", "bucket": "15_MIN"}],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-01T06:00:00Z",
+            "bucket": "15_MIN",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled_vrm = compiler.compile(vrm_spec, context)
+
+    sql = compiled_vrm.sql
+    assert "dwell_dwell_events" in sql
+    assert "entrance_count - exit_count" in sql
+    assert "matched_seq" in sql
+    assert "prev_matched_seq" in sql
+    assert "matched_seq > prev_matched_seq" in sql
+    assert "entrance.entrance_seq = e.matched_seq" in sql
+    assert "PARTITION BY site_id, cam_id" in sql
+    assert (
+        "PARTITION BY site_id, cam_id, track_id\n                        ORDER BY timestamp, index\n                    ) AS rn\n                FROM scoped\n                WHERE event = 1"
+        not in sql
+    )
+    assert "AND e.track_id = x.track_id" not in sql
+
+    standard_spec = copy.deepcopy(vrm_spec)
+    standard_spec["measures"][0]["options"] = {}
+    compiled_standard = compiler.compile(standard_spec, context)
+    standard_sql = compiled_standard.sql
+    assert "PARTITION BY site_id, cam_id, track_id" in standard_sql
+    assert "AND e.track_id = x.track_id" in standard_sql
+
+
+def test_reflection_helper_never_negative():
+    deltas = pd.Series([-5, 2, 2, -3, 4])
+    running_sum = deltas.cumsum()
+    running_min = running_sum.cummin().clip(upper=0)
+    reflected = running_sum - running_min
+
+    assert reflected.min() >= 0
+    assert list(reflected) == [0, 2, 4, 1, 5]
+
+
+def test_vrm_dwell_fifo_queue_discards_early_exits_and_pairs_in_order():
+    events = pd.DataFrame(
+        {
+            "timestamp": pd.to_datetime(
+                [
+                    "2024-01-01T00:00:00Z",  # early exit
+                    "2024-01-01T00:05:00Z",  # entrance 1
+                    "2024-01-01T00:10:00Z",  # entrance 2
+                    "2024-01-01T00:15:00Z",  # exit for entrance 1
+                    "2024-01-01T00:20:00Z",  # exit for entrance 2
+                ]
+            ),
+            "event": [0, 1, 1, 0, 0],
+        }
+    )
+
+    events["entrance_count"] = (events["event"] == 1).cumsum()
+    events["exit_count"] = (events["event"] == 0).cumsum()
+    events["balance"] = events["entrance_count"] - events["exit_count"]
+    events["min_balance"] = events["balance"].cummin()
+
+    exits = events[events["event"] == 0].copy()
+    exits["matched_seq"] = exits["exit_count"] + exits["min_balance"].clip(upper=0)
+    exits["prev_matched_seq"] = exits["matched_seq"].shift(fill_value=0)
+    exits = exits[exits["matched_seq"] > exits["prev_matched_seq"]]
+
+    entrances = events[events["event"] == 1].reset_index(drop=True)
+    entrances["entrance_seq"] = entrances.index + 1
+
+    assert list(exits["matched_seq"]) == [1, 2]
+
+    paired = exits.merge(
+        entrances, left_on="matched_seq", right_on="entrance_seq", suffixes=("_exit", "_entrance")
+    )
+    dwell_minutes = (
+        (paired["timestamp_exit"] - paired["timestamp_entrance"])  # type: ignore[index]
+        .dt.total_seconds()
+        / 60.0
+    )
+
+    assert all(dwell_minutes >= 0)
+    assert dwell_minutes.tolist() == [10.0, 10.0]
+
+
+def test_vrm_capacity_compiles_with_vrm_occupancy_pipeline():
+    spec = {
+        "id": "dashboard.kpi.vrm.capacity_usage",
+        "dataset": "events",
+        "chartType": "single_value",
+        "measures": [
+            {
+                "id": "occupancy",
+                "aggregation": "occupancy_recursion",
+                "options": {"vrmOccupancy": True},
+            }
+        ],
+        "dimensions": [
+            {"id": "timestamp", "column": "timestamp", "bucket": "15_MIN"},
+        ],
+        "timeWindow": {
+            "from": "2024-01-01T00:00:00Z",
+            "to": "2024-01-02T00:00:00Z",
+            "bucket": "15_MIN",
+            "timezone": "UTC",
+        },
+    }
+
+    compiler = SpecCompiler()
+    context = CompilerContext(table_name="project.dataset.table")
+    compiled = compiler.compile(spec, context)
+
+    sql = compiled.sql
+    assert "occupancy_occupancy_anchor" in sql
+    assert "occupancy_occupancy_deltas" in sql
+    assert "MIN(IF(cumulative.bucket_start >= anchor.anchor_ts" in sql
+    assert "seeded_by_exit" not in sql
+

--- a/frontend/src/dashboard/v2/utils/applyVRMOverrides.test.ts
+++ b/frontend/src/dashboard/v2/utils/applyVRMOverrides.test.ts
@@ -181,8 +181,8 @@ describe("applyVRMOverrides", () => {
           geometry: "line",
           unit: "people",
           data: [
-            { x: prev.toISOString(), y: 100 },
-            { x: now.toISOString(), y: 90 },
+            { x: prev.toISOString(), y: 3 },
+            { x: now.toISOString(), y: 4 },
           ],
         },
       ],
@@ -198,11 +198,11 @@ describe("applyVRMOverrides", () => {
     expect(footfallResult.meta?.summary?.vrmChipText).toBe("today: 15");
 
     const capacityHeadline = getCapacityUsageHeadline(rawCapacityResult as any, "client1");
-    expect(capacityHeadline.currentUsage).toBe(90);
-    expect(capacityHeadline.peakToday).toBe(100);
-    expect(capacityResult.meta?.summary?.headlineValue).toBe(90);
+    expect(capacityHeadline.currentUsage).toBe(80);
+    expect(capacityHeadline.peakToday).toBe(80);
+    expect(capacityResult.meta?.summary?.headlineValue).toBe(80);
     expect(capacityResult.meta?.summary?.hideDelta).toBeTruthy();
-    expect(capacityResult.meta?.summary?.vrmChipText).toBe("peak: 100%");
+    expect(capacityResult.meta?.summary?.vrmChipText).toBe("peak: 80%");
   });
 
   it("uses UI client identifiers for capacity mapping", () => {
@@ -231,7 +231,7 @@ describe("applyVRMOverrides", () => {
     );
 
     const headline = getCapacityUsageHeadline(capacityResult as any, "client2");
-    expect(Math.round(headline.currentUsage ?? 0)).toBe(327);
+    expect(Math.round(headline.currentUsage ?? 0)).toBe(44);
     expect(capacityResult.meta?.summary?.peak_capacity_usage_today).toBeGreaterThan(0);
   });
 

--- a/frontend/src/dashboard/v2/utils/applyVRMOverrides.ts
+++ b/frontend/src/dashboard/v2/utils/applyVRMOverrides.ts
@@ -89,7 +89,14 @@ const vrmWidgets: DashboardWidget[] = [
     fixtureId: "golden_dashboard_kpi_live_occupancy",
     inlineSpec: singleValueSpec({
       id: "dashboard.kpi.vrm.occupancy",
-      measures: [{ aggregation: "occupancy_recursion", id: "occupancy", label: "Occupancy" }],
+      measures: [
+        {
+          aggregation: "occupancy_recursion",
+          id: "occupancy",
+          label: "Occupancy",
+          options: { vrmOccupancy: true },
+        },
+      ],
       notes: ["Occupancy per 15 minutes"],
     }),
     fixedTimeWindow: fixedWindow,
@@ -133,7 +140,14 @@ const vrmWidgets: DashboardWidget[] = [
     fixtureId: "golden_dashboard_kpi_average_dwell_time",
     inlineSpec: singleValueSpec({
       id: "dashboard.kpi.vrm.dwell",
-      measures: [{ aggregation: "dwell_mean", id: "dwell", label: "Avg dwell" }],
+      measures: [
+        {
+          aggregation: "dwell_mean",
+          id: "dwell",
+          label: "Avg dwell",
+          options: { vrmDwellFifo: true },
+        },
+      ],
       notes: ["Average dwell by 15-minute bucket"],
     }),
     fixedTimeWindow: fixedWindow,
@@ -168,7 +182,14 @@ const vrmWidgets: DashboardWidget[] = [
     fixtureId: "golden_dashboard_kpi_live_occupancy",
     inlineSpec: singleValueSpec({
       id: "dashboard.kpi.vrm.capacity_usage",
-      measures: [{ aggregation: "occupancy_recursion", id: "occupancy", label: "Occupancy" }],
+      measures: [
+        {
+          aggregation: "occupancy_recursion",
+          id: "occupancy",
+          label: "Occupancy",
+          options: { vrmOccupancy: true },
+        },
+      ],
       notes: ["Capacity usage derived from occupancy"],
     }),
     fixedTimeWindow: fixedWindow,

--- a/frontend/src/dashboard/v2/utils/vrmDecorators.test.ts
+++ b/frontend/src/dashboard/v2/utils/vrmDecorators.test.ts
@@ -1,15 +1,21 @@
 import type { ChartResult } from "../../../analytics/schemas/charting";
-import { applyTrafficDistributionShare, lookupCapacity, resolveUiClient } from "./vrmDecorators";
+import { VRM_KPI_IDS } from "./applyVRMOverrides";
+import {
+  applyTrafficDistributionShare,
+  decorateResult,
+  lookupCapacity,
+  resolveUiClient,
+} from "./vrmDecorators";
 
 describe("vrm capacity mapping", () => {
-  it("maps table client0 to ui client1 with capacity 10", () => {
+  it("maps table client0 to ui client1 with capacity 5", () => {
     expect(resolveUiClient("client0")).toBe("client1");
-    expect(lookupCapacity("client0")).toBe(10);
+    expect(lookupCapacity("client0")).toBe(5);
   });
 
-  it("maps table client1 to ui client2 with capacity 100", () => {
+  it("maps table client1 to ui client2 with capacity 750", () => {
     expect(resolveUiClient("client1")).toBe("client2");
-    expect(lookupCapacity("client1")).toBe(100);
+    expect(lookupCapacity("client1")).toBe(750);
   });
 
   it("throws for unknown clients", () => {
@@ -95,5 +101,81 @@ describe("traffic distribution decorator", () => {
     expect(primarySeries.data.map((point) => point.value ?? point.y)).toEqual([100]);
     expect(decorated.meta?.summary?.headlineValue).toBe(100);
     expect(decorated.meta?.summary?.chartSubType).toBe("traffic_distribution");
+  });
+
+  it("renders zero-value slices instead of empty state when totals are zero", () => {
+    const result: ChartResult = {
+      chartType: "composed_time",
+      xDimension: { id: "timestamp", type: "time" },
+      series: [
+        {
+          id: "cam-1",
+          label: "Events | camera_id=1",
+          geometry: "column",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: 0 },
+            { x: "2024-01-01T00:15:00Z", value: 0 },
+          ],
+        },
+      ],
+      meta: { timezone: "UTC" },
+    };
+
+    const decorated = applyTrafficDistributionShare(result, "client0");
+    const primarySeries = decorated.series[0];
+
+    expect(decorated.meta?.summary?.headlineValue).toBe(0);
+    expect(primarySeries.data).toHaveLength(1);
+    expect(primarySeries.data[0]).toEqual({ x: "Cam 0", value: 0, y: 0 });
+    expect(decorated.meta?.summary?.chartSubType).toBe("traffic_distribution");
+  });
+});
+
+describe("vrm dwell headline carry-forward", () => {
+  it("uses the latest non-null dwell value when the last bucket is null", () => {
+    const dwellResult: ChartResult = {
+      chartType: "single_value",
+      xDimension: { id: "timestamp", type: "time" },
+      series: [
+        {
+          id: "dwell",
+          label: "dwell",
+          geometry: "line",
+          unit: "minutes",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: 4 },
+            { x: "2024-01-01T00:15:00Z", value: null },
+          ],
+        },
+      ],
+      meta: { timezone: "UTC", summary: {} },
+    };
+
+    const decorated = decorateResult(VRM_KPI_IDS.dwell, dwellResult, "client1");
+    expect(decorated.meta?.summary?.headlineValue).toBe(4);
+  });
+
+  it("leaves the headline null when all buckets are null", () => {
+    const dwellResult: ChartResult = {
+      chartType: "single_value",
+      xDimension: { id: "timestamp", type: "time" },
+      series: [
+        {
+          id: "dwell",
+          label: "dwell",
+          geometry: "line",
+          unit: "minutes",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: null },
+            { x: "2024-01-01T00:15:00Z", value: null },
+          ],
+        },
+      ],
+      meta: { timezone: "UTC", summary: {} },
+    };
+
+    const decorated = decorateResult(VRM_KPI_IDS.dwell, dwellResult, "client1");
+    expect(decorated.meta?.summary?.headlineValue).toBeNull();
   });
 });

--- a/frontend/src/dashboard/v2/utils/vrmDecorators.ts
+++ b/frontend/src/dashboard/v2/utils/vrmDecorators.ts
@@ -2,8 +2,13 @@ import type { ChartResult, ChartSeries, DataPoint } from "../../../analytics/sch
 import { VRM_KPI_IDS } from "./applyVRMOverrides";
 
 const CAPACITY_BY_CLIENT: Record<string, number> = {
-  client1: 10,
-  client2: 100,
+  client1: 5,
+  client2: 750,
+};
+
+const CAMERAS_BY_CLIENT: Record<string, string[]> = {
+  client1: ["Cam 0"],
+  client2: ["Cam 1", "Cam 2"],
 };
 
 const TABLE_TO_UI_CLIENT: Record<string, string> = {
@@ -93,6 +98,20 @@ const applyLastBucketHeadline = (widgetId: string, result: ChartResult) => {
   const lastValue = lastBucketValue(series);
   setHeadlineValue(result, lastValue);
   logVrmDebug(widgetId, series, lastValue);
+};
+
+const lastNonNullValue = (series?: ChartSeries): number | null => {
+  if (!series) {
+    return null;
+  }
+  for (let index = series.data.length - 1; index >= 0; index -= 1) {
+    const point = series.data[index];
+    const value = point?.value ?? point?.y;
+    if (typeof value === "number") {
+      return value;
+    }
+  }
+  return null;
 };
 
 const addSummaryText = (result: ChartResult, key: string, value?: string) => {
@@ -342,6 +361,19 @@ export const applyTrafficDistributionShare = (result: ChartResult, orgId?: strin
       });
     }
 
+    const resolvedUiClient = resolveUiClient(orgId);
+    const configuredNames = resolvedUiClient ? CAMERAS_BY_CLIENT[resolvedUiClient] : undefined;
+    const discoveredNames = cameraShares.length
+      ? cameraShares.map((share) => share.camera)
+      : seriesList.map((series, index) => deriveCameraLabel(series, index)).filter(Boolean);
+    const fallbackNames = configuredNames?.length
+      ? configuredNames
+      : discoveredNames.length > 0
+        ? discoveredNames
+        : ["Camera 0"];
+
+    const shareData: DataPoint[] = fallbackNames.map((camera) => ({ x: camera, value: 0, y: 0 }));
+
     trafficDistributionResult.chartType = "categorical";
     trafficDistributionResult.xDimension = { id: "camera", type: "category" } as ChartResult["xDimension"];
     trafficDistributionResult.series = [
@@ -350,11 +382,11 @@ export const applyTrafficDistributionShare = (result: ChartResult, orgId?: strin
         label: "Traffic by Camera",
         geometry: "bar",
         unit: "percentage",
-        data: [],
+        data: shareData,
       },
     ];
-    setHeadlineValue(trafficDistributionResult, null);
-    addSummaryText(trafficDistributionResult, "headline", undefined);
+    setHeadlineValue(trafficDistributionResult, 0);
+    addSummaryText(trafficDistributionResult, "headline", `${fallbackNames[0] ?? "Camera"} – 0%`);
     addSummaryText(trafficDistributionResult, "chartSubType", "traffic_distribution");
     addSummaryText(trafficDistributionResult, "legendTitle", "Camera");
     addSummaryText(trafficDistributionResult, "chartStyle", "traffic_distribution");
@@ -368,7 +400,7 @@ export const applyTrafficDistributionShare = (result: ChartResult, orgId?: strin
         chartSubType: (trafficDistributionResult.meta?.summary as Record<string, unknown> | undefined)?.chartSubType,
         presentation: (trafficDistributionResult.meta?.summary as Record<string, unknown> | undefined)?.presentation,
         headlineValue: (trafficDistributionResult.meta?.summary as Record<string, unknown> | undefined)?.headlineValue,
-        dataLength: 0,
+        dataLength: shareData.length,
       });
     }
     return trafficDistributionResult;
@@ -540,6 +572,21 @@ const applyBasicVrmHeadline = (widgetId: string, result: ChartResult) => {
   return next;
 };
 
+const applyDwellHeadline = (result: ChartResult) => {
+  const next = applyBasicVrmHeadline(VRM_KPI_IDS.dwell, result);
+  const summary = next.meta?.summary;
+  const headline = summary?.headlineValue;
+  if (headline === null || typeof headline !== "number") {
+    const series = next.series?.[0];
+    const carried = lastNonNullValue(series);
+    if (typeof carried === "number") {
+      setHeadlineValue(next, carried);
+      logVrmDebug(VRM_KPI_IDS.dwell, series, carried);
+    }
+  }
+  return next;
+};
+
 export const decorateResult = (
   widgetId: string,
   result: ChartResult,
@@ -588,7 +635,10 @@ export const decorateResult = (
   if (widgetId === VRM_KPI_IDS.occupancy) {
     return applyOccupancyDelta(result);
   }
-  if (widgetId === VRM_KPI_IDS.entrances || widgetId === VRM_KPI_IDS.exits || widgetId === VRM_KPI_IDS.dwell) {
+  if (widgetId === VRM_KPI_IDS.dwell) {
+    return applyDwellHeadline(result);
+  }
+  if (widgetId === VRM_KPI_IDS.entrances || widgetId === VRM_KPI_IDS.exits) {
     return applyBasicVrmHeadline(widgetId, result);
   }
   return result;


### PR DESCRIPTION
## Summary
- update VRM capacity lookup so client1 uses 5 and client2 uses 750 and keep usage scoped to the VRM capacity widget
- carry forward the latest non-null VRM dwell value for the headline and emit zero-valued traffic slices instead of empty state when totals are zero
- expand VRM decorator tests to cover new capacity mapping, dwell headline carry-forward, and traffic zero-state rendering

## Testing
- pytest backend/tests/test_vrm_kpis.py
- pytest *(fails in backend/tests/test_golden_outputs.py due to missing derive_sessions import)*
- CI=true npm test -- --runInBand --watch=false src/dashboard/v2/utils/vrmDecorators.test.ts
- npm run lint
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692325723a348322873d1b1ed67544b9)