### PR TITLE
Fix VRM sparkline tooltip overlay handling

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/__tests__/ChartRendererStates.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/__tests__/ChartRendererStates.test.tsx
@@ -136,7 +136,7 @@ describe('ChartRenderer high-level states', () => {
     const tree = renderer.create(<ChartRenderer result={trafficResult} height={200} />);
     const json = JSON.stringify(tree.toJSON());
     expect(json).toContain('traffic-distribution kpi-tile');
-    expect(json).toContain('Traffic by Camera');
+    expect(json).toContain('Traffic Split');
     expect(json).not.toContain('Nothing to display yet');
   });
 

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable testing-library/await-async-query */
 import React from "react";
 import { jest } from "@jest/globals";
-import renderer from "react-test-renderer";
+import renderer, { act } from "react-test-renderer";
 import { KpiTile } from "./KpiTile";
 import type { ChartPrimitiveProps } from "./types";
 import type { ChartResult, ChartSeries } from "../../../schemas/charting";
@@ -10,6 +10,7 @@ jest.mock("recharts", () => ({
   ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   AreaChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Area: () => <div>area</div>,
+  YAxis: () => <div>y-axis</div>,
   Tooltip: () => null,
 }));
 
@@ -211,5 +212,62 @@ describe("KpiTile", () => {
       .replace(/\s+/g, "");
     expect(labelText).toBe("Cam 0");
     expect(valueText).toBe("67%");
+  });
+
+  it("shows VRM popover from overlay hover without Recharts tooltip metadata", () => {
+    const props = buildProps();
+    props.result.meta = { timezone: "UTC", summary: { presentation: "vrm" } as any } as ChartResult["meta"];
+
+    const tree = renderer.create(<KpiTile {...props} />);
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
+
+    act(() => {
+      overlay.props.onMouseMove({
+        clientX: 0,
+        currentTarget: { getBoundingClientRect: () => ({ left: 0, width: 200 }) },
+      });
+    });
+
+    const popover = tree.root.findByProps({ className: "kpi-sparkline__popover" });
+    const valueNode = popover.findByProps({ className: "kpi-sparkline__popover-value" });
+    const timeNode = popover.findByProps({ className: "kpi-sparkline__popover-time" });
+
+    expect(valueNode.children.join(" ")).toBe("10");
+    expect(timeNode.children.join(" ")).not.toBe("");
+  });
+
+  it("derives VRM hover index from overlay position", () => {
+    const props = buildProps({
+      series: [
+        {
+          id: "primary",
+          label: "Primary",
+          geometry: "metric",
+          unit: "events",
+          data: [
+            { x: "2024-01-01T00:00:00Z", value: 1 },
+            { x: "2024-01-01T00:15:00Z", value: 5 },
+            { x: "2024-01-01T00:30:00Z", value: 10 },
+            { x: "2024-01-01T00:45:00Z", value: 20 },
+          ],
+        },
+      ],
+    });
+    props.result.meta = { timezone: "UTC", summary: { presentation: "vrm" } as any } as ChartResult["meta"];
+
+    const tree = renderer.create(<KpiTile {...props} />);
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
+
+    act(() => {
+      overlay.props.onMouseMove({
+        clientX: 200,
+        currentTarget: { getBoundingClientRect: () => ({ left: 0, width: 200 }) },
+      });
+    });
+
+    const popover = tree.root.findByProps({ className: "kpi-sparkline__popover" });
+    const valueNode = popover.findByProps({ className: "kpi-sparkline__popover-value" });
+
+    expect(valueNode.children.join(" ")).toBe("20");
   });
 });

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -51,8 +51,11 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
     );
   }, [primarySeries]);
 
