### PR TITLE
Add expanding hover footer for VRM KPI sparkline

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -273,14 +273,14 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
         </div>
 
         {!isTraffic && sparklineData.length > 1 ? (
-          <div className={`kpi-sparkline-region${isVrm ? " kpi-sparkline-region--vrm" : ""}`}>
-            <div
-              className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}
-              onMouseLeave={isVrm ? handleSparklineLeave : undefined}
-            >
+          <div
+            className={`kpi-sparkline-region${isVrm ? " kpi-sparkline-region--vrm" : ""}`}
+            onMouseLeave={isVrm ? handleSparklineLeave : undefined}
+            data-testid={isVrm ? "vrm-sparkline-region" : undefined}
+          >
+            <div className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}>
               <div
                 className={`kpi-sparkline-anchor${isVrm ? " kpi-sparkline-anchor--vrm" : ""}`}
-                onMouseLeave={isVrm ? handleSparklineLeave : undefined}
                 data-testid={isVrm ? "vrm-sparkline-shell" : undefined}
                 style={isVrm ? { paddingBottom: 0 } : undefined}
                 ref={sparklineRef}
@@ -294,7 +294,7 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                     <XAxis dataKey="index" hide />
                     <YAxis
                       type="number"
-                      domain={[0, "dataMax"]}
+                      domain={[(dataMin: number) => Math.min(0, dataMin), (dataMax: number) => Math.max(0, dataMax)]}
                       padding={{ bottom: 0, top: 0 }}
                       allowDataOverflow={false}
                       hide
@@ -318,6 +318,7 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                       fill={primarySeries?.color ?? "#2d6cdf"}
                       fillOpacity={0.2}
                       isAnimationActive={false}
+                      baseValue={0}
                     />
                     {isVrm && vrmHover && hoveredNumericValue !== null ? (
                       <ReferenceDot
@@ -338,22 +339,22 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                     data-testid="vrm-sparkline-overlay"
                     onMouseMove={handleOverlayHover}
                     onMouseEnter={handleOverlayHover}
-                    onMouseLeave={handleSparklineLeave}
                   />
                 ) : null}
               </div>
-              {isVrm && vrmHover ? (
-                <div
-                  className="kpi-sparkline-strip kpi-sparkline-strip--vrm"
-                  aria-label="VRM sparkline hover strip"
-                >
-                  <div className="kpi-sparkline-strip__time">{vrmHover.label}</div>
-                  <div className="kpi-sparkline-strip__value">
-                    {formatKpiValue(vrmHover.value, primarySeries?.unit)}
-                  </div>
-                </div>
-              ) : null}
             </div>
