### PR TITLE
Normalize categorical hour values before frontend parsing

### DIFF
--- a/backend/app/analytics/compiler.py
+++ b/backend/app/analytics/compiler.py
@@ -544,6 +544,7 @@ class SpecCompiler:
                         ) AS index,
                         track_id,
                         event,
+                        -- Keep event timestamp raw for downstream hour extraction (no truncation).
                         timestamp,
                         age_bucket AS age_bucket,
                         sex AS sex,
@@ -1398,7 +1399,8 @@ class SpecCompiler:
         if column == "timestamp":
             category_bucket = bucket_label or bucket
             if category_bucket == "HOUR":
-                category_expr = "EXTRACT(HOUR FROM scoped.timestamp)"
+                # Demographics hour buckets must surface as integer hours (0-23) for frontend mapping.
+                category_expr = "CAST(EXTRACT(HOUR FROM scoped.timestamp) AS INT64)"
             elif category_bucket and category_bucket != "RAW":
                 category_expr = _bucket_expression(category_bucket, field="scoped.timestamp")
             else:
@@ -1454,7 +1456,8 @@ class SpecCompiler:
         if column == "timestamp":
             category_bucket = bucket_label or bucket
             if category_bucket == "HOUR":
-                category_expr = "EXTRACT(HOUR FROM scoped.timestamp)"
+                # Demographics hour buckets must surface as integer hours (0-23) for frontend mapping.
+                category_expr = "CAST(EXTRACT(HOUR FROM scoped.timestamp) AS INT64)"
             elif category_bucket and category_bucket != "RAW":
                 category_expr = _bucket_expression(category_bucket, field="scoped.timestamp")
             else:

--- a/backend/app/analytics/engine.py
+++ b/backend/app/analytics/engine.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime
+from numbers import Number
 from typing import Any, Dict, Iterable, List, Optional
 
 import pandas as pd
@@ -187,9 +189,19 @@ class AnalyticsEngine:
                 if label is None or (hasattr(pd, "isna") and pd.isna(label)):
                     continue
                 value = _coerce_number(record.get("value"))