-  const [vrmHover, setVrmHover] = useState<{ value: number | null; label: string } | null>(null);
-  const lastTooltipIndex = useRef<number | null>(null);
+  const [vrmHover, setVrmHover] = useState<{
+    value: number | null;
+    label: string;
+    index: number;
+  } | null>(null);
   const sparklineRef = useRef<HTMLDivElement | null>(null);
 
   if (!primarySeries) {
@@ -147,71 +150,11 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
     if (!isVrm || !sparklineData.length) return;
 
     const clampedIndex = Math.max(0, Math.min(sparklineData.length - 1, index));
-    lastTooltipIndex.current = clampedIndex;
     const chosen = sparklineData[clampedIndex];
     if (!chosen) return;
 
     const numeric = typeof chosen.value === "number" ? chosen.value : null;
-    setVrmHover({ value: numeric, label: formatPopoverLabel(chosen.x) });
-  };
-
-  const handleSparklineHover = (state: any) => {
-    if (!isVrm) {
-      return;
-    }
-
-    const payload = state?.activePayload?.[0]?.payload as { value?: number | null; x?: string | number } | undefined;
-    const normalizeLabel = (label: unknown) => {
-      if (label === null || label === undefined) return null;
-      const parsed = parseLabelDate(label as string | number);
-      return parsed ? parsed.valueOf() : String(label);
-    };
-
-    const deriveIndexFromPosition = () => {
-      const width =
-        typeof state?.chartWidth === "number"
-          ? state.chartWidth
-          : sparklineRef.current?.getBoundingClientRect().width ?? 0;
-      const xCoord = typeof state?.chartX === "number" ? state.chartX : null;
-
-      if (!width || width <= 0 || xCoord === null || typeof xCoord !== "number") {
-        return -1;
-      }
-
-      const clampedRatio = Math.max(0, Math.min(1, xCoord / width));
-      return Math.round(clampedRatio * Math.max(0, sparklineData.length - 1));
-    };
-
-    const tooltipIndex = (() => {
-      if (typeof state?.activeTooltipIndex === "number") {
-        return state.activeTooltipIndex;
-      }
-      if (state?.activeLabel !== undefined) {
-        const target = normalizeLabel(state.activeLabel);
-        if (target === null) return -1;
-        return sparklineData.findIndex((point) => {
-          const pointLabel = normalizeLabel(point.x);
-          return pointLabel === target;
-        });
-      }
-
-      return deriveIndexFromPosition();
-    })();
-
-    if (tooltipIndex >= 0) {
-      applyHoverIndex(tooltipIndex);
-      return;
-    }
-
-    if (lastTooltipIndex.current !== null) {
-      applyHoverIndex(lastTooltipIndex.current);
-      return;
-    }
-
-    if (payload) {
-      const numeric = typeof payload.value === "number" ? payload.value : null;
-      setVrmHover({ value: numeric, label: formatPopoverLabel(payload.x) });
-    }
+    setVrmHover({ value: numeric, label: formatPopoverLabel(chosen.x), index: clampedIndex });
   };
 
   const handleOverlayHover = (event: React.MouseEvent<HTMLDivElement>) => {
@@ -221,8 +164,8 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
       event.currentTarget?.getBoundingClientRect?.();
     if (!rect || rect.width <= 0) return;
 
-    const ratio = (event.clientX - rect.left) / rect.width;
-    const index = Math.round(Math.max(0, Math.min(1, ratio)) * Math.max(0, sparklineData.length - 1));
+    const ratio = Math.max(0, Math.min(1, (event.clientX - rect.left) / rect.width));
+    const index = Math.round(ratio * Math.max(0, sparklineData.length - 1));
     applyHoverIndex(index);
   };
 
@@ -327,8 +270,7 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
             <AreaChart
               data={sparklineData}
               margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
