### PR TITLE
Fix time window handling for Site Flow demographics

### DIFF
--- a/backend/app/analytics/compiler.py
+++ b/backend/app/analytics/compiler.py
@@ -89,6 +89,37 @@ def _parse_iso8601(value: object) -> datetime | None:
         return None
 
 
+def _normalize_timestamp_param(value: object, *, fallback: str, timezone: str | None = None) -> str:
+    """Return a safe ISO8601 timestamp for query parameters.
+
+    - Valid ISO8601 strings are normalized to include timezone info.
+    - Empty/invalid inputs fall back to the provided default to avoid TIMESTAMP("") errors.
+    """
+
+    parsed = _parse_iso8601(value)
+    if parsed is None:
+        return fallback
+
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=ZoneInfo(timezone or "UTC"))
+    else:
+        parsed = parsed.astimezone(ZoneInfo(timezone or "UTC"))
+    return parsed.isoformat()
+
+
+def _resolve_time_params(time_window: Dict[str, object], timezone: str) -> Tuple[str, str, str]:
+    """Ensure @start_ts/@end_ts/@now are always valid ISO strings."""
+
+    start_fallback = datetime.fromtimestamp(0, tz=ZoneInfo("UTC")).isoformat()
+    start_ts = _normalize_timestamp_param(time_window.get("from"), fallback=start_fallback, timezone=timezone)
+
+    end_fallback = _current_time(timezone, time_window.get("to"))
+    end_ts = _normalize_timestamp_param(time_window.get("to"), fallback=end_fallback, timezone=timezone)
+
+    now = _current_time(timezone, end_ts)
+    return start_ts, end_ts, now
+
+
 def _current_time(timezone: str, end_ts: object) -> str:
     tzinfo = ZoneInfo(timezone)
     now_in_tz = datetime.now(tzinfo)
@@ -223,10 +254,12 @@ class SpecCompiler:
         if vrm_occupancy_enabled:
             use_calendar = True
 