+
+                if isinstance(label, pd.Timestamp):
+                    x_value: object = int(label.hour)
+                elif isinstance(label, datetime):
+                    x_value = label.hour
+                elif isinstance(label, Number):
+                    x_value = int(label)
+                else:
+                    x_value = str(label)
+
                 data_points.append(
                     {
-                        "x": str(label),
+                        "x": x_value,
                         "value": float(value) if value is not None else None,
                         "y": float(value) if value is not None else None,
                     }

--- a/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
@@ -11,6 +11,7 @@ export const TrafficDistribution = ({
   className,
   widgetId,
   useRawLabels = false,
+  labelKey,
 }: ChartPrimitiveProps) => {
   const primary = series[0];
   const data = primary?.data ?? [];
@@ -70,7 +71,11 @@ export const TrafficDistribution = ({
     const rawCamera = point.x ?? `Cam ${index + 1}`;
     const normalizedCameraId = String(rawCamera).replace(/^Cam\s*/i, "").trim();
     const cameraId = normalizedCameraId !== "" ? normalizedCameraId : String(index + 1);
-    const rawLabel = String(rawCamera).trim() || `Slice ${index + 1}`;
+    const baseLabel =
+      labelKey && point && typeof point === "object"
+        ? (point as unknown as Record<string, unknown>)[labelKey]
+        : rawCamera;
+    const rawLabel = String(baseLabel ?? rawCamera).trim() || `Slice ${index + 1}`;
     const rawValue =
       typeof point.value === "number"
         ? point.value
@@ -79,8 +84,9 @@ export const TrafficDistribution = ({
         : 0;
     const numericValue = Number(rawValue);
     const value = Number.isFinite(numericValue) ? numericValue : 0;
+    const label = useRawLabels || labelKey ? rawLabel : `Cam ${cameraId}`;
     return {
-      label: useRawLabels ? rawLabel : `Cam ${cameraId}`,
+      label,
       camId: cameraId,
       value,
       color: sliceColors[index % sliceColors.length],
@@ -166,6 +172,7 @@ export const TrafficDistribution = ({
             <Pie
               dataKey="value"
               data={pieLegend}
+              nameKey={labelKey ?? undefined}
               cx="50%"
               cy="50%"
               innerRadius={48}

--- a/frontend/src/analytics/components/ChartRenderer/primitives/types.ts
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/types.ts
@@ -11,4 +11,5 @@ export interface ChartPrimitiveProps {
   className?: string;
   widgetId?: string;
   useRawLabels?: boolean;
+  labelKey?: string;
 }

--- a/frontend/src/dashboard/v2/components/SiteFlowDemographicsView.tsx
+++ b/frontend/src/dashboard/v2/components/SiteFlowDemographicsView.tsx
@@ -4,7 +4,11 @@ import type {
   ChartResult,
   ChartSeries,
 } from "../../../analytics/schemas/charting";
-import type { SiteFlowDemographicsData, DemographicSlice } from "../utils/siteFlowDemographics";
+import type {
+  SiteFlowDemographicsData,
+  DemographicSlice,
+  HourSlice,
+} from "../utils/siteFlowDemographics";
 import "../styles/DashboardV2Page.css";
 
 const toPercentageSeries = (title: string, slices: DemographicSlice[]): ChartSeries => {
@@ -14,7 +18,13 @@ const toPercentageSeries = (title: string, slices: DemographicSlice[]): ChartSer
     id: `${title.toLowerCase().replace(/\s+/g, "-")}-demographics`,
     label: title,
     geometry: "bar",
-    data: slices.map((slice) => ({ x: slice.label, value: (slice.count / safeTotal) * 100 })),
+    data: slices.map((slice) => ({
+      x: slice.label,
+      label: slice.label,
+      code: slice.code,
+      ...("hour" in slice ? { hour: (slice as HourSlice).hour } : {}),
+      value: (slice.count / safeTotal) * 100,
+    })),
   };
 };
 
@@ -72,6 +82,7 @@ export const SiteFlowDemographicsView = ({ data }: { data: SiteFlowDemographicsD
                 className="site-flow-demographics__pie"
                 widgetId={`site-flow-${title.toLowerCase()}`}
                 useRawLabels
+                labelKey="label"
               />
             ) : (
               <EmptyPie title={title} />

--- a/frontend/src/dashboard/v2/utils/siteFlowDemographics.ts
+++ b/frontend/src/dashboard/v2/utils/siteFlowDemographics.ts
@@ -156,6 +156,7 @@ export const isSiteFlowWidget = (widget: DashboardWidget): boolean =>
   widget.id === "live-flow" || widget.chartSpecId === "dashboard.live_flow";
 
 export interface DemographicSlice {
+  code: string | number | null;
   label: string;
   count: number;
 }
@@ -185,16 +186,37 @@ const toNumeric = (point: { value?: number | null; y?: number | null }): number 
   return typeof raw === "number" && Number.isFinite(raw) ? raw : 0;
 };
 
+const AGE_LABELS = new Set(["0–4", "5–13", "14–25", "26–45", "46–65", "66+", "Unknown"]);
+const GENDER_LABELS = new Set(["Male", "Female", "Unknown"]);
+const RACE_LABELS = new Set(["Light", "Mix", "Dark", "Unknown"]);
+
 const normalizeCode = (code: string | number): number | null => {
-  if (typeof code === "number" && Number.isFinite(code)) return code;
+  if (typeof code === "number" && Number.isFinite(code)) {
+    return Math.trunc(code);
+  }
+
   if (typeof code === "string") {
-    const match = code.trim().match(/(-?\d+)\s*$/);
-    if (match) {
-      const parsed = Number(match[1]);
-      return Number.isFinite(parsed) ? parsed : null;
+    const trimmed = code.trim();
+    if (/^-?\d+$/.test(trimmed)) {
+      const parsed = Number(trimmed);
+      return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
     }
   }
+
   return null;
+};
+
+const ensureAllowedLabel = (kind: DemographicWidgetKind, label: string): string => {
+  if (kind === "age") {
+    return AGE_LABELS.has(label) ? label : "Unknown";
+  }
+  if (kind === "gender") {
+    return GENDER_LABELS.has(label) ? label : "Unknown";
+  }
+  if (kind === "race") {
+    return RACE_LABELS.has(label) ? label : "Unknown";
+  }
+  return label;
 };
 
 export const mapAgeLabel = (code: string | number): string => {
@@ -254,11 +276,11 @@ const mapSeries = (
 ): DemographicSlice[] => {
   const series: ChartSeries | undefined = result?.series?.[0];
   if (!series) return [];
-  const aggregated = new Map<string, number>();
+  const aggregated = new Map<string, { count: number; code: string | number | null }>();
 
   (series.data ?? []).forEach((point) => {
     const raw = point.x ?? "";
-    const baseLabel =
+    const mappedLabel =
       kind === "age"
         ? mapAgeLabel(raw as string | number)
         : kind === "gender"
@@ -266,14 +288,41 @@ const mapSeries = (
           : kind === "race"
             ? mapRaceLabel(raw as string | number)
             : "Unknown";
+    const baseLabel = ensureAllowedLabel(kind, mappedLabel);
     const nextCount = toNumeric(point);
     if (baseLabel === "" || nextCount <= 0) {
       return;
     }
-    aggregated.set(baseLabel, (aggregated.get(baseLabel) ?? 0) + nextCount);
+    const existing = aggregated.get(baseLabel);
+    const currentCount = existing?.count ?? 0;
+    const currentCode = existing?.code ?? null;
+    const nextCode = currentCode ?? (raw as string | number | null);
+    aggregated.set(baseLabel, { count: currentCount + nextCount, code: nextCode });
   });
 
-  return Array.from(aggregated.entries()).map(([label, count]) => ({ label, count }));
+  return Array.from(aggregated.entries()).map(([label, { count, code }]) => ({
+    label,
+    count,
+    code,
+  }));
+};
+
+const parseHour = (raw: unknown): number | null => {
+  if (typeof raw === "number" && Number.isInteger(raw) && raw >= 0 && raw <= 23) {
+    return raw;
+  }
+
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (/^\d{1,2}$/.test(trimmed)) {
+      const parsed = Number.parseInt(trimmed, 10);
+      if (parsed >= 0 && parsed <= 23) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
 };
 
 const mapHours = (result: ChartResult | undefined): HourSlice[] => {
@@ -282,7 +331,7 @@ const mapHours = (result: ChartResult | undefined): HourSlice[] => {
   const aggregated = new Map<number, number>();
 
   (series.data ?? []).forEach((point) => {
-    const hour = normalizeCode(point.x as string | number);
+    const hour = parseHour(point.x as string | number);
     if (hour == null || hour < 0 || hour > 23) {
       return;
     }
@@ -293,6 +342,7 @@ const mapHours = (result: ChartResult | undefined): HourSlice[] => {
 
   return Array.from(aggregated.entries())
     .map(([hour, count]) => ({
+      code: hour,
       hour,
       label: formatHourLabel(hour),
       count,


### PR DESCRIPTION
## Summary
- normalize categorical chart category values to preserve numeric hours for demographics before frontend parsing
- keep hour values as integers when normalizing pandas results to avoid collapsing slices

## Testing
- npm run build --prefix frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69369481264c832195d5a0e259e5c1d8)