+            {isVrm && vrmHover ? (
+              <div
+                className="kpi-sparkline-strip kpi-sparkline-strip--vrm"
+                aria-label="VRM sparkline hover strip"
+                data-testid="vrm-sparkline-footer"
+              >
+                <div className="kpi-sparkline-strip__time">{vrmHover.label}</div>
+                <div className="kpi-sparkline-strip__value">
+                  {formatKpiValue(vrmHover.value, primarySeries?.unit)}
+                </div>
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.vrm.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.vrm.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import type { ChartPrimitiveProps } from "../types";
+import type { ChartResult } from "../../../schemas/charting";
+import { KpiTile } from "../KpiTile";
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => <div data-testid="area" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  ReferenceDot: () => <div data-testid="reference-dot" />,
+}));
+
+let consoleErrorSpy: jest.SpyInstance;
+let rectSpy: jest.SpyInstance;
+
+beforeAll(() => {
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+  class ResizeObserverMock {
+    observe() {
+      // no-op
+    }
+    unobserve() {
+      // no-op
+    }
+    disconnect() {
+      // no-op
+    }
+  }
+  // @ts-expect-error jsdom test environment does not ship ResizeObserver
+  global.ResizeObserver = ResizeObserverMock;
+
+  rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: 200,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 200,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return "";
+    },
+  });
+});
+
+afterAll(() => {
+  rectSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+const mockResult: ChartResult = {
+  chartType: "single_value",
+  xDimension: { id: "timestamp", type: "time", bucket: "MINUTE", timezone: "UTC" },
+  series: [
+    {
+      id: "occupancy",
+      label: "Occupancy",
+      geometry: "line",
+      unit: "people",
+      data: [
+        { x: "2024-01-01T00:00:00Z", value: 100 },
+        { x: "2024-01-01T00:05:00Z", value: 120 },
+        { x: "2024-01-01T00:10:00Z", value: 90 },
+      ],
+      summary: { delta: -0.01 },
+      color: "#2d6cdf",
+    },
+  ],
+  meta: {
+    timezone: "UTC",
+    summary: {
+      presentation: "vrm",
+      title: "Occupancy",
+    } as Record<string, unknown>,
+  },
+};
+
+const defaultProps: Omit<ChartPrimitiveProps, "series" | "result"> = {
+  axisConfig: {} as any,
+  visibility: {},
+  height: 200,
+};
+
+describe("KpiTile VRM hover footer", () => {
+  it("renders hover footer below sparkline and toggles with hover state", () => {
+    const tree = renderer.create(<KpiTile {...defaultProps} result={mockResult} series={mockResult.series} />);
+    const root = tree.root;
+
+    expect(() => root.findByProps({ "data-testid": "vrm-sparkline-footer" })).toThrow();
+
+    const overlay = root.findByProps({ "data-testid": "vrm-sparkline-overlay" });
+    renderer.act(() => {
+      overlay.props.onMouseEnter?.({
+        clientX: 100,
+        clientY: 0,
+        currentTarget: {
+          getBoundingClientRect: () => overlay.props.getBoundingClientRect?.() ?? {
+            width: 200,
+            left: 0,
+          },
+        },
+      });
+    });
+
+    const footer = root.findByProps({ "data-testid": "vrm-sparkline-footer" });
+    const region = root.findByProps({ "data-testid": "vrm-sparkline-region" });
+    const shell = root.findByProps({ "data-testid": "vrm-sparkline-shell" });
+
+    expect(region.children[0]).toBe(shell);
+    expect(shell.children).not.toContain(footer);
+    expect(region.children[region.children.length - 1]).toBe(footer);
+
+    renderer.act(() => {
+      region.props.onMouseLeave?.();
+    });
+
+    expect(() => root.findByProps({ "data-testid": "vrm-sparkline-footer" })).toThrow();
+  });
+});

--- a/frontend/src/analytics/components/ChartRenderer/styles.css
+++ b/frontend/src/analytics/components/ChartRenderer/styles.css
@@ -362,6 +362,7 @@
   padding: 0;
   min-height: 0;
   flex-shrink: 0;
+  gap: var(--vrm-spacing-2, 8px);
 }
 
 .kpi-sparkline--vrm {
@@ -393,9 +394,9 @@
   border-radius: 0;
   padding: var(--vrm-spacing-2, 8px) var(--vrm-spacing-3, 12px);
   gap: var(--vrm-spacing-3, 12px);
-  position: absolute;
-  inset: auto 0 0 0;
-  pointer-events: none;
+  position: static;
+  pointer-events: auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .kpi-sparkline-strip--vrm .kpi-sparkline-strip__time {


### PR DESCRIPTION
## Summary
- render VRM KPI hover details in a footer below the sparkline so the card expands on hover without overlaying the chart
- adjust sparkline axis configuration to anchor the area fill to zero and keep hover interactions stable while moving into the footer
- add a unit test covering the VRM hover footer DOM placement and visibility toggle

## Testing
- CI=true npm test -- --runInBand --watch=false --runTestsByPath src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.vrm.test.tsx *(command hung locally in this environment; see notes in task response)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d750dcc088323bb2d71d3994e6a37)