+        start_ts, end_ts, now = _resolve_time_params(time_window, timezone)
+
         params: Dict[str, object] = {
-            "start_ts": time_window["from"],
-            "end_ts": time_window["to"],
-            "now": _current_time(timezone, time_window.get("to")),
+            "start_ts": start_ts,
+            "end_ts": end_ts,
+            "now": now,
         }
 
         filters_sql = self._build_filters(spec.get("filters", []), params)

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -9,6 +9,7 @@ import type {
   DashboardManifest,
   DashboardWidget,
   DashboardWidgetState,
+  DashboardTimeRangeOption,
 } from "../types";
 import { fetchDashboardManifest, type FetchDashboardManifestOptions } from "../transport/fetchDashboardManifest";
 import {
@@ -33,6 +34,7 @@ import {
   isSiteFlowWidget,
   type DemographicWidgetKind,
   mapChartResultsToDemographics,
+  resolveDemographicsTimeWindow,
   type SiteFlowDemographicsData,
 } from "../utils/siteFlowDemographics";
 
@@ -604,7 +606,7 @@ const DashboardV2Page = ({
   ]);
 
   useEffect(() => {
-    if (!siteFlowWidget || !manifest || !selectedTimeRange) {
+    if (!siteFlowWidget || !manifest) {
       setSiteFlowDemographics((previous) =>
         previous.status === "idle" ? previous : { status: "idle" },
       );
@@ -614,13 +616,22 @@ const DashboardV2Page = ({
     const controller = new AbortController();
     const timezone = manifest.timeControls?.timezone;
     const kinds: DemographicWidgetKind[] = ["age", "gender", "hour", "race"];
+    const resolvedTimeRange =
+      selectedTimeRange ?? ({
+        id: "all_time_default",
+        label: "All time",
+        durationMinutes: null,
+        allTime: true,
+      } satisfies DashboardTimeRangeOption);
+    const anchor = new Date();
+    const timeWindow = resolveDemographicsTimeWindow(resolvedTimeRange, timezone, anchor);
 
     setSiteFlowDemographics({ status: "loading" });
 
     const loadDemographic = async (kind: DemographicWidgetKind) =>
-      widgetResultLoaderImpl(buildDemographicsWidget(kind), {
+      widgetResultLoaderImpl(buildDemographicsWidget(kind, timeWindow), {
         signal: controller.signal,
-        timeRange: selectedTimeRange ?? undefined,
+        timeRange: resolvedTimeRange ?? undefined,
         timezone,
         orgId,
         viewToken,

--- a/frontend/src/dashboard/v2/utils/siteFlowDemographics.ts
+++ b/frontend/src/dashboard/v2/utils/siteFlowDemographics.ts
@@ -1,12 +1,43 @@
-import type { ChartResult, ChartSeries, ChartSpec } from "../../../analytics/schemas/charting";
-import type { DashboardWidget } from "../types";
+import type {
+  ChartResult,
+  ChartSeries,
+  ChartSpec,
+  TimeBucket,
+} from "../../../analytics/schemas/charting";
+import type { DashboardTimeRangeOption, DashboardWidget } from "../types";
 
 export type DemographicWidgetKind = "age" | "gender" | "hour" | "race";
+
+const resolveTimeWindow = (
+  timeRange: DashboardTimeRangeOption | null | undefined,
+  timezone: string | undefined,
+  anchor: Date,
+  bucketOverride?: TimeBucket,
+): ChartSpec["timeWindow"] => {
+  const to = anchor.toISOString();
+  const isAllTime = timeRange?.allTime ?? timeRange?.durationMinutes == null;
+  const durationMinutes = timeRange?.durationMinutes ?? 0;
+  const from = isAllTime
+    ? new Date(0).toISOString()
+    : new Date(anchor.getTime() - durationMinutes * 60_000).toISOString();
+
+  const timeWindow: ChartSpec["timeWindow"] = { from, to };
+  const bucket = bucketOverride ?? timeRange?.bucket;
+  if (bucket) {
+    timeWindow.bucket = bucket;
+  }
+  if (timezone) {
+    timeWindow.timezone = timezone;
+  }
+  return timeWindow;
+};
+
+const DEFAULT_DEMOGRAPHIC_TIME_WINDOW = resolveTimeWindow(null, undefined, new Date());
 
 const BASE_DEMOGRAPHIC_SPEC: Pick<ChartSpec, "dataset" | "chartType" | "timeWindow"> = {
   dataset: "events",
   chartType: "categorical",
-  timeWindow: { from: "", to: "" },
+  timeWindow: DEFAULT_DEMOGRAPHIC_TIME_WINDOW,
 };
 
 const demographicDimension: Record<DemographicWidgetKind, ChartSpec["dimensions"]> = {
@@ -100,9 +131,26 @@ const DEMOGRAPHIC_WIDGET_BASE: Record<DemographicWidgetKind, DashboardWidget> = 
   },
 };
 
-export const buildDemographicsWidget = (kind: DemographicWidgetKind): DashboardWidget => ({
-  ...DEMOGRAPHIC_WIDGET_BASE[kind],
-});
+export const buildDemographicsWidget = (
+  kind: DemographicWidgetKind,
+  timeWindow: ChartSpec["timeWindow"],
+): DashboardWidget => {
+  const base = DEMOGRAPHIC_WIDGET_BASE[kind];
+  return {
+    ...base,
+    inlineSpec: {
+      ...(base.inlineSpec as ChartSpec),
+      timeWindow: { ...timeWindow },
+    },
+  };
+};
+
+export const resolveDemographicsTimeWindow = (
+  timeRange: DashboardTimeRangeOption | null | undefined,
+  timezone: string | undefined,
+  anchor: Date = new Date(),
+  bucketOverride?: TimeBucket,
+): ChartSpec["timeWindow"] => resolveTimeWindow(timeRange, timezone, anchor, bucketOverride);
 
 export const isSiteFlowWidget = (widget: DashboardWidget): boolean =>
   widget.id === "live-flow" || widget.chartSpecId === "dashboard.live_flow";


### PR DESCRIPTION
## Summary
- normalize analytics compiler time parameters to guard against missing or malformed time windows
- build Site Flow demographics widgets with explicit, non-empty time windows derived from the dashboard range
- fall back to an all-time range when no time control is selected so demographics requests remain valid

## Testing
- npm run build --prefix frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6935fa0d0b9c83219e64c4b58f18caa0)