### PR TITLE
Align KPI tile frame and baseline

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/__tests__/ChartRendererStates.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/__tests__/ChartRendererStates.test.tsx
@@ -69,6 +69,17 @@ describe('ChartRenderer high-level states', () => {
     expect(json).toContain('Unable to render chart');
   });
 
+  it('applies KPI renderer classnames to error state for dashboard overrides', () => {
+    const invalid: ChartResult = { ...baseTimeResult, series: [] };
+    const tree = renderer.create(
+      <ChartRenderer result={invalid} height={300} className="dashboard-v2__kpi-renderer" />,
+    );
+    const root = tree.root.find(
+      (node) => typeof node.props?.className === 'string' && node.props.className.includes('analytics-chart-error'),
+    );
+    expect(root.props.className).toContain('dashboard-v2__kpi-renderer');
+  });
+
   it('shows ChartEmptyState when all data points are null', () => {
     const emptyResult: ChartResult = {
       ...baseTimeResult,

--- a/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/KpiTile.tsx
@@ -273,14 +273,14 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
         </div>
 
         {!isTraffic && sparklineData.length > 1 ? (
-          <div className={`kpi-sparkline-region${isVrm ? " kpi-sparkline-region--vrm" : ""}`}>
-            <div
-              className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}
-              onMouseLeave={isVrm ? handleSparklineLeave : undefined}
-            >
+          <div
+            className={`kpi-sparkline-region${isVrm ? " kpi-sparkline-region--vrm" : ""}`}
+            onMouseLeave={isVrm ? handleSparklineLeave : undefined}
+            data-testid={isVrm ? "vrm-sparkline-region" : undefined}
+          >
+            <div className={`kpi-sparkline-shell${isVrm ? " kpi-sparkline-shell--vrm" : ""}`}>
               <div
                 className={`kpi-sparkline-anchor${isVrm ? " kpi-sparkline-anchor--vrm" : ""}`}
-                onMouseLeave={isVrm ? handleSparklineLeave : undefined}
                 data-testid={isVrm ? "vrm-sparkline-shell" : undefined}
                 style={isVrm ? { paddingBottom: 0 } : undefined}
                 ref={sparklineRef}
@@ -294,7 +294,7 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                     <XAxis dataKey="index" hide />
                     <YAxis
                       type="number"
-                      domain={[0, "dataMax"]}
+                      domain={[(dataMin: number) => Math.min(0, dataMin), (dataMax: number) => Math.max(0, dataMax)]}
                       padding={{ bottom: 0, top: 0 }}
                       allowDataOverflow={false}
                       hide
@@ -318,6 +318,7 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                       fill={primarySeries?.color ?? "#2d6cdf"}
                       fillOpacity={0.2}
                       isAnimationActive={false}
+                      baseValue={0}
                     />
                     {isVrm && vrmHover && hoveredNumericValue !== null ? (
                       <ReferenceDot
@@ -338,22 +339,22 @@ export const KpiTile = ({ series, height, className, result }: ChartPrimitivePro
                     data-testid="vrm-sparkline-overlay"
                     onMouseMove={handleOverlayHover}
                     onMouseEnter={handleOverlayHover}
-                    onMouseLeave={handleSparklineLeave}
                   />
                 ) : null}
               </div>
-              {isVrm && vrmHover ? (
-                <div
-                  className="kpi-sparkline-strip kpi-sparkline-strip--vrm"
-                  aria-label="VRM sparkline hover strip"
-                >
-                  <div className="kpi-sparkline-strip__time">{vrmHover.label}</div>
-                  <div className="kpi-sparkline-strip__value">
-                    {formatKpiValue(vrmHover.value, primarySeries?.unit)}
-                  </div>
-                </div>
-              ) : null}
             </div>
+            {isVrm && vrmHover ? (
+              <div
+                className="kpi-sparkline-strip kpi-sparkline-strip--vrm"
+                aria-label="VRM sparkline hover strip"
+                data-testid="vrm-sparkline-footer"
+              >
+                <div className="kpi-sparkline-strip__time">{vrmHover.label}</div>
+                <div className="kpi-sparkline-strip__value">
+                  {formatKpiValue(vrmHover.value, primarySeries?.unit)}
+                </div>
+              </div>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.vrm.test.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.vrm.test.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import type { ChartPrimitiveProps } from "../types";
+import type { ChartResult } from "../../../schemas/charting";
+import { KpiTile } from "../KpiTile";
+
+jest.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  AreaChart: ({ children }: { children: React.ReactNode }) => <div data-testid="area-chart">{children}</div>,
+  Area: () => <div data-testid="area" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  ReferenceDot: () => <div data-testid="reference-dot" />,
+}));
+
+let consoleErrorSpy: jest.SpyInstance;
+let rectSpy: jest.SpyInstance;
+
+beforeAll(() => {
+  consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+
+  class ResizeObserverMock {
+    observe() {
+      // no-op
+    }
+    unobserve() {
+      // no-op
+    }
+    disconnect() {
+      // no-op
+    }
+  }
+  // @ts-expect-error jsdom test environment does not ship ResizeObserver
+  global.ResizeObserver = ResizeObserverMock;
+
+  rectSpy = jest.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: 200,
+    height: 80,
+    top: 0,
+    left: 0,
+    bottom: 80,
+    right: 200,
+    x: 0,
+    y: 0,
+    toJSON() {
+      return "";
+    },
+  });
+});
+
+afterAll(() => {
+  rectSpy.mockRestore();
+  consoleErrorSpy.mockRestore();
+});
+
+const mockResult: ChartResult = {
+  chartType: "single_value",
+  xDimension: { id: "timestamp", type: "time", bucket: "MINUTE", timezone: "UTC" },
+  series: [
+    {
+      id: "occupancy",
+      label: "Occupancy",
+      geometry: "line",
+      unit: "people",
+      data: [
+        { x: "2024-01-01T00:00:00Z", value: 100 },
+        { x: "2024-01-01T00:05:00Z", value: 120 },
+        { x: "2024-01-01T00:10:00Z", value: 90 },
+      ],
+      summary: { delta: -0.01 },
+      color: "#2d6cdf",
+    },
+  ],
+  meta: {
+    timezone: "UTC",
+    summary: {
+      presentation: "vrm",
+      title: "Occupancy",
+    } as Record<string, unknown>,
+  },
+};
+
+const defaultProps: Omit<ChartPrimitiveProps, "series" | "result"> = {
+  axisConfig: {} as any,
+  visibility: {},
+  height: 200,
+};
+
+describe("KpiTile VRM hover footer", () => {
+  it("renders hover footer below sparkline and toggles with hover state", () => {
+    const tree = renderer.create(<KpiTile {...defaultProps} result={mockResult} series={mockResult.series} />);
+    const root = tree.root;
+
+    expect(() => root.findByProps({ "data-testid": "vrm-sparkline-footer" })).toThrow();
+
+    const overlay = root.findByProps({ "data-testid": "vrm-sparkline-overlay" });
+    renderer.act(() => {
+      overlay.props.onMouseEnter?.({
+        clientX: 100,
+        clientY: 0,
+        currentTarget: {
+          getBoundingClientRect: () => overlay.props.getBoundingClientRect?.() ?? {
+            width: 200,
+            left: 0,
+          },
+        },
+      });
+    });
+
+    const footer = root.findByProps({ "data-testid": "vrm-sparkline-footer" });
+    const region = root.findByProps({ "data-testid": "vrm-sparkline-region" });
+    const shell = root.findByProps({ "data-testid": "vrm-sparkline-shell" });
+
+    expect(region.children[0]).toBe(shell);
+    expect(shell.children).not.toContain(footer);
+    expect(region.children[region.children.length - 1]).toBe(footer);
+
+    renderer.act(() => {
+      region.props.onMouseLeave?.();
+    });
+
+    expect(() => root.findByProps({ "data-testid": "vrm-sparkline-footer" })).toThrow();
+  });
+});

--- a/frontend/src/analytics/components/ChartRenderer/styles.css
+++ b/frontend/src/analytics/components/ChartRenderer/styles.css
@@ -362,6 +362,7 @@
   padding: 0;
   min-height: 0;
   flex-shrink: 0;
+  gap: var(--vrm-spacing-2, 8px);
 }
 
 .kpi-sparkline--vrm {
@@ -393,9 +394,9 @@
   border-radius: 0;
   padding: var(--vrm-spacing-2, 8px) var(--vrm-spacing-3, 12px);
   gap: var(--vrm-spacing-3, 12px);
-  position: absolute;
-  inset: auto 0 0 0;
-  pointer-events: none;
+  position: static;
+  pointer-events: auto;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .kpi-sparkline-strip--vrm .kpi-sparkline-strip__time {

--- a/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
+++ b/frontend/src/dashboard/v2/pages/DashboardV2Page.tsx
@@ -84,8 +84,11 @@ interface DashboardV2PageProps {
   dashboardId?: string;
 }
 
-const renderLoading = (label: string) => (
-  <div className="dashboard-v2__placeholder" aria-live="polite">
+const renderLoading = (label: string, variant: "card" | "kpi" = "card") => (
+  <div
+    className={`dashboard-v2__placeholder dashboard-v2__placeholder--${variant}`}
+    aria-live="polite"
+  >
     Loading {label}…
   </div>
 );
@@ -125,7 +128,7 @@ const KpiTile = ({
 
   let content: JSX.Element;
   if (state.status === "loading") {
-    content = renderLoading(title);
+    content = renderLoading(title, "kpi");
   } else if (state.status === "error") {
     content = renderError(state.error ?? `Failed to load ${title}`);
   } else if (!result) {
@@ -144,7 +147,11 @@ const KpiTile = ({
   const showRemove = Boolean(onRemove) && !locked;
 
   return (
-    <div className="dashboard-v2__kpi-tile vrm-kpi-tile vrm-kpi-tile--panel" data-state={state.status}>
+    <div
+      className="dashboard-v2__kpi-tile vrm-kpi-tile vrm-kpi-tile--panel"
+      data-state={state.status}
+      style={{ paddingBottom: 0 }}
+    >
       {showRemove ? (
         <div className="dashboard-v2__kpi-controls">
           <button type="button" className="dashboard-v2__remove-button" onClick={onRemove}>
@@ -953,5 +960,5 @@ const DashboardV2PageWithBoundary = (props: DashboardV2PageProps) => (
   </ErrorBoundary>
 );
 
-export { DashboardV2Page };
+export { DashboardV2Page, renderLoading, renderError };
 export default DashboardV2PageWithBoundary;

--- a/frontend/src/dashboard/v2/pages/__tests__/DashboardV2Page.placeholders.test.tsx
+++ b/frontend/src/dashboard/v2/pages/__tests__/DashboardV2Page.placeholders.test.tsx
@@ -1,0 +1,15 @@
+import renderer from "react-test-renderer";
+
+import { renderLoading } from "../DashboardV2Page";
+
+describe("DashboardV2 KPI placeholders", () => {
+  it("applies the KPI variant class for loading tiles", () => {
+    const tree = renderer.create(renderLoading("Test KPI", "kpi")).toJSON() as any;
+    expect(tree?.props?.className).toContain("dashboard-v2__placeholder--kpi");
+  });
+
+  it("retains the card variant styling by default", () => {
+    const tree = renderer.create(renderLoading("Chart"))?.toJSON() as any;
+    expect(tree?.props?.className).toContain("dashboard-v2__placeholder--card");
+  });
+});

--- a/frontend/src/dashboard/v2/styles/DashboardV2Page.css
+++ b/frontend/src/dashboard/v2/styles/DashboardV2Page.css
@@ -148,6 +148,10 @@
   height: 100%;
 }
 
+.dashboard-v2__kpi-tile.vrm-kpi-tile--panel {
+  padding-bottom: 0;
+}
+
 .dashboard-v2__kpi-renderer.kpi-tile,
 .dashboard-v2__kpi-renderer .kpi-tile {
   box-shadow: none !important;
@@ -162,6 +166,15 @@
   border: none !important;
   box-shadow: none !important;
   padding: 0 !important;
+}
+
+.dashboard-v2__kpi-renderer .analytics-chart-error,
+.dashboard-v2__kpi-renderer .analytics-chart-empty {
+  border: none !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+  min-height: inherit;
 }
 
 .dashboard-v2__kpi-renderer .kpi-sparkline-strip,
@@ -191,6 +204,7 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: stretch;
+  flex: 1;
 }
 
 .dashboard-v2__kpi-content .kpi-sparkline-region--vrm {
@@ -300,9 +314,20 @@
   justify-content: center;
   min-height: 160px;
   color: var(--vrm-text-muted);
+}
+
+.dashboard-v2__placeholder--card {
   background: rgba(255, 255, 255, 0.04);
   border: 1px dashed rgba(255, 255, 255, 0.12);
   border-radius: var(--vrm-radii-card);
+}
+
+.dashboard-v2__placeholder--kpi {
+  width: 100%;
+  min-height: 100%;
+  background: transparent;
+  border: none;
+  padding: 0;
 }
 
 .dashboard-v2__error {


### PR DESCRIPTION
## Summary
- ensure KPI tiles use a single-frame layout across loaded/loading/error states with KPI-specific placeholders
- remove KPI band bottom padding so the sparkline baseline aligns to the outer frame while keeping the footer behaviour intact
- add coverage for KPI placeholder variants and KPI error class propagation into ChartRenderer

## Testing
- CI=true npm test -- --runInBand --watch=false --runTestsByPath src/dashboard/v2/pages/__tests__/DashboardV2Page.placeholders.test.tsx
- CI=true npm test -- --runInBand --watch=false --runTestsByPath src/analytics/components/ChartRenderer/__tests__/ChartRendererStates.test.tsx
- CI=true npm test -- --runInBand --watch=false --runTestsByPath src/analytics/components/ChartRenderer/primitives/__tests__/KpiTile.vrm.test.tsx --testTimeout=10000 --forceExit *(hangs in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693d750dcc088323bb2d71d3994e6a37)