### PR TITLE
Reduce default dashboard grid height for Site Flow card

### DIFF
--- a/backend/app/analytics/dashboard_catalogue.py
+++ b/backend/app/analytics/dashboard_catalogue.py
@@ -13,7 +13,7 @@ Widget = Dict[str, Any]
 
 _DEFAULT_TIMEZONE = "UTC"
 _DEFAULT_GRID_COLUMNS = 12
-_DEFAULT_GRID_HEIGHT = 8
+_DEFAULT_GRID_HEIGHT = 4
 
 
 def _single_value_spec(


### PR DESCRIPTION
### Motivation
- Root cause: the dashboard template used a default grid placement height of `8` rows for the `live-flow` widget which produced a grid-item `scrollHeight` far larger than the visual card, so the extra blank scroll space came from grid/widget placement sizing (H1: TRUE, H2: FALSE, H3: FALSE, H4: FALSE); measurements showed the grid item dropped from ~936px (`h=8`) to ~456px (`h=4`) while the card stayed ~360px, proving the placement size drove the blank area.

### Description
- Change: lowered `_DEFAULT_GRID_HEIGHT` from `8` to `4` in `backend/app/analytics/dashboard_catalogue.py` so the default manifest produces a smaller grid placement for the Site Flow chart and removes the extra blank scroll area; no frontend hacks or logging were added and no other layout logic was changed.

### Testing
- Commands run: `npm --prefix frontend ci` (succeeded) and `npm --prefix frontend run build` (succeeded); dev-time DOM measurements and before/after full-page screenshots were captured during test runs to verify the grid `scrollHeight` reduced as expected (artifacts saved during the run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6988c808577c832999087bad6018fa58)