### PR TITLE
Fix VRM client resolution and polish capacity/traffic donuts

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/primitives/CapacityDonut.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/CapacityDonut.tsx
@@ -1,9 +1,8 @@
-import { ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from "recharts";
 
 import type { ChartPrimitiveProps } from "./types";
-import { formatNumeric } from "../utils/format";
 
-const capacityColors = ["#2d6cdf", "#f4b63d", "#2f3b52"];
+const capacityColors = ["#2d6cdf", "#f97066", "#2f3b52"];
 
 const extractNumeric = (value: unknown): number => {
   if (typeof value === "number") {
@@ -16,12 +15,6 @@ const extractNumeric = (value: unknown): number => {
   return 0;
 };
 
-const LABEL_COPY: Record<string, string> = {
-  Usage: "Current",
-  "Peak extra": "Peak +",
-  Remaining: "Remaining",
-};
-
 export const CapacityDonut = ({
   result,
   series,
@@ -32,7 +25,6 @@ export const CapacityDonut = ({
   const data = primary?.data ?? [];
   const summary = (result.meta?.summary as Record<string, unknown> | undefined) ?? {};
   const title = typeof summary.title === "string" ? (summary.title as string) : "Capacity Usage";
-  const chip = typeof summary.vrmChipText === "string" ? (summary.vrmChipText as string) : undefined;
   const headline = summary.headlineValue as number | null | undefined;
   const centerValue = typeof headline === "number" && Number.isFinite(headline) ? headline : 0;
 
@@ -44,13 +36,14 @@ export const CapacityDonut = ({
   });
 
   const total = mappedData.reduce((sum, entry) => sum + entry.value, 0);
-  const renderData = total > 0
-    ? mappedData
-    : [
-        { label: "Usage", value: 0, color: capacityColors[0] },
-        { label: "Peak extra", value: 0, color: capacityColors[1] },
-        { label: "Remaining", value: 100, color: capacityColors[2] },
-      ];
+  const renderData =
+    total > 0
+      ? mappedData
+      : [
+          { label: "Usage", value: 0, color: capacityColors[0] },
+          { label: "Peak extra", value: 0, color: capacityColors[1] },
+          { label: "Remaining", value: 100, color: capacityColors[2] },
+        ];
 
   const renderTotal = renderData.reduce((sum, entry) => sum + entry.value, 0) || 1;
   const normalizedData = renderData.map((entry) => ({
@@ -60,29 +53,15 @@ export const CapacityDonut = ({
 
   const centerDisplay = `${Math.round(centerValue)}%`;
 
-  const RADIAN = Math.PI / 180;
-  const renderArcLabel = (props: any) => {
-    const { cx = 0, cy = 0, midAngle = 0, outerRadius = 0, payload } = props ?? {};
-    const radius = outerRadius + 18;
-    const angle = -midAngle * RADIAN;
-    const x = cx + radius * Math.cos(angle);
-    const y = cy + radius * Math.sin(angle);
-    const label = payload?.label ?? "";
-    const labelPrefix = LABEL_COPY[label] ?? label;
-    const value = Math.max(0, Math.round(extractNumeric(payload?.value)));
-    const textAnchor = x >= cx ? "start" : "end";
-    return (
-      <text
-        x={x}
-        y={y}
-        fill="var(--vrm-color-text-primary, #ffffff)"
-        textAnchor={textAnchor}
-        dominantBaseline="central"
-        className="capacity-usage__arc-label"
-      >
-        {`${labelPrefix} ${value}%`}
-      </text>
-    );
+  const tooltipFormatter = (value: number, _name: string, props: any) => {
+    const label = (props?.payload as { label?: string })?.label ?? "";
+    const baseLabel = label === "Peak extra" ? "Peak add-on" : label === "Usage" ? "Current" : "Remaining";
+    const numericValue = Math.max(0, Math.round(extractNumeric(value)));
+    const valueLabel =
+      label === "Remaining"
+        ? `${numericValue}% (capacity not reached)`
+        : `${numericValue}%`;
+    return [valueLabel, baseLabel];
   };
 
   return (
@@ -91,6 +70,7 @@ export const CapacityDonut = ({
       <div className="capacity-usage__content">
         <ResponsiveContainer width="100%" height={140}>
           <PieChart>
+            <Tooltip formatter={tooltipFormatter} labelFormatter={() => ""} />
             <Pie
               dataKey="value"
               data={normalizedData}
@@ -102,8 +82,6 @@ export const CapacityDonut = ({
               startAngle={90}
               endAngle={-270}
               stroke="none"
-              label={renderArcLabel}
-              labelLine={{ stroke: "var(--vrm-color-text-muted, #8290a6)", strokeWidth: 1 }}
             >
               {normalizedData.map((entry) => (
                 <Cell key={entry.label} fill={entry.color} stroke="none" />
@@ -118,12 +96,8 @@ export const CapacityDonut = ({
             >
               {centerDisplay}
             </text>
-            <text x="50%" y="95%" textAnchor="middle" dominantBaseline="middle" className="capacity-usage__subtitle">
-              Peak {formatNumeric(Math.round((summary.peak_capacity_usage_today as number) ?? 0))}%
-            </text>
           </PieChart>
         </ResponsiveContainer>
-        {chip ? <div className="capacity-usage__chip">{chip}</div> : null}
       </div>
     </div>
   );

--- a/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
@@ -166,24 +166,17 @@ export const TrafficDistribution = ({
               data={pieLegend}
               cx="50%"
               cy="50%"
-              innerRadius={40}
-              outerRadius={60}
-              paddingAngle={2}
-              label={
-                isVrmTraffic
-                  ? ({ payload, value }) => {
-                      const camId = (payload as { camId?: string })?.camId ?? (payload as { label?: string })?.label;
-                      const shareCandidate = (payload as { displayValue?: number })?.displayValue ?? value;
-                      const share = typeof shareCandidate === "number" ? Math.round(shareCandidate) : 0;
-                      const cameraLabel = camId ? `Cam ${camId.replace(/^Cam\s*/i, "").trim()}` : "Cam";
-                      return `${cameraLabel} ${share}%`;
-                    }
-                  : undefined
-              }
-              labelLine={isVrmTraffic ? false : undefined}
+              innerRadius={48}
+              outerRadius={68}
+              paddingAngle={0}
+              startAngle={90}
+              endAngle={-270}
+              label={undefined}
+              labelLine={false}
+              stroke="none"
             >
               {pieLegend.map((entry) => (
-                <Cell key={entry.label} fill={entry.color} />
+                <Cell key={entry.label} fill={entry.color} stroke="none" />
               ))}
               <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle" className="traffic-distribution__center">
                 {`${Math.round(centerValue)}%`}

--- a/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/CapacityDonut.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/CapacityDonut.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/await-async-query */
 import React from "react";
 import renderer from "react-test-renderer";
-import { Pie, Cell } from "recharts";
+import { Pie, Cell, Tooltip } from "recharts";
 
 import type { ChartResult } from "../../../../schemas/charting";
 import { CapacityDonut } from "../CapacityDonut";
@@ -10,11 +10,13 @@ jest.mock("recharts", () => {
   const MockPie = (props: any) => <pie-mock {...props}>{props.children}</pie-mock>;
   const MockPieChart = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
   const MockCell = (props: any) => <cell-mock {...props} />;
+  const MockTooltip = (props: any) => <tooltip-mock {...props} />;
   return {
     ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     PieChart: MockPieChart,
     Pie: MockPie,
     Cell: MockCell,
+    Tooltip: MockTooltip,
   } as typeof import("recharts");
 });
 
@@ -46,7 +48,7 @@ describe("CapacityDonut", () => {
     },
   };
 
-  it("renders seamless donut starting north with ordered slices", () => {
+  it("renders an anti-clockwise seamless donut with VRM slices and tooltips", () => {
     const tree = renderer.create(
       <CapacityDonut result={baseResult} series={baseResult.series} height={200} className="" />,
     );
@@ -57,16 +59,30 @@ describe("CapacityDonut", () => {
     expect(pie.props.paddingAngle).toBe(0);
     expect(pie.props.stroke).toBe("none");
 
-    const pieData = pie.props.data as Array<{ label: string; value: number }>;
+    const pieData = pie.props.data as Array<{ label: string; value: number; color: string }>;
     expect(pieData.map((entry) => entry.label)).toEqual(["Usage", "Peak extra", "Remaining"]);
     expect(Math.round(pieData.reduce((sum, entry) => sum + entry.value, 0))).toBe(100);
+    expect(pieData.map((entry) => entry.color)).toEqual(["#2d6cdf", "#f97066", "#2f3b52"]);
 
     const cells = tree.root.findAllByType(Cell);
     expect(cells.length).toBe(3);
     cells.forEach((cell) => expect(cell.props.stroke).toBe("none"));
 
+    const tooltip = tree.root.findByType(Tooltip);
+    expect(tooltip.props.formatter(40, "value", { payload: { label: "Usage" } })).toEqual([
+      "40%",
+      "Current",
+    ]);
+    expect(
+      tooltip.props.formatter(10, "value", { payload: { label: "Peak extra" } }),
+    ).toEqual(["10%", "Peak add-on"]);
+    expect(
+      tooltip.props.formatter(50, "value", { payload: { label: "Remaining" } }),
+    ).toEqual(["50% (capacity not reached)", "Remaining"]);
+
     const json = JSON.stringify(tree.toJSON());
     expect(json).toContain("capacity-usage__center");
     expect(json).toContain("40%");
+    expect(json).not.toContain("capacity-usage__subtitle");
   });
 });

--- a/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/TrafficDistribution.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/TrafficDistribution.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/await-async-query */
 import React from "react";
 import renderer from "react-test-renderer";
-import { Tooltip } from "recharts";
+import { Pie, Tooltip } from "recharts";
 
 import type { ChartResult } from "../../../../schemas/charting";
 import { TrafficDistribution } from "../TrafficDistribution";
@@ -44,5 +44,10 @@ describe("TrafficDistribution", () => {
     const tooltip = tree.root.findByType(Tooltip);
     const formatted = tooltip.props.formatter(1, "traffic_share", { payload: { displayValue: 0 } });
     expect(formatted).toBe("0%");
+
+    const pie = tree.root.findByType(Pie);
+    expect(pie.props.startAngle).toBe(90);
+    expect(pie.props.endAngle).toBe(-270);
+    expect(pie.props.paddingAngle).toBe(0);
   });
 });

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.test.tsx
@@ -103,6 +103,31 @@ const buildSeriesPoints = (values: number[]) => {
   }));
 };
 
+const buildVrmManifest = (orgId: string): DashboardManifest => ({
+  id: "dashboard-default",
+  orgId,
+  widgets: [
+    {
+      id: VRM_KPI_IDS.capacity,
+      title: "Capacity Usage",
+      kind: "kpi",
+      chartSpecId: "vrm.capacity_usage",
+      fixtureId: "vrm.capacity_usage",
+      locked: true,
+    },
+    {
+      id: VRM_KPI_IDS.traffic,
+      title: "Traffic by Camera",
+      kind: "kpi",
+      chartSpecId: "vrm.traffic_distribution",
+      fixtureId: "vrm.traffic_distribution",
+      locked: true,
+    },
+  ],
+  layout: { kpiBand: [VRM_KPI_IDS.capacity, VRM_KPI_IDS.traffic], grid: { columns: 12, placements: {} } },
+  timeControls: cloneManifest().timeControls,
+});
+
 const buildChartResult = (
   values: number[],
   options?: {
@@ -155,6 +180,19 @@ afterEach(() => {
   renderedResults.length = 0;
 });
 
+const renderText = (node: any): string => {
+  if (typeof node === "string" || typeof node === "number") {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(renderText).join(" ");
+  }
+  if (node?.props?.children) {
+    return renderText(node.props.children);
+  }
+  return "";
+};
+
 async function flushEffects(times = 3) {
   for (let i = 0; i < times; i += 1) {
     // eslint-disable-next-line no-await-in-loop
@@ -166,9 +204,9 @@ async function flushEffects(times = 3) {
 
 describe("lookupCapacity", () => {
   it("returns configured capacity for known clients", () => {
-    expect(lookupCapacity("client0")).toBe(10);
-    expect(lookupCapacity("client1")).toBe(100);
-    expect(lookupCapacity("client2")).toBe(100);
+    expect(lookupCapacity("client0")).toBe(5);
+    expect(lookupCapacity("client1")).toBe(5);
+    expect(lookupCapacity("client2")).toBe(750);
   });
 
   it("throws for unknown clients", () => {
@@ -510,6 +548,65 @@ describe("DashboardV2Page", () => {
     expect(headlines.length).toBeGreaterThan(0);
   });
 
+  it("uses manifest org to resolve VRM capacity per client without leakage", async () => {
+    const loadOrgView = async (orgId: string, occupancy: number) => {
+      const manifestLoader = jest.fn(async () => buildVrmManifest(orgId));
+      const widgetLoader = jest.fn(async (widget: DashboardWidget) => {
+        if (widget.id === VRM_KPI_IDS.capacity) {
+          return buildChartResult([occupancy], {
+            meta: { timezone: "UTC", summary: { widgetId: widget.id } },
+          });
+        }
+        if (widget.id === VRM_KPI_IDS.traffic) {
+          return trafficDistributionResult;
+        }
+        return buildChartResult([1], { meta: { timezone: "UTC", summary: { widgetId: widget.id } } });
+      });
+
+      let tree: TestRenderer;
+      await act(async () => {
+        tree = renderer.create(
+          <DashboardV2Page
+            credentials={{ username: "client1", password: "secret" }}
+            manifestLoader={manifestLoader}
+            widgetResultLoader={widgetLoader}
+          />,
+        );
+      });
+      await flushEffects();
+
+      const capacityResult = renderedResults.find(
+        (result) =>
+          (result.meta?.summary as Record<string, unknown> | undefined)?.chartSubType === "capacity_usage",
+      );
+      const headerText = renderText(
+        tree!.root.findByProps({ className: "dashboard-v2__header" }).props.children,
+      ).toLowerCase();
+
+      return { capacityResult, headerText };
+    };
+
+    const client2View = await loadOrgView("demodata0.client1", 375);
+    expect(
+      (client2View.capacityResult?.meta?.summary as Record<string, unknown> | undefined)?.vrmCapacity,
+    ).toBe(750);
+    expect(
+      (client2View.capacityResult?.meta?.summary as Record<string, unknown> | undefined)?.vrmResolvedClient,
+    ).toBe("client2");
+    expect(client2View.headerText).toContain("client2");
+
+    renderedResults.length = 0;
+
+    const client1View = await loadOrgView("client1", 4);
+    expect(
+      (client1View.capacityResult?.meta?.summary as Record<string, unknown> | undefined)?.vrmCapacity,
+    ).toBe(5);
+    expect(
+      (client1View.capacityResult?.meta?.summary as Record<string, unknown> | undefined)?.vrmResolvedClient,
+    ).toBe("client1");
+    expect(client1View.headerText).toContain("client1");
+  });
+
   it("renders empty states when manifest has no widgets", async () => {
     const manifestLoader = jest.fn(async () =>
       cloneManifest({
@@ -566,10 +663,13 @@ describe("DashboardV2Page", () => {
     const capacityResult = renderedResults.find(
       (result) => (result.meta?.summary as Record<string, string> | undefined)?.widgetId === VRM_KPI_IDS.capacity,
     );
-    expect(lastBucketValue(capacityResult?.series?.[0])).toBeCloseTo(60);
+    expect((capacityResult?.meta?.summary as Record<string, unknown> | undefined)?.vrmCapacity).toBe(750);
+    expect((capacityResult?.meta?.summary as Record<string, number> | undefined)?.headlineValue).toBeCloseTo(
+      (60 / 750) * 100,
+    );
   });
 
-  it("prefers credential org over manifest org when decorating VRM results", async () => {
+  it("prefers manifest org over credential org when decorating VRM results", async () => {
     renderedResults.length = 0;
     const manifestLoader = jest.fn(async () => cloneManifest({ orgId: "client1" }));
     const widgetLoader = jest.fn(async (widget: DashboardWidget) => {
@@ -596,12 +696,13 @@ describe("DashboardV2Page", () => {
     await flushEffects();
 
     const title = tree!.root.findByProps({ className: "dashboard-v2__title" });
-    expect(title.children.join(" ")).toContain("client2 – client2");
+    expect(title.children.join(" ")).toContain("client1 – client1");
 
     const capacityResult = renderedResults.find(
       (result) => (result.meta?.summary as Record<string, string> | undefined)?.widgetId === VRM_KPI_IDS.capacity,
     );
-    expect(capacityResult?.meta?.summary?.headlineValue).toBe(100);
+    expect((capacityResult?.meta?.summary as Record<string, number> | undefined)?.vrmCapacity).toBe(5);
+    expect((capacityResult?.meta?.summary as Record<string, number> | undefined)?.headlineValue).toBeCloseTo(2000);
   });
 
   it("derives VRM KPI headlines from the latest bucket values instead of 24h totals", () => {
@@ -636,8 +737,9 @@ describe("DashboardV2Page", () => {
     expect(lastBucketValue(occupancy.series[0])).toBe(60);
     expect(lastBucketValue(occupancy.series[0])).not.toBe(105);
 
-    expect(lastBucketValue(capacity.series[0])).toBe(90);
-    expect(lastBucketValue(capacity.series[0])).not.toBe(160);
+    expect((capacity.meta?.summary as Record<string, number> | undefined)?.headlineValue).toBeCloseTo(
+      (90 / 5) * 100,
+    );
   });
 
   it("uses the latest 15-minute bucket for VRM KPI headlines", async () => {
@@ -697,7 +799,9 @@ describe("DashboardV2Page", () => {
     expect(getLastValue(resultsByWidgetId[VRM_KPI_IDS.footfall])).toBe(9);
     expect(getLastValue(resultsByWidgetId[VRM_KPI_IDS.dwell])).toBeCloseTo(3.5);
     expect(getLastValue(resultsByWidgetId[VRM_KPI_IDS.occupancy])).toBe(60);
-    expect(getLastValue(resultsByWidgetId[VRM_KPI_IDS.capacity])).toBe(90);
+    expect(
+      (resultsByWidgetId[VRM_KPI_IDS.capacity]?.meta?.summary as Record<string, number> | undefined)?.headlineValue,
+    ).toBeCloseTo((90 / 5) * 100);
   });
 });
 

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -222,7 +222,7 @@ const DashboardV2Page = ({
   }, []);
 
   const resolvedUiClient = useMemo(() => {
-    const candidates = [credentials.orgId, credentials.username, manifest?.orgId, orgId];
+    const candidates = [manifest?.orgId, orgId, credentials.orgId, credentials.username];
     for (const candidate of candidates) {
       const resolved = resolveUiClient(candidate);
       if (resolved) {
@@ -557,8 +557,8 @@ const DashboardV2Page = ({
     () => localTime.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
     [localTime],
   );
-  const siteOrgId = orgId ?? manifest?.orgId;
-  const siteUiOrgId = resolveUiClient(siteOrgId) ?? siteOrgId;
+  const siteOrgId = manifest?.orgId ?? orgId;
+  const siteUiOrgId = resolvedUiClient ?? resolveUiClient(siteOrgId) ?? siteOrgId;
   const siteLabel = siteUiOrgId ?? "Site";
   const siteId = siteUiOrgId ?? "—";
   const isVrmDashboard = useMemo(() => {


### PR DESCRIPTION
## Summary
- prioritize manifest/view org IDs when resolving VRM client context so headers and capacity lookup use the right tenant
- update VRM capacity donut to render anti-clockwise with red peak slice, streamlined annotations, and clearer tooltips
- align VRM traffic donut styling with the capacity ring and add coverage for per-client capacity isolation, donut ordering, and tooltips

## Testing
- pytest backend/tests/test_vrm_kpis.py
- CI=true npm test -- --runInBand --watch=false src/dashboard/v2/pages/DashboardV2Page.test.tsx src/analytics/components/ChartRenderer/primitives/__tests__/CapacityDonut.test.tsx src/analytics/components/ChartRenderer/primitives/__tests__/TrafficDistribution.test.tsx
- npm run lint
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692357ad4f488325ba2e9a029b2224a3)