### PR TITLE
Adjust VRM KPI sparkline tooltip anchoring and hover dot

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
@@ -11,7 +11,9 @@ jest.mock("recharts", () => ({
   AreaChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   Area: () => <div>area</div>,
   YAxis: () => <div>y-axis</div>,
+  XAxis: () => <div>x-axis</div>,
   Tooltip: () => null,
+  ReferenceDot: (props: any) => <div {...props}>reference-dot</div>,
 }));
 
 const buildProps = (overrides?: Partial<ChartPrimitiveProps>): ChartPrimitiveProps => {
@@ -228,7 +230,9 @@ describe("KpiTile", () => {
       });
     });
 
-    const popover = tree.root.findByProps({ className: "kpi-sparkline__popover" });
+    const popover = tree.root.find(
+      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline__popover"),
+    );
     const valueNode = popover.findByProps({ className: "kpi-sparkline__popover-value" });
     const timeNode = popover.findByProps({ className: "kpi-sparkline__popover-time" });
 
@@ -265,7 +269,9 @@ describe("KpiTile", () => {
       });
     });
 
-    const popover = tree.root.findByProps({ className: "kpi-sparkline__popover" });
+    const popover = tree.root.find(
+      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline__popover"),
+    );
     const valueNode = popover.findByProps({ className: "kpi-sparkline__popover-value" });
 
     expect(valueNode.children.join(" ")).toBe("20");

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -268,61 +268,58 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
         </div>
       ) : null}
       {!isTraffic && sparklineData.length > 1 ? (
-        <div
-          className={`kpi-sparkline${isVrm ? " kpi-sparkline--vrm" : ""}`}
-          ref={sparklineRef}
-        >
-          <ResponsiveContainer width="100%" height={sparklineHeight}>
-            <AreaChart
-              data={sparklineData}
-              margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
-              onMouseLeave={isVrm ? undefined : handleSparklineLeave}
-            >
-              <ResponsiveContainer width="100%" height={sparklineHeight}>
-                <AreaChart
-                  data={sparklineData}
-                  margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
-                  onMouseLeave={isVrm ? undefined : handleSparklineLeave}
-                >
-                  <XAxis dataKey="index" type="number" hide domain={["dataMin", "dataMax"]} />
-                  <YAxis type="number" domain={[0, (dataMax: number | undefined) => dataMax ?? 0]} hide />
-                  {!isVrm ? (
-                    <Tooltip
-                      formatter={(tooltipValue) => [
-                        formatValue(tooltipValue as number, primarySeries.unit),
-                        primarySeries.label ?? primarySeries.id ?? "",
-                      ]}
-                      labelFormatter={(label, payload) => formatLabel(label as string | number, payload)}
-                    />
-                  ) : (
-                    <Tooltip
-                      cursor={false}
-                      isAnimationActive={false}
-                      wrapperStyle={{ visibility: "hidden", pointerEvents: "none" }}
-                      content={() => null}
-                    />
-                  )}
-                  <Area
-                    type="monotone"
-                    dataKey="value"
-                    stroke={primarySeries?.color ?? "#2d6cdf"}
-                    fill={primarySeries?.color ?? "#2d6cdf"}
-                    fillOpacity={0.2}
-                    isAnimationActive={false}
+        <div className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}>
+          <div
+            className={`kpi-sparkline${isVrm ? " kpi-sparkline--vrm" : ""}`}
+            ref={sparklineRef}
+          >
+            <ResponsiveContainer width="100%" height={sparklineHeight}>
+              <AreaChart
+                data={sparklineData}
+                margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+                onMouseLeave={isVrm ? undefined : handleSparklineLeave}
+              >
+                <XAxis dataKey="index" type="number" hide domain={["dataMin", "dataMax"]} />
+                <YAxis type="number" domain={[0, (dataMax: number | undefined) => dataMax ?? 0]} hide />
+                {!isVrm ? (
+                  <Tooltip
+                    formatter={(tooltipValue) => [
+                      formatValue(tooltipValue as number, primarySeries.unit),
+                      primarySeries.label ?? primarySeries.id ?? "",
+                    ]}
+                    labelFormatter={(label, payload) => formatLabel(label as string | number, payload)}
                   />
-                  {isVrm && vrmHover && hoveredNumericValue !== null ? (
-                    <ReferenceDot
-                      x={vrmHover.index}
-                      y={hoveredNumericValue}
-                      r={5}
-                      fill="#ffffff"
-                      stroke={primarySeries?.color ?? "#2d6cdf"}
-                      strokeWidth={2}
-                    />
-                  ) : null}
-                </AreaChart>
-              </ResponsiveContainer>
-              {isVrm ? (
+                ) : (
+                  <Tooltip
+                    cursor={false}
+                    isAnimationActive={false}
+                    wrapperStyle={{ visibility: "hidden", pointerEvents: "none" }}
+                    content={() => null}
+                  />
+                )}
+                <Area
+                  type="monotone"
+                  dataKey="value"
+                  stroke={primarySeries?.color ?? "#2d6cdf"}
+                  fill={primarySeries?.color ?? "#2d6cdf"}
+                  fillOpacity={0.2}
+                  isAnimationActive={false}
+                />
+                {isVrm && vrmHover && hoveredNumericValue !== null ? (
+                  <ReferenceDot
+                    x={sparklineData[vrmHover.index]?.index ?? vrmHover.index}
+                    y={hoveredNumericValue}
+                    r={5}
+                    fill="#ffffff"
+                    stroke={primarySeries?.color ?? "#2d6cdf"}
+                    strokeWidth={2}
+                    strokeOpacity={0.9}
+                  />
+                ) : null}
+              </AreaChart>
+            </ResponsiveContainer>
+            {isVrm ? (
+              <>
                 <div
                   className="kpi-sparkline__overlay"
                   data-testid="vrm-sparkline-overlay"
@@ -330,51 +327,19 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                   onMouseEnter={handleOverlayHover}
                   onMouseLeave={handleSparklineLeave}
                 />
-              ) : (
-                <Tooltip
-                  cursor={false}
-                  isAnimationActive={false}
-                />
-                {isVrm && vrmHover && hoveredNumericValue !== null ? (
-                  <ReferenceDot
-                    x={vrmHover.index}
-                    y={hoveredNumericValue}
-                    r={4}
-                    fill={primarySeries?.color ?? "#2d6cdf"}
-                    stroke="#0f131a"
-                    strokeWidth={1.5}
-                  />
+                {vrmHover ? (
+                  <div
+                    className="kpi-sparkline__popover kpi-sparkline__popover--vrm"
+                    aria-label="VRM sparkline popover"
+                  >
+                    <div className="kpi-sparkline__popover-time">{vrmHover.label}</div>
+                    <div className="kpi-sparkline__popover-value">
+                      {formatKpiValue(vrmHover.value, primarySeries?.unit)}
+                    </div>
+                  </div>
                 ) : null}
-              </AreaChart>
-            </ResponsiveContainer>
-            {isVrm ? (
-              <div
-                className="kpi-sparkline__overlay"
-                data-testid="vrm-sparkline-overlay"
-                onMouseMove={handleOverlayHover}
-                onMouseEnter={handleOverlayHover}
-                onMouseLeave={handleSparklineLeave}
-              />
+              </>
             ) : null}
-          </div>
-          {isVrm && vrmHover ? (
-            <div
-              className="kpi-sparkline__popover kpi-sparkline__popover--vrm"
-              aria-label="VRM sparkline popover"
-            >
-              <div className="kpi-sparkline__popover-time">{vrmHover.label}</div>
-              <div className="kpi-sparkline__popover-value">
-                {formatKpiValue(vrmHover.value, primarySeries?.unit)}
-              </div>
-            </div>
-          </div>
-        </div>
-      ) : null}
-      {isVrm && vrmHover ? (
-        <div className="kpi-sparkline__popover kpi-sparkline__popover--vrm" aria-label="VRM sparkline popover">
-          <div className="kpi-sparkline__popover-time">{vrmHover.label}</div>
-          <div className="kpi-sparkline__popover-value">
-            {formatKpiValue(vrmHover.value, primarySeries?.unit)}
           </div>
         </div>
       ) : null}

--- a/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.test.tsx
@@ -133,7 +133,7 @@ describe("KpiTile VRM sparkline", () => {
     let cursor: any = popover.parent;
     let anchored = false;
     while (cursor) {
-      if (cursor.props?.className?.includes("kpi-tile--vrm")) {
+      if (cursor.props?.className?.includes("kpi-sparkline-shell--vrm")) {
         anchored = true;
         break;
       }
@@ -141,7 +141,7 @@ describe("KpiTile VRM sparkline", () => {
     }
 
     expect(anchored).toBe(true);
-    expect(popover.parent?.props?.className).toContain("kpi-sparkline-shell");
+    expect(popover.parent?.props?.className).toContain("kpi-sparkline");
   });
 
   it("clamps overlay hover to the first bucket", () => {
@@ -162,6 +162,63 @@ describe("KpiTile VRM sparkline", () => {
     const json = tree.toJSON();
     expect(JSON.stringify(json)).toContain("VRM sparkline popover");
     expect(JSON.stringify(json)).toContain("1");
+  });
+
+  it("renders a single VRM overlay and popover within the sparkline shell", () => {
+    const built = buildResult("vrm");
+    if (!built) throw new Error("missing data");
+    const tree = renderer.create(
+      <KpiTile result={built.result} series={built.series} height={200} className="" />,
+    );
+
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
+
+    act(() => {
+      overlay.props.onMouseMove({
+        clientX: 150,
+        currentTarget: { getBoundingClientRect: () => ({ width: 300, left: 0 }) },
+      });
+    });
+
+    const overlays = tree.root.findAll((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
+    expect(overlays).toHaveLength(1);
+
+    const popovers = tree.root.findAllByProps({ "aria-label": "VRM sparkline popover" });
+    expect(popovers).toHaveLength(1);
+
+    let cursor: any = popovers[0]?.parent;
+    let anchoredToShell = false;
+    while (cursor) {
+      if (typeof cursor.props?.className === "string" && cursor.props.className.includes("kpi-sparkline-shell--vrm")) {
+        anchoredToShell = true;
+        break;
+      }
+      cursor = cursor.parent;
+    }
+
+    expect(anchoredToShell).toBe(true);
+  });
+
+  it("renders a visible VRM hover dot with contrast styling", () => {
+    const built = buildResult("vrm");
+    if (!built) throw new Error("missing data");
+    const tree = renderer.create(
+      <KpiTile result={built.result} series={built.series} height={200} className="" />,
+    );
+
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
+    act(() => {
+      overlay.props.onMouseMove({
+        clientX: 225,
+        currentTarget: { getBoundingClientRect: () => ({ width: 300, left: 0 }) },
+      });
+    });
+
+    const dots = tree.root.findAllByType("reference-dot-mock");
+    expect(dots).toHaveLength(1);
+    expect(dots[0].props.r).toBeGreaterThanOrEqual(5);
+    expect(dots[0].props.fill).toBe("#ffffff");
+    expect(dots[0].props.strokeWidth).toBeGreaterThanOrEqual(2);
   });
 
   it("keeps default tooltip for non-VRM charts", () => {

--- a/frontend/src/analytics/components/ChartRenderer/styles.css
+++ b/frontend/src/analytics/components/ChartRenderer/styles.css
@@ -307,6 +307,7 @@
 }
 
 .kpi-sparkline-shell--vrm {
+  position: relative;
   overflow: visible;
   padding-bottom: var(--vrm-spacing-4, 16px);
 }
@@ -330,6 +331,12 @@
   min-width: 160px;
   text-align: center;
   border: 1px solid rgba(255, 255, 255, 0.08);
+  z-index: 3;
+}
+
+.kpi-sparkline-shell--vrm .kpi-sparkline__popover {
+  bottom: 0;
+  transform: translateX(-50%) translateY(8px);
   z-index: 3;
 }
 


### PR DESCRIPTION
## Summary
- wrap VRM sparklines in the rendered shell to anchor overlays, tooltips, and hover markers correctly
- simplify VRM popover/overlay rendering to a single instance and update tooltip positioning for drawer-style emergence
- add high-contrast hover dot styling and tests covering VRM tooltip anchoring and overlay uniqueness

## Testing
- npm --prefix frontend run lint
- CI=true npm --prefix frontend test -- --watch=false
- npm --prefix frontend run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924b72fd3a883288ba4ddaba50a70c8)