-              onMouseMove={isVrm ? handleSparklineHover : undefined}
-              onMouseLeave={isVrm ? handleSparklineLeave : undefined}
+              onMouseLeave={isVrm ? undefined : handleSparklineLeave}
             >
               <YAxis type="number" domain={[0, (dataMax: number | undefined) => dataMax ?? 0]} hide />
               {!isVrm ? (

--- a/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.test.tsx
@@ -62,7 +62,7 @@ describe("KpiTile VRM sparkline", () => {
     expect(responsive.props.height).toBe(64);
 
     const areaChart = tree.root.findByType("area-chart-mock");
-    expect(typeof areaChart.props.onMouseMove).toBe("function");
+    expect(areaChart.props.onMouseMove).toBeUndefined();
 
     const yAxis = tree.root.findByType("y-axis-mock");
     expect(Array.isArray(yAxis.props.domain)).toBe(true);
@@ -75,10 +75,12 @@ describe("KpiTile VRM sparkline", () => {
     const tooltips = tree.root.findAllByType("tooltip-mock");
     expect(tooltips).toHaveLength(1);
     expect(tooltips[0].props.wrapperStyle).toEqual({ visibility: "hidden", pointerEvents: "none" });
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
 
     act(() => {
-      areaChart.props.onMouseMove({
-        activePayload: [{ payload: { x: "2024-01-01T00:30:00Z", value: 2 } }],
+      overlay.props.onMouseMove({
+        clientX: 300,
+        currentTarget: { getBoundingClientRect: () => ({ width: 300, left: 0 }) },
       });
     });
 
@@ -87,85 +89,24 @@ describe("KpiTile VRM sparkline", () => {
     expect(JSON.stringify(json)).toContain("2");
   });
 
-  it("falls back to activeLabel when payload is missing", () => {
+  it("computes hover from overlay midpoint", () => {
     const built = buildResult("vrm");
     if (!built) throw new Error("missing data");
     const tree = renderer.create(
       <KpiTile result={built.result} series={built.series} height={200} className="" />,
     );
 
-    const areaChart = tree.root.findByType("area-chart-mock");
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
     act(() => {
-      areaChart.props.onMouseMove({
-        activeLabel: "2024-01-01T00:15:00Z",
-        activePayload: [],
+      overlay.props.onMouseMove({
+        clientX: 150,
+        currentTarget: { getBoundingClientRect: () => ({ width: 300, left: 0 }) },
       });
     });
 
     const json = tree.toJSON();
     expect(JSON.stringify(json)).toContain("VRM sparkline popover");
     expect(JSON.stringify(json)).toContain("3");
-  });
-
-  it("keeps hover when payload is missing but last index exists", () => {
-    const built = buildResult("vrm");
-    if (!built) throw new Error("missing data");
-    const tree = renderer.create(
-      <KpiTile result={built.result} series={built.series} height={200} className="" />,
-    );
-
-    const areaChart = tree.root.findByType("area-chart-mock");
-    act(() => {
-      areaChart.props.onMouseMove({
-        activeLabel: "2024-01-01T00:15:00Z",
-        activePayload: [],
-        activeTooltipIndex: 1,
-      });
-    });
-
-    act(() => {
-      areaChart.props.onMouseMove({
-        activePayload: [],
-      });
-    });
-
-    const json = tree.toJSON();
-    expect(JSON.stringify(json)).toContain("VRM sparkline popover");
-    expect(JSON.stringify(json)).toContain("3");
-  });
-
-  it("derives index from chartX when no payload or label is provided", () => {
-    const built = buildResult("vrm");
-    if (!built) throw new Error("missing data");
-    const tree = renderer.create(
-      <KpiTile result={built.result} series={built.series} height={200} className="" />,
-    );
-
-    const areaChart = tree.root.findByType("area-chart-mock");
-
-    act(() => {
-      areaChart.props.onMouseMove({
-        activePayload: [],
-        chartWidth: 300,
-        chartX: 150,
-      });
-    });
-
-    const jsonMid = tree.toJSON();
-    expect(JSON.stringify(jsonMid)).toContain("VRM sparkline popover");
-    expect(JSON.stringify(jsonMid)).toContain("3");
-
-    act(() => {
-      areaChart.props.onMouseMove({
-        activePayload: [],
-        chartWidth: 300,
-        chartX: 295,
-      });
-    });
-
-    const jsonEnd = tree.toJSON();
-    expect(JSON.stringify(jsonEnd)).toContain("VRM sparkline popover");
-    expect(JSON.stringify(jsonEnd)).toContain("2");
   });
 
   it("uses overlay hover when tooltip metadata is absent", () => {
@@ -175,7 +116,7 @@ describe("KpiTile VRM sparkline", () => {
       <KpiTile result={built.result} series={built.series} height={200} className="" />,
     );
 
-    const overlay = tree.root.find((node) => node.props["data-testid"] === "vrm-sparkline-overlay");
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
 
     act(() => {
       overlay.props.onMouseMove({
@@ -191,24 +132,24 @@ describe("KpiTile VRM sparkline", () => {
     expect(JSON.stringify(json)).toContain("3");
   });
 
-  it("matches numeric activeLabel timestamps to sparkline points", () => {
+  it("clamps overlay hover to the first bucket", () => {
     const built = buildResult("vrm");
     if (!built) throw new Error("missing data");
     const tree = renderer.create(
       <KpiTile result={built.result} series={built.series} height={200} className="" />,
     );
 
-    const areaChart = tree.root.findByType("area-chart-mock");
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
     act(() => {
-      areaChart.props.onMouseMove({
-        activeLabel: new Date("2024-01-01T00:15:00Z").valueOf(),
-        activePayload: [],
+      overlay.props.onMouseMove({
+        clientX: -50,
+        currentTarget: { getBoundingClientRect: () => ({ width: 300, left: 0 }) },
       });
     });
 
     const json = tree.toJSON();
     expect(JSON.stringify(json)).toContain("VRM sparkline popover");
-    expect(JSON.stringify(json)).toContain("3");
+    expect(JSON.stringify(json)).toContain("1");
   });
 
   it("keeps default tooltip for non-VRM charts", () => {

--- a/frontend/src/analytics/components/ChartRenderer/styles.css
+++ b/frontend/src/analytics/components/ChartRenderer/styles.css
@@ -311,8 +311,8 @@
 .kpi-sparkline__popover {
   position: absolute;
   left: 50%;
-  bottom: 0;
-  transform: translate(-50%, -6px);
+  bottom: -6px;
+  transform: translate(-50%, 100%);
   background: rgba(15, 19, 26, 0.9);
   color: #ffffff;
   padding: 8px 12px;
@@ -329,6 +329,7 @@
   position: absolute;
   inset: 0;
   z-index: 1;
+  pointer-events: auto;
 }
 
 .kpi-sparkline__popover-time {


### PR DESCRIPTION
## Summary
- derive VRM sparkline hover state from the overlay position instead of suppressed Recharts tooltip metadata
- update anchored popover/overlay styling for VRM sparklines and keep non-VRM tooltips unchanged
- refresh tests for overlay-driven hover behavior and VRM traffic label expectations

## Testing
- npm --prefix frontend run lint
- CI=true npm --prefix frontend test -- --watch=false
- npm --prefix frontend run build
- pytest *(fails: ImportError in backend/tests/test_golden_outputs.py: cannot import name 'derive_sessions' from backend.app.analytics.fixtures)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924757665888322a50807e7790d6f8f)