### PR TITLE
Add VRM hover strip to KPI sparklines

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx
@@ -216,7 +216,7 @@ describe("KpiTile", () => {
     expect(valueText).toBe("67%");
   });
 
-  it("shows VRM popover from overlay hover without Recharts tooltip metadata", () => {
+  it("shows VRM hover strip from overlay hover without Recharts tooltip metadata", () => {
     const props = buildProps();
     props.result.meta = { timezone: "UTC", summary: { presentation: "vrm" } as any } as ChartResult["meta"];
 
@@ -230,11 +230,11 @@ describe("KpiTile", () => {
       });
     });
 
-    const popover = tree.root.find(
-      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline__popover"),
+    const strip = tree.root.find(
+      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline-strip"),
     );
-    const valueNode = popover.findByProps({ className: "kpi-sparkline__popover-value" });
-    const timeNode = popover.findByProps({ className: "kpi-sparkline__popover-time" });
+    const valueNode = strip.findByProps({ className: "kpi-sparkline-strip__value" });
+    const timeNode = strip.findByProps({ className: "kpi-sparkline-strip__time" });
 
     expect(valueNode.children.join(" ")).toBe("10");
     expect(timeNode.children.join(" ")).not.toBe("");
@@ -269,11 +269,40 @@ describe("KpiTile", () => {
       });
     });
 
-    const popover = tree.root.find(
-      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline__popover"),
+    const strip = tree.root.find(
+      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline-strip"),
     );
-    const valueNode = popover.findByProps({ className: "kpi-sparkline__popover-value" });
+    const valueNode = strip.findByProps({ className: "kpi-sparkline-strip__value" });
 
     expect(valueNode.children.join(" ")).toBe("20");
+  });
+
+  it("hides the VRM hover strip on leave", () => {
+    const props = buildProps();
+    props.result.meta = { timezone: "UTC", summary: { presentation: "vrm" } as any } as ChartResult["meta"];
+
+    const tree = renderer.create(<KpiTile {...props} />);
+    const overlay = tree.root.find((node: any) => node.props["data-testid"] === "vrm-sparkline-overlay");
+
+    act(() => {
+      overlay.props.onMouseEnter({
+        clientX: 50,
+        currentTarget: { getBoundingClientRect: () => ({ left: 0, width: 100 }) },
+      });
+    });
+
+    let strips = tree.root.findAll(
+      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline-strip"),
+    );
+    expect(strips.length).toBeGreaterThan(0);
+
+    act(() => {
+      overlay.props.onMouseLeave();
+    });
+
+    strips = tree.root.findAll(
+      (node: any) => typeof node.props?.className === "string" && node.props.className.includes("kpi-sparkline-strip"),
+    );
+    expect(strips).toHaveLength(0);
   });
 });

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -268,7 +268,10 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
         </div>
       ) : null}
       {!isTraffic && sparklineData.length > 1 ? (
-        <div className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}>
+        <div
+          className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}
+          onMouseLeave={isVrm ? handleSparklineLeave : undefined}
+        >
           <div
             className={`kpi-sparkline${isVrm ? " kpi-sparkline--vrm" : ""}`}
             ref={sparklineRef}
@@ -327,19 +330,16 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                   onMouseEnter={handleOverlayHover}
                   onMouseLeave={handleSparklineLeave}
                 />
-                {vrmHover ? (
-                  <div
-                    className="kpi-sparkline__popover kpi-sparkline__popover--vrm"
-                    aria-label="VRM sparkline popover"
-                  >
-                    <div className="kpi-sparkline__popover-time">{vrmHover.label}</div>
-                    <div className="kpi-sparkline__popover-value">
-                      {formatKpiValue(vrmHover.value, primarySeries?.unit)}
-                    </div>
-                  </div>
-                ) : null}
               </>
             ) : null}
+          </div>
+        </div>
+      ) : null}
+      {isVrm && vrmHover ? (
+        <div className="kpi-sparkline-strip" aria-label="VRM sparkline hover strip">
+          <div className="kpi-sparkline-strip__time">{vrmHover.label}</div>
+          <div className="kpi-sparkline-strip__value">
+            {formatKpiValue(vrmHover.value, primarySeries?.unit)}
           </div>
         </div>
       ) : null}

--- a/frontend/src/analytics/components/ChartRenderer/styles.css
+++ b/frontend/src/analytics/components/ChartRenderer/styles.css
@@ -333,6 +333,37 @@
   align-items: flex-end;
 }
 
+.kpi-sparkline-strip {
+  position: absolute;
+  left: var(--vrm-spacing-4, 16px);
+  right: var(--vrm-spacing-4, 16px);
+  bottom: -12px;
+  padding: var(--vrm-spacing-2, 8px) var(--vrm-spacing-3, 12px);
+  border-radius: var(--vrm-radii-card, 12px);
+  background: rgba(15, 19, 26, 0.95);
+  color: var(--vrm-color-text-primary, #ffffff);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--vrm-spacing-3, 12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--vrm-elevation-popover, 0 20px 30px rgba(0, 0, 0, 0.35));
+  z-index: 4;
+  pointer-events: none;
+}
+
+.kpi-sparkline-strip__time {
+  font-size: var(--vrm-typography-font-size-caption, 12px);
+  color: rgba(255, 255, 255, 0.72);
+  white-space: nowrap;
+}
+
+.kpi-sparkline-strip__value {
+  font-weight: 700;
+  font-size: var(--vrm-typography-font-size-body, 14px);
+  margin-left: auto;
+}
+
 .kpi-sparkline__popover {
   position: absolute;
   left: 50%;


### PR DESCRIPTION
## Summary
- replace the VRM KPI sparkline popover with a bottom-attached hover strip
- keep hover tracking via the sparkline overlay and clear state on leave
- add styling and tests to ensure the strip renders and hides correctly

## Testing
- npm --prefix frontend test -- --runTestsByPath src/analytics/components/ChartRenderer/primitives/KpiTile.test.tsx --watch=false


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692adcf0fee083218f61496089d80db1)