### PR TITLE
Fix landing topology: deterministic anchors, single-path routing, and topology verification

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^8.57.0",
+        "playwright": "^1.54.2",
         "vite": "^5.4.8"
       }
     },
@@ -3016,6 +3017,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "dev": "vite --host 0.0.0.0 --port 3000",
     "build": "vite build && if [ -d ../backend ]; then rm -rf ../backend/frontend_build && cp -R build ../backend/frontend_build; fi",
     "preview": "vite preview --host 0.0.0.0 --port 3000",
-    "ci": "npm run build"
+    "ci": "npm run build",
+    "verify:topology": "node scripts/topology-check.mjs"
   },
   "browserslist": {
     "production": [
@@ -36,6 +37,7 @@
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^8.57.0",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "playwright": "^1.54.2"
   }
 }

--- a/frontend/scripts/topology-check.mjs
+++ b/frontend/scripts/topology-check.mjs
@@ -1,0 +1,90 @@
+import { chromium } from 'playwright';
+
+const baseUrl = process.env.TOPOLOGY_BASE_URL ?? 'http://127.0.0.1:3000';
+const targetUrl = `${baseUrl}/?topologyMock=1`;
+
+const expectedDirections = {
+  entrances: 'toNode',
+  exits: 'toNode',
+  occupancy: 'fromNode',
+  traffic: 'fromNode',
+  dwell: 'fromNode',
+};
+
+const assert = (condition, message) => {
+  if (!condition) throw new Error(message);
+};
+
+const runForViewport = async (page, width, height, screenshotPath) => {
+  await page.setViewportSize({ width, height });
+  await page.goto(targetUrl, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-topology-mock="true"]');
+  await page.waitForSelector('line[data-testid="topology-bus"]', { state: 'attached' });
+
+  const geometry = await page.evaluate(() => {
+    const bus = document.querySelector('line[data-testid="topology-bus"]');
+    if (!bus) throw new Error('missing topology bus line');
+    const connectors = Array.from(document.querySelectorAll('line[data-route-id]')).map((el) => ({
+      routeId: el.getAttribute('data-route-id') ?? '',
+      x1: Number(el.getAttribute('x1') ?? 0),
+      y1: Number(el.getAttribute('y1') ?? 0),
+      x2: Number(el.getAttribute('x2') ?? 0),
+      y2: Number(el.getAttribute('y2') ?? 0),
+    }));
+
+    const routes = Array.from(document.querySelectorAll('path[data-route-id]')).map((el) => ({
+      routeId: el.getAttribute('data-route-id') ?? '',
+      direction: el.getAttribute('data-direction') ?? '',
+    }));
+
+    const busX1 = Number(bus.getAttribute('x1') ?? 0);
+    const busX2 = Number(bus.getAttribute('x2') ?? 0);
+
+    const edgeDistances = connectors
+      .filter((c) => c.routeId === 'traffic' || c.routeId === 'dwell')
+      .map((connector) => {
+        const anchor = document.querySelector(`[data-anchor-id="bottom-${connector.routeId}"]`);
+        if (!anchor) {
+          return { routeId: connector.routeId, distancePx: Number.POSITIVE_INFINITY };
+        }
+        const lineY = connector.y1;
+        const anchorRect = anchor.getBoundingClientRect();
+        const canvasRect = anchor.closest('[data-topology-mock]')?.getBoundingClientRect();
+        if (!canvasRect) {
+          return { routeId: connector.routeId, distancePx: Number.POSITIVE_INFINITY };
+        }
+        const anchorCenterY = anchorRect.top - canvasRect.top + anchorRect.height / 2;
+        return { routeId: connector.routeId, distancePx: Math.abs(lineY - anchorCenterY) };
+      });
+
+    return { busX1, busX2, connectors, routes, edgeDistances };
+  });
+
+  const tapXs = geometry.connectors.map((c) => c.x1);
+  const minTap = Math.min(...tapXs);
+  const maxTap = Math.max(...tapXs);
+  assert(Math.abs(geometry.busX1 - minTap) < 0.5, `busX1 mismatch at ${width}px: ${geometry.busX1} vs ${minTap}`);
+  assert(Math.abs(geometry.busX2 - maxTap) < 0.5, `busX2 mismatch at ${width}px: ${geometry.busX2} vs ${maxTap}`);
+
+  for (const { routeId, distancePx } of geometry.edgeDistances) {
+    assert(distancePx <= 6, `${routeId} connector is not terminating at card edge (distance ${distancePx.toFixed(2)}px)`);
+  }
+
+  for (const route of geometry.routes) {
+    const expected = expectedDirections[route.routeId];
+    assert(expected === route.direction, `direction mismatch for ${route.routeId}: expected ${expected}, got ${route.direction}`);
+  }
+
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+};
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+try {
+  await runForViewport(page, 1440, 1100, 'artifacts/topology-1440.png');
+  await runForViewport(page, 1024, 1000, 'artifacts/topology-1024.png');
+  console.log('Topology verification passed at 1440 and 1024.');
+} finally {
+  await browser.close();
+}

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -86,6 +86,21 @@
   background: transparent !important;
 }
 
+.preview :global(.dashboard-v2__kpi-renderer.kpi-tile),
+.preview :global(.dashboard-v2__kpi-renderer.kpi-tile--vrm),
+.preview :global(.dashboard-v2__kpi-renderer.kpi-content),
+.preview :global(.dashboard-v2__kpi-renderer.kpi-content--vrm) {
+  background: transparent !important;
+  border: none !important;
+  box-shadow: none !important;
+  padding: 0 !important;
+}
+
+.preview :global(.dashboard-v2__kpi-renderer.kpi-content--vrm),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-content--vrm) {
+  gap: 0 !important;
+}
+
 .preview :global(.dashboard-v2__kpi-renderer .kpi-footer),
 .preview :global(.dashboard-v2__kpi-renderer .kpi-footer-reserve) {
   display: none !important;

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -4,7 +4,7 @@
   --topo-gap-row: 8px;
   --kpi-min: var(--kpi-col);
   --kpi-max: var(--kpi-col);
-  --anchor-inset: 4px;
+  --anchor-inset: 14px;
   --mid-span: 56px;
 
   position: relative;
@@ -182,7 +182,7 @@
 }
 
 .node {
-  z-index: 5;
+  z-index: 6;
   position: relative;
   text-align: center;
   font-size: 14px;
@@ -241,7 +241,7 @@
   width: 100%;
   height: 100%;
   pointer-events: none;
-  z-index: 3;
+  z-index: 5;
 }
 
 .busLine {
@@ -267,11 +267,11 @@
 }
 
 .beamFromNode {
-  animation: beam-forward 4.8s linear infinite;
+  animation: beam-reverse 4.8s linear infinite;
 }
 
 .beamToNode {
-  animation: beam-reverse 4.8s linear infinite;
+  animation: beam-forward 4.8s linear infinite;
 }
 
 @keyframes beam-forward {

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -73,10 +73,17 @@
 .preview :global(.dashboard-v2__kpi-renderer .kpi-tile),
 .preview :global(.dashboard-v2__kpi-renderer .kpi-content),
 .preview :global(.dashboard-v2__kpi-renderer .kpi-content--vrm),
-.preview :global(.dashboard-v2__kpi-renderer .kpi-panel-header) {
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel-header),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel::before),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel::after) {
   border: none !important;
   outline: none !important;
   box-shadow: none !important;
+}
+
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel) {
+  background: transparent !important;
 }
 
 .wireEdgeAnchor {

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -4,7 +4,8 @@
   --topo-gap-row: 8px;
   --kpi-min: var(--kpi-col);
   --kpi-max: var(--kpi-col);
-  --anchor-inset: 14px;
+  --top-anchor-inset: 2px;
+  --bottom-anchor-inset: 14px;
   --mid-span: 56px;
 
   position: relative;
@@ -77,11 +78,11 @@
 }
 
 .wireEdgeAnchorBottom {
-  bottom: var(--anchor-inset);
+  bottom: var(--top-anchor-inset);
 }
 
 .wireEdgeAnchorTop {
-  top: var(--anchor-inset);
+  top: var(--bottom-anchor-inset);
 }
 
 .tileT1 { grid-column: 1; grid-row: 1; }
@@ -266,22 +267,13 @@
   opacity: 0.52;
 }
 
-.beamFromNode {
-  animation: beam-reverse 4.8s linear infinite;
+.beamRoute {
+  animation: beam-flow 4.8s linear infinite;
 }
 
-.beamToNode {
-  animation: beam-forward 4.8s linear infinite;
-}
-
-@keyframes beam-forward {
+@keyframes beam-flow {
   from { stroke-dashoffset: 0; }
   to { stroke-dashoffset: -208; }
-}
-
-@keyframes beam-reverse {
-  from { stroke-dashoffset: 0; }
-  to { stroke-dashoffset: 208; }
 }
 
 .errorNote {
@@ -348,8 +340,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .beamFromNode,
-  .beamToNode {
+  .beamRoute {
     animation: none;
   }
 }

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -4,11 +4,9 @@
   --topo-gap-row: 8px;
   --kpi-min: var(--kpi-col);
   --kpi-max: var(--kpi-col);
-  --top-to-bus: 42px;
-  --lower-connector-inset: 6px;
-  --bus-to-bottom: 30px;
+  --anchor-inset: 4px;
   --mid-span: 56px;
-  
+
   position: relative;
   width: min(1040px, 100%);
   margin: 0 auto;
@@ -33,19 +31,6 @@
   filter: none;
 }
 
-.preview::before,
-.preview::after,
-.canvas::before,
-.canvas::after,
-.topCluster::before,
-.topCluster::after,
-.bottomCluster::before,
-.bottomCluster::after,
-.kpiSlot::before,
-.kpiSlot::after {
-  content: none;
-}
-
 .canvas {
   position: relative;
   display: grid;
@@ -57,7 +42,7 @@
 
 .topCluster {
   position: relative;
-  z-index: 2;
+  z-index: 4;
   display: grid;
   grid-template-columns: repeat(4, var(--kpi-col));
   grid-template-rows: auto 72px;
@@ -74,22 +59,30 @@
 .kpiSlot {
   min-width: 0;
   width: 100%;
-  margin-inline: 0;
-  box-sizing: border-box;
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  outline: none;
   padding: 0;
-  border-radius: 0;
 }
 
-
-.wireAnchor {
-  display: flow-root;
+.wireAnchorSlot {
+  position: relative;
   width: 100%;
 }
 
+.wireEdgeAnchor {
+  position: absolute;
+  left: 50%;
+  width: 6px;
+  height: 6px;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.wireEdgeAnchorBottom {
+  bottom: var(--anchor-inset);
+}
+
+.wireEdgeAnchorTop {
+  top: var(--anchor-inset);
+}
 
 .tileT1 { grid-column: 1; grid-row: 1; }
 .tileT2 { grid-column: 2; grid-row: 1; }
@@ -104,7 +97,7 @@
 
 .bottomCluster {
   position: relative;
-  z-index: 2;
+  z-index: 4;
   display: grid;
   grid-template-columns: repeat(4, var(--kpi-col));
   column-gap: var(--topo-gap-col);
@@ -137,15 +130,10 @@
   cursor: pointer;
 }
 
-.retryButton:hover {
-  background: color-mix(in srgb, var(--sys-accent) 18%, var(--sys-bg-2) 82%);
-}
-
 .capacityTile {
   border-radius: var(--sys-radius-sm);
   border: 1px solid color-mix(in srgb, var(--sys-line-soft) 64%, transparent);
   background: color-mix(in srgb, var(--sys-bg-2) 70%, transparent);
-  box-shadow: none;
   grid-column: 4;
   grid-row: 2;
   min-height: 72px;
@@ -156,21 +144,23 @@
   gap: 3px;
 }
 
-.capacityLabel {
+.capacityLabel,
+.capacityMeta {
   margin: 0;
+}
+
+.capacityLabel {
   font-size: 0.66rem;
   line-height: 1;
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--sys-text-3);
-  font-weight: 530;
 }
 
 .capacityTrack {
   height: 10px;
   border-radius: 999px;
   background: linear-gradient(180deg, color-mix(in srgb, var(--sys-line-soft) 92%, transparent), color-mix(in srgb, var(--sys-line-soft) 76%, transparent));
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 10%, transparent);
   overflow: hidden;
 }
 
@@ -181,21 +171,19 @@
 }
 
 .capacityMeta {
-  margin: 0;
   color: var(--sys-text-2);
   font-size: 0.67rem;
-  line-height: 1.15;
 }
 
 .midZone {
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 36px;
 }
 
 .node {
-  z-index: 4;
+  z-index: 5;
+  position: relative;
   text-align: center;
   font-size: 14px;
   font-weight: 600;
@@ -203,6 +191,11 @@
   color: var(--sys-text-1);
   background: color-mix(in srgb, var(--sys-bg-1) 88%, transparent);
   padding: 2px 8px;
+}
+
+.nodeAnchor {
+  position: absolute;
+  inset: 0;
 }
 
 .nodeSub {
@@ -218,76 +211,28 @@
 
 .trafficTile {
   grid-column: 1;
-  min-height: 0;
-  padding: 0;
-  border: none;
-  background: transparent;
-  box-shadow: none;
 }
 
-.trafficTitle {
+.mockTile {
+  min-height: 112px;
+  border: 1px solid color-mix(in srgb, var(--sys-line-soft) 55%, transparent);
+  background: color-mix(in srgb, var(--sys-bg-2) 70%, transparent);
+  padding: 14px 12px;
+}
+
+.mockTile p {
   margin: 0;
-  font-size: 0.66rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
   color: var(--sys-text-3);
-}
-
-.pieWrap {
-  display: grid;
-  place-items: center;
-}
-
-.pieSvg {
-  width: 66px;
-  height: 66px;
-}
-
-.legend {
-  display: grid;
-  gap: 3px;
-}
-
-.pieCenterLabel {
-  fill: var(--sys-text-2);
-  font-size: 6px;
-  letter-spacing: 0.12em;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  text-anchor: middle;
-  dominant-baseline: middle;
-  font-family: "Roboto Mono", ui-monospace, Menlo, monospace;
+  letter-spacing: 0.06em;
 }
 
-.pieCenterValue {
-  fill: var(--sys-text-1);
-  font-size: 10px;
-  font-weight: 620;
-  text-anchor: middle;
-  dominant-baseline: middle;
-}
-
-.legendRow {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  color: var(--sys-text-2);
-  font-size: 0.64rem;
-  line-height: 1.1;
-  column-gap: 8px;
-}
-
-.legendLabel {
-  display: inline-flex;
-  align-items: center;
-  color: var(--sys-text-3);
-}
-
-.legendSwatch {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  margin-right: 5px;
-  display: inline-block;
+.mockTile strong {
+  display: block;
+  margin-top: 8px;
+  color: var(--sys-text-1);
+  font-size: 1.25rem;
 }
 
 .wireSvg {
@@ -300,59 +245,43 @@
 }
 
 .busLine {
-  stroke: color-mix(in srgb, var(--sys-line) 82%, transparent);
-  stroke-width: 2;
+  stroke: color-mix(in srgb, #2e4b77 72%, transparent);
+  stroke-width: 1.8;
   fill: none;
-  shape-rendering: geometricPrecision;
 }
 
 .connectorLine {
-  stroke: color-mix(in srgb, var(--sys-line) 74%, transparent);
-  stroke-width: 1.4;
+  stroke: color-mix(in srgb, #3c608f 68%, transparent);
+  stroke-width: 1.3;
   fill: none;
-  shape-rendering: crispEdges;
 }
 
 .beamRoute {
-  stroke: rgba(95, 162, 230, 0.58);
-  stroke-width: 1.8;
+  stroke-width: 1.6;
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-dasharray: 8 72;
-  filter: drop-shadow(0 0 4px rgba(92, 164, 236, 0.34));
-  opacity: 0.72;
+  stroke-dasharray: 12 92;
+  filter: drop-shadow(0 0 3px rgba(64, 122, 192, 0.25));
+  opacity: 0.52;
 }
 
 .beamFromNode {
-  animation: beam-forward 3.2s linear infinite, beam-flicker 4.2s ease-in-out infinite;
+  animation: beam-forward 4.8s linear infinite;
 }
 
 .beamToNode {
-  animation: beam-reverse 3.2s linear infinite, beam-flicker 4.2s ease-in-out infinite;
+  animation: beam-reverse 4.8s linear infinite;
 }
-
 
 @keyframes beam-forward {
   from { stroke-dashoffset: 0; }
-  to { stroke-dashoffset: -160; }
+  to { stroke-dashoffset: -208; }
 }
 
 @keyframes beam-reverse {
   from { stroke-dashoffset: 0; }
-  to { stroke-dashoffset: 160; }
-}
-
-@keyframes beam-flicker {
-  0%, 100% { opacity: 0.56; }
-  45% { opacity: 0.76; }
-  65% { opacity: 0.66; }
-}
-
-
-.tapMark {
-  fill: color-mix(in srgb, var(--sys-line) 96%, transparent);
-  stroke: none;
+  to { stroke-dashoffset: 208; }
 }
 
 .errorNote {
@@ -365,13 +294,8 @@
   .preview {
     width: min(920px, 100%);
     --kpi-col: 214px;
-    --kpi-min: var(--kpi-col);
-    --kpi-max: var(--kpi-col);
     --topo-gap-col: 14px;
     --topo-gap-row: 7px;
-    --top-to-bus: 38px;
-    --lower-connector-inset: 6px;
-    --bus-to-bottom: 28px;
     --mid-span: 50px;
   }
 
@@ -420,16 +344,12 @@
     border-top: 1px solid var(--sys-line-soft);
     border-bottom: 1px solid var(--sys-line-soft);
     padding: 8px 0;
-    min-height: 0;
   }
 }
-
 
 @media (prefers-reduced-motion: reduce) {
   .beamFromNode,
   .beamToNode {
     animation: none;
   }
-
-
 }

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -68,6 +68,17 @@
   width: 100%;
 }
 
+.preview :global(.dashboard-v2__kpi-tile),
+.preview :global(.dashboard-v2__kpi-content),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-tile),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-content),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-content--vrm),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel-header) {
+  border: none !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+
 .wireEdgeAnchor {
   position: absolute;
   left: 50%;
@@ -137,8 +148,8 @@
   background: color-mix(in srgb, var(--sys-bg-2) 70%, transparent);
   grid-column: 4;
   grid-row: 2;
-  width: calc(100% - 10px);
-  justify-self: center;
+  width: 100%;
+  justify-self: stretch;
   min-height: 62px;
   max-height: 62px;
   padding: 6px 9px;

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -4,7 +4,7 @@
   --topo-gap-row: 8px;
   --kpi-min: var(--kpi-col);
   --kpi-max: var(--kpi-col);
-  --top-anchor-inset: 2px;
+  --top-anchor-outset: 2px;
   --bottom-anchor-inset: 14px;
   --mid-span: 56px;
 
@@ -78,7 +78,7 @@
 }
 
 .wireEdgeAnchorBottom {
-  bottom: var(--top-anchor-inset);
+  bottom: calc(var(--top-anchor-outset) * -1);
 }
 
 .wireEdgeAnchorTop {
@@ -253,18 +253,18 @@
 
 .connectorLine {
   stroke: color-mix(in srgb, #3c608f 68%, transparent);
-  stroke-width: 1.3;
+  stroke-width: 1.45;
   fill: none;
 }
 
 .beamRoute {
-  stroke-width: 1.6;
+  stroke-width: 2;
   fill: none;
   stroke-linecap: round;
   stroke-linejoin: round;
-  stroke-dasharray: 12 92;
-  filter: drop-shadow(0 0 3px rgba(64, 122, 192, 0.25));
-  opacity: 0.52;
+  stroke-dasharray: 14 86;
+  filter: drop-shadow(0 0 3px rgba(64, 122, 192, 0.32));
+  opacity: 0.72;
 }
 
 .beamRoute {

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -86,6 +86,21 @@
   background: transparent !important;
 }
 
+.preview :global(.dashboard-v2__kpi-renderer .kpi-footer),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-footer-reserve) {
+  display: none !important;
+}
+
+.preview :global(.dashboard-v2__kpi-renderer .kpi-panel--footer-open) {
+  border-bottom-left-radius: var(--vrm-radii-card, 12px) !important;
+  border-bottom-right-radius: var(--vrm-radii-card, 12px) !important;
+}
+
+.preview :global(.dashboard-v2__kpi-renderer .kpi-sparkline-strip--vrm) {
+  border-top: none !important;
+  background: transparent !important;
+}
+
 .wireEdgeAnchor {
   position: absolute;
   left: 50%;

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -116,6 +116,13 @@
   background: transparent !important;
 }
 
+.preview :global(.dashboard-v2__kpi-renderer .kpi-value),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-sparkline-region--vrm),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-sparkline-plot),
+.preview :global(.dashboard-v2__kpi-renderer .kpi-sparkline--vrm) {
+  filter: saturate(0.8) brightness(0.8);
+}
+
 .wireEdgeAnchor {
   position: absolute;
   left: 50%;
@@ -192,7 +199,7 @@
   padding: 6px 9px;
   box-sizing: border-box;
   display: grid;
-  grid-template-rows: auto auto auto;
+  grid-template-rows: auto auto;
   gap: 3px;
 }
 
@@ -355,7 +362,7 @@
   .canvas {
     min-height: 0;
     row-gap: 10px;
-    grid-template-rows: auto auto auto;
+    grid-template-rows: auto auto;
     padding: 0;
   }
 

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -137,9 +137,12 @@
   background: color-mix(in srgb, var(--sys-bg-2) 70%, transparent);
   grid-column: 4;
   grid-row: 2;
-  min-height: 72px;
-  max-height: 72px;
-  padding: 8px 10px;
+  width: calc(100% - 10px);
+  justify-self: center;
+  min-height: 62px;
+  max-height: 62px;
+  padding: 6px 9px;
+  box-sizing: border-box;
   display: grid;
   grid-template-rows: auto auto auto;
   gap: 3px;
@@ -159,7 +162,7 @@
 }
 
 .capacityTrack {
-  height: 10px;
+  height: 8px;
   border-radius: 999px;
   background: linear-gradient(180deg, color-mix(in srgb, var(--sys-line-soft) 92%, transparent), color-mix(in srgb, var(--sys-line-soft) 76%, transparent));
   overflow: hidden;

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -194,18 +194,22 @@
   grid-row: 2;
   width: 100%;
   justify-self: stretch;
-  min-height: 62px;
-  max-height: 62px;
-  padding: 6px 9px;
+  min-height: 44px;
+  max-height: 44px;
+  padding: 6px 9px 5px;
   box-sizing: border-box;
   display: grid;
   grid-template-rows: auto auto;
-  gap: 3px;
+  gap: 4px;
 }
 
 .capacityLabel,
 .capacityMeta {
   margin: 0;
+}
+
+.capacityMeta {
+  display: none;
 }
 
 .capacityLabel {
@@ -216,8 +220,24 @@
   color: var(--sys-text-3);
 }
 
+.capacityHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.capacityValue {
+  margin: 0;
+  color: var(--sys-text-1);
+  font-size: 0.78rem;
+  line-height: 1;
+  font-weight: 620;
+}
+
+
 .capacityTrack {
-  height: 8px;
+  height: 6px;
   border-radius: 999px;
   background: linear-gradient(180deg, color-mix(in srgb, var(--sys-line-soft) 92%, transparent), color-mix(in srgb, var(--sys-line-soft) 76%, transparent));
   overflow: hidden;

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -15,6 +15,8 @@ import "../../dashboard/styles/DashboardPage.css";
 import styles from "./SystemOverviewPreview.module.css";
 
 type TopTileId = "entrances" | "occupancy" | "exits" | "footfall";
+type RouteId = "entrances" | "occupancy" | "exits" | "traffic" | "dwell";
+type FlowDirection = "toNode" | "fromNode";
 
 type WireLayout = {
   width: number;
@@ -22,11 +24,14 @@ type WireLayout = {
   busY: number;
   busX1: number;
   busX2: number;
-  taps: number[];
-  connectedBottomY: number[];
-  leftTopY: number;
-  rightTopY: number;
   nodeX: number;
+  taps: Record<RouteId, number>;
+  endpointsY: Record<RouteId, number>;
+};
+
+type RouteDefinition = {
+  id: RouteId;
+  direction: FlowDirection;
 };
 
 const TOP_TILES: Array<{ key: TopTileId; widgetId: string; slotClass: string }> = [
@@ -37,10 +42,19 @@ const TOP_TILES: Array<{ key: TopTileId; widgetId: string; slotClass: string }> 
 ];
 
 const CONNECTED_TOP_IDS: TopTileId[] = ["entrances", "occupancy", "exits"];
+const FLOW_ROUTE_DEFINITIONS: RouteDefinition[] = [
+  { id: "entrances", direction: "toNode" },
+  { id: "occupancy", direction: "fromNode" },
+  { id: "exits", direction: "toNode" },
+  { id: "traffic", direction: "fromNode" },
+  { id: "dwell", direction: "fromNode" },
+];
+
 const CAPACITY_PERCENT = 68;
 const NOOP_REMOVE = () => undefined;
 const PREVIEW_CREDENTIALS: Credentials = { username: "", password: "" };
 const LANDING_BOOTSTRAP_KEY = "landing_demo_bootstrap_done";
+const TOPOLOGY_MOCK_PARAM = "topologyMock";
 
 const initialWireLayout: WireLayout = {
   width: 0,
@@ -48,20 +62,12 @@ const initialWireLayout: WireLayout = {
   busY: 0,
   busX1: 0,
   busX2: 0,
-  taps: [0, 0, 0, 0, 0],
-  connectedBottomY: [0, 0, 0],
-  leftTopY: 0,
-  rightTopY: 0,
   nodeX: 0,
+  taps: { entrances: 0, occupancy: 0, exits: 0, traffic: 0, dwell: 0 },
+  endpointsY: { entrances: 0, occupancy: 0, exits: 0, traffic: 0, dwell: 0 },
 };
 
-
-const parseCssPx = (value: string, fallback: number) => {
-  const parsed = Number.parseFloat(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-};
-
-const SystemOverviewLiveKpis: React.FC = () => {
+const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forceMockTopology }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const topClusterRef = useRef<HTMLDivElement | null>(null);
   const bottomClusterRef = useRef<HTMLDivElement | null>(null);
@@ -71,17 +77,18 @@ const SystemOverviewLiveKpis: React.FC = () => {
     exits: null,
     footfall: null,
   });
-  const topAnchorRefs = useRef<Record<TopTileId, HTMLDivElement | null>>({
+  const topEdgeRefs = useRef<Record<TopTileId, HTMLSpanElement | null>>({
     entrances: null,
     occupancy: null,
     exits: null,
     footfall: null,
   });
+  const leftSlotRef = useRef<HTMLDivElement | null>(null);
+  const leftEdgeRef = useRef<HTMLSpanElement | null>(null);
   const dwellSlotRef = useRef<HTMLDivElement | null>(null);
-  const dwellAnchorRef = useRef<HTMLDivElement | null>(null);
-  const leftRef = useRef<HTMLDivElement | null>(null);
-  const leftAnchorRef = useRef<HTMLDivElement | null>(null);
-  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const dwellEdgeRef = useRef<HTMLSpanElement | null>(null);
+  const nodeAnchorRef = useRef<HTMLSpanElement | null>(null);
+  const rafRef = useRef<number | null>(null);
   const [wire, setWire] = useState<WireLayout>(initialWireLayout);
 
   const {
@@ -110,10 +117,7 @@ const SystemOverviewLiveKpis: React.FC = () => {
     setManifest,
   });
 
-  const kpiLookup = useMemo(
-    () => new Map(kpiWidgets.map((item) => [item.widget.id, item])),
-    [kpiWidgets],
-  );
+  const kpiLookup = useMemo(() => new Map(kpiWidgets.map((item) => [item.widget.id, item])), [kpiWidgets]);
 
   const topWidgets = TOP_TILES.map((tile) => ({
     ...tile,
@@ -122,146 +126,160 @@ const SystemOverviewLiveKpis: React.FC = () => {
   const hasTopWidgets = topWidgets.every((item) => Boolean(item.widget));
   const dwellWidget = kpiLookup.get(VRM_KPI_IDS.dwell) ?? null;
   const trafficWidget = kpiLookup.get(VRM_KPI_IDS.traffic) ?? null;
+  const hasKpis = forceMockTopology || (hasTopWidgets && Boolean(dwellWidget) && Boolean(trafficWidget));
+  const hasError = manifestStatus === "error" || widgetStatus === "error";
 
   useLayoutEffect(() => {
-    const update = () => {
-      if (
-        !containerRef.current ||
-        !topClusterRef.current ||
-        !bottomClusterRef.current ||
-        !leftRef.current ||
-        !dwellSlotRef.current ||
-        !nodeRef.current
-      ) {
-        return;
+    const scheduleMeasure = () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
       }
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        if (
+          !containerRef.current ||
+          !topClusterRef.current ||
+          !bottomClusterRef.current ||
+          !leftSlotRef.current ||
+          !dwellSlotRef.current ||
+          !nodeAnchorRef.current
+        ) {
+          return;
+        }
 
-      const topAnchorsById = Object.fromEntries(
-        TOP_TILES.map(({ key }) => [key, topAnchorRefs.current[key]]),
-      ) as Record<TopTileId, HTMLDivElement | null>;
+        const connectedTopEdges = CONNECTED_TOP_IDS.map((id) => topEdgeRefs.current[id]);
+        if (connectedTopEdges.some((edge) => !edge) || !leftEdgeRef.current || !dwellEdgeRef.current) {
+          return;
+        }
 
-      const connectedTopAnchors = CONNECTED_TOP_IDS.map((id) => topAnchorsById[id]);
-      if (connectedTopAnchors.some((anchor) => !anchor) || !leftAnchorRef.current || !dwellAnchorRef.current) {
-        return;
-      }
+        const containerRect = containerRef.current.getBoundingClientRect();
+        const nodeRect = nodeAnchorRef.current.getBoundingClientRect();
+        const topRects = connectedTopEdges.map((edge) => (edge as HTMLSpanElement).getBoundingClientRect());
+        const trafficRect = leftEdgeRef.current.getBoundingClientRect();
+        const dwellRect = dwellEdgeRef.current.getBoundingClientRect();
 
-      const container = containerRef.current.getBoundingClientRect();
-      const topCluster = topClusterRef.current.getBoundingClientRect();
-      const leftAnchor = leftAnchorRef.current.getBoundingClientRect();
-      const rightAnchor = dwellAnchorRef.current.getBoundingClientRect();
-      const node = nodeRef.current.getBoundingClientRect();
+        const taps: Record<RouteId, number> = {
+          entrances: topRects[0].left - containerRect.left + topRects[0].width / 2,
+          occupancy: topRects[1].left - containerRect.left + topRects[1].width / 2,
+          exits: topRects[2].left - containerRect.left + topRects[2].width / 2,
+          traffic: trafficRect.left - containerRect.left + trafficRect.width / 2,
+          dwell: dwellRect.left - containerRect.left + dwellRect.width / 2,
+        };
 
-      const computed = window.getComputedStyle(containerRef.current);
-      const topToBus = parseCssPx(computed.getPropertyValue("--top-to-bus"), 56);
-      const lowerConnectorInset = parseCssPx(computed.getPropertyValue("--lower-connector-inset"), 8);
-
-      const busY = topCluster.bottom - container.top + topToBus;
-
-      const connectedBottomY = connectedTopAnchors.map((anchor) => (anchor as HTMLDivElement).getBoundingClientRect().bottom - container.top);
-      const taps = [
-        ...connectedTopAnchors.map((anchor) => {
-          const rect = (anchor as HTMLDivElement).getBoundingClientRect();
-          return rect.left - container.left + rect.width / 2;
-        }),
-        leftAnchor.left - container.left + leftAnchor.width / 2,
-        rightAnchor.left - container.left + rightAnchor.width / 2,
-      ];
-      const busX1 = Math.min(...taps);
-      const busX2 = Math.max(...taps);
-
-      const lowerLeftAnchorY = leftAnchor.top - container.top + lowerConnectorInset;
-      const lowerRightAnchorY = rightAnchor.top - container.top + lowerConnectorInset;
-
-      setWire({
-        width: container.width,
-        height: container.height,
-        busY,
-        busX1,
-        busX2,
-        taps,
-        connectedBottomY,
-        leftTopY: lowerLeftAnchorY,
-        rightTopY: lowerRightAnchorY,
-        nodeX: node.left - container.left + node.width / 2,
+        setWire({
+          width: containerRect.width,
+          height: containerRect.height,
+          busY: nodeRect.top - containerRect.top + nodeRect.height / 2,
+          busX1: Math.min(...Object.values(taps)),
+          busX2: Math.max(...Object.values(taps)),
+          nodeX: nodeRect.left - containerRect.left + nodeRect.width / 2,
+          taps,
+          endpointsY: {
+            entrances: topRects[0].top - containerRect.top + topRects[0].height / 2,
+            occupancy: topRects[1].top - containerRect.top + topRects[1].height / 2,
+            exits: topRects[2].top - containerRect.top + topRects[2].height / 2,
+            traffic: trafficRect.top - containerRect.top + trafficRect.height / 2,
+            dwell: dwellRect.top - containerRect.top + dwellRect.height / 2,
+          },
+        });
       });
     };
 
-    update();
-    const observer = new ResizeObserver(update);
+    scheduleMeasure();
+
+    const observer = new ResizeObserver(() => scheduleMeasure());
     if (containerRef.current) observer.observe(containerRef.current);
     if (topClusterRef.current) observer.observe(topClusterRef.current);
     if (bottomClusterRef.current) observer.observe(bottomClusterRef.current);
+    if (nodeAnchorRef.current) observer.observe(nodeAnchorRef.current);
     TOP_TILES.forEach(({ key }) => {
       const slot = topSlotRefs.current[key];
+      const edge = topEdgeRefs.current[key];
       if (slot) observer.observe(slot);
+      if (edge) observer.observe(edge);
     });
+    if (leftSlotRef.current) observer.observe(leftSlotRef.current);
+    if (leftEdgeRef.current) observer.observe(leftEdgeRef.current);
     if (dwellSlotRef.current) observer.observe(dwellSlotRef.current);
-    if (dwellAnchorRef.current) observer.observe(dwellAnchorRef.current);
-    if (leftRef.current) observer.observe(leftRef.current);
-    if (leftAnchorRef.current) observer.observe(leftAnchorRef.current);
-    if (nodeRef.current) observer.observe(nodeRef.current);
-    window.addEventListener("resize", update);
+    if (dwellEdgeRef.current) observer.observe(dwellEdgeRef.current);
+    window.addEventListener("resize", scheduleMeasure);
 
     return () => {
       observer.disconnect();
-      window.removeEventListener("resize", update);
+      window.removeEventListener("resize", scheduleMeasure);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
     };
-  }, [hasTopWidgets, dwellWidget, trafficWidget]);
+  }, [forceMockTopology, hasTopWidgets, dwellWidget, trafficWidget]);
 
-  const hasKpis = hasTopWidgets && Boolean(dwellWidget);
-  const hasError = manifestStatus === "error" || widgetStatus === "error";
   const nodeX = wire.nodeX || (wire.busX1 + (wire.busX2 - wire.busX1) / 2);
+  const flowRoutes = useMemo(
+    () =>
+      FLOW_ROUTE_DEFINITIONS.map((route) => {
+        const tapX = wire.taps[route.id];
+        const endpointY = wire.endpointsY[route.id];
+        const isToNode = route.direction === "toNode";
+        const sourceX = isToNode ? tapX : nodeX;
+        const sourceY = isToNode ? endpointY : wire.busY;
+        const targetX = isToNode ? nodeX : tapX;
+        const targetY = isToNode ? wire.busY : endpointY;
+        return {
+          ...route,
+          d: `M ${sourceX} ${sourceY} L ${tapX} ${wire.busY} L ${targetX} ${targetY}`,
+          gradientId: `topology-gradient-${route.id}`,
+        };
+      }),
+    [nodeX, wire],
+  );
 
-  // Keep the topology animation dash-only (no moving dot/arrow heads),
-  // while preserving explicit per-route direction semantics.
-  const flowRoutes = useMemo(() => ([
-    {
-      id: "entrances",
-      d: `M ${nodeX} ${wire.busY} L ${wire.taps[0]} ${wire.busY} L ${wire.taps[0]} ${wire.connectedBottomY[0]}`,
-      direction: "fromNode" as const,
-    },
-    {
-      id: "occupancy",
-      d: `M ${nodeX} ${wire.busY} L ${wire.taps[1]} ${wire.busY} L ${wire.taps[1]} ${wire.connectedBottomY[1]}`,
-      direction: "fromNode" as const,
-    },
-    {
-      id: "exits",
-      d: `M ${nodeX} ${wire.busY} L ${wire.taps[2]} ${wire.busY} L ${wire.taps[2]} ${wire.connectedBottomY[2]}`,
-      direction: "fromNode" as const,
-    },
-    {
-      id: "traffic",
-      d: `M ${nodeX} ${wire.busY} L ${wire.taps[3]} ${wire.busY} L ${wire.taps[3]} ${wire.leftTopY}`,
-      direction: "fromNode" as const,
-    },
-    {
-      id: "dwell",
-      d: `M ${nodeX} ${wire.busY} L ${wire.taps[4]} ${wire.busY} L ${wire.taps[4]} ${wire.rightTopY}`,
-      direction: "fromNode" as const,
-    },
-  ]), [nodeX, wire]);
+  const renderMockTile = (label: string, value: string) => (
+    <article className={styles.mockTile}>
+      <p>{label}</p>
+      <strong>{value}</strong>
+    </article>
+  );
 
   return (
     <section className={styles.preview} aria-label="System overview topology preview">
-      <div className={styles.canvas} ref={containerRef}>
+      <div className={styles.canvas} ref={containerRef} data-topology-mock={forceMockTopology ? "true" : "false"}>
         {wire.width > 0 && wire.height > 0 ? (
           <svg className={styles.wireSvg} width={wire.width} height={wire.height} viewBox={`0 0 ${wire.width} ${wire.height}`} aria-hidden="true">
-            <line className={styles.busLine} x1={wire.busX1} y1={wire.busY} x2={wire.busX2} y2={wire.busY} />
-            <line className={styles.connectorLine} x1={wire.taps[0]} y1={wire.connectedBottomY[0]} x2={wire.taps[0]} y2={wire.busY} />
-            <line className={styles.connectorLine} x1={wire.taps[1]} y1={wire.connectedBottomY[1]} x2={wire.taps[1]} y2={wire.busY} />
-            <line className={styles.connectorLine} x1={wire.taps[2]} y1={wire.connectedBottomY[2]} x2={wire.taps[2]} y2={wire.busY} />
-            <line className={styles.connectorLine} x1={wire.taps[3]} y1={wire.leftTopY} x2={wire.taps[3]} y2={wire.busY} />
-            <line className={styles.connectorLine} x1={wire.taps[4]} y1={wire.rightTopY} x2={wire.taps[4]} y2={wire.busY} />
+            <line className={styles.busLine} data-testid="topology-bus" x1={wire.busX1} y1={wire.busY} x2={wire.busX2} y2={wire.busY} />
+            {FLOW_ROUTE_DEFINITIONS.map((route) => (
+              <line
+                key={`connector-${route.id}`}
+                className={styles.connectorLine}
+                data-route-id={route.id}
+                x1={wire.taps[route.id]}
+                y1={wire.endpointsY[route.id]}
+                x2={wire.taps[route.id]}
+                y2={wire.busY}
+              />
+            ))}
+            <defs>
+              {flowRoutes.map((route) => {
+                const isToNode = route.direction === "toNode";
+                const x1 = isToNode ? wire.taps[route.id] : nodeX;
+                const x2 = isToNode ? nodeX : wire.taps[route.id];
+                return (
+                  <linearGradient key={route.gradientId} id={route.gradientId} gradientUnits="userSpaceOnUse" x1={x1} y1={wire.busY} x2={x2} y2={wire.busY}>
+                    <stop offset="0%" stopColor="rgba(138, 188, 248, 0.68)" />
+                    <stop offset="100%" stopColor="rgba(42, 86, 148, 0.24)" />
+                  </linearGradient>
+                );
+              })}
+            </defs>
             {flowRoutes.map((route) => (
               <path
                 key={route.id}
+                data-route-id={route.id}
+                data-direction={route.direction}
                 className={`${styles.beamRoute} ${route.direction === "toNode" ? styles.beamToNode : styles.beamFromNode}`}
+                style={{ stroke: `url(#${route.gradientId})` }}
                 d={route.d}
               />
-            ))}
-            {wire.taps.map((tap, index) => (
-              <circle key={`tap-${index}`} className={styles.tapMark} cx={tap} cy={wire.busY} r="3" />
             ))}
           </svg>
         ) : null}
@@ -276,13 +294,17 @@ const SystemOverviewLiveKpis: React.FC = () => {
                   topSlotRefs.current[item.key] = node;
                 }}
               >
-                <div
-                  className={styles.wireAnchor}
-                  ref={(node) => {
-                    topAnchorRefs.current[item.key] = node;
-                  }}
-                >
-                  <DashboardKpiSection mode="preview" kpiWidgets={[item.widget!]} onRemoveWidget={NOOP_REMOVE} />
+                <div className={styles.wireAnchorSlot}>
+                  {forceMockTopology
+                    ? renderMockTile(item.key, item.key === "occupancy" ? "67%" : "2,481")
+                    : <DashboardKpiSection mode="preview" kpiWidgets={[item.widget!]} onRemoveWidget={NOOP_REMOVE} />}
+                  <span
+                    className={`${styles.wireEdgeAnchor} ${styles.wireEdgeAnchorBottom}`}
+                    data-anchor-id={`top-${item.key}`}
+                    ref={(node) => {
+                      topEdgeRefs.current[item.key] = node;
+                    }}
+                  />
                 </div>
               </div>
             ))
@@ -300,14 +322,17 @@ const SystemOverviewLiveKpis: React.FC = () => {
         </div>
 
         <div className={styles.midZone}>
-          <div className={styles.node} ref={nodeRef}>camOS<span className={styles.nodeSub}>System Sheet</span></div>
+          <div className={styles.node}>camOS<span className={styles.nodeSub}>System Sheet</span><span className={styles.nodeAnchor} ref={nodeAnchorRef} /></div>
         </div>
 
         <div className={styles.bottomCluster} ref={bottomClusterRef}>
-          <article className={styles.trafficTile} ref={leftRef}>
-            {trafficWidget ? (
-              <div className={styles.wireAnchor} ref={leftAnchorRef}>
-                <DashboardKpiSection mode="preview" kpiWidgets={[trafficWidget]} onRemoveWidget={NOOP_REMOVE} />
+          <article className={styles.trafficTile}>
+            {trafficWidget || forceMockTopology ? (
+              <div className={styles.wireAnchorSlot} ref={leftSlotRef}>
+                {forceMockTopology
+                  ? renderMockTile("Traffic Split", "41/34/25")
+                  : <DashboardKpiSection mode="preview" kpiWidgets={[trafficWidget!]} onRemoveWidget={NOOP_REMOVE} />}
+                <span className={`${styles.wireEdgeAnchor} ${styles.wireEdgeAnchorTop}`} data-anchor-id="bottom-traffic" ref={leftEdgeRef} />
               </div>
             ) : hasError ? (
               <div className={styles.inlineNotice}>Preview unavailable.</div>
@@ -316,10 +341,13 @@ const SystemOverviewLiveKpis: React.FC = () => {
             )}
           </article>
 
-          <div className={`${styles.kpiSlot} ${styles.tileT5}`} ref={dwellSlotRef}>
-            {dwellWidget ? (
-              <div className={styles.wireAnchor} ref={dwellAnchorRef}>
-                <DashboardKpiSection mode="preview" kpiWidgets={[dwellWidget]} onRemoveWidget={NOOP_REMOVE} />
+          <div className={`${styles.kpiSlot} ${styles.tileT5}`}>
+            {dwellWidget || forceMockTopology ? (
+              <div className={styles.wireAnchorSlot} ref={dwellSlotRef}>
+                {forceMockTopology
+                  ? renderMockTile("Dwell Minutes", "18.2")
+                  : <DashboardKpiSection mode="preview" kpiWidgets={[dwellWidget!]} onRemoveWidget={NOOP_REMOVE} />}
+                <span className={`${styles.wireEdgeAnchor} ${styles.wireEdgeAnchorTop}`} data-anchor-id="bottom-dwell" ref={dwellEdgeRef} />
               </div>
             ) : hasError ? (
               <div className={styles.inlineNotice}>Preview unavailable.</div>
@@ -338,13 +366,19 @@ const SystemOverviewLiveKpis: React.FC = () => {
 
 const SystemOverviewPreview: React.FC = () => {
   const location = useLocation();
+  const forceMockTopology = useMemo(() => {
+    if (!import.meta.env.DEV && !import.meta.env.MODE.includes("test")) {
+      return false;
+    }
+    return new URLSearchParams(location.search).get(TOPOLOGY_MOCK_PARAM) === "1";
+  }, [location.search]);
   const hasViewToken = Boolean(getViewTokenFromLocation(location.search));
   const isLoggedIn = typeof window !== "undefined" && Boolean(window.sessionStorage.getItem("camOS_credentials"));
   const [bootstrapState, setBootstrapState] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const bootstrapStartedRef = useRef(false);
 
   const runBootstrap = async () => {
-    if (isLoggedIn || hasViewToken || isDemoSessionActive()) {
+    if (forceMockTopology || isLoggedIn || hasViewToken || isDemoSessionActive()) {
       setBootstrapState("ready");
       return;
     }
@@ -373,7 +407,7 @@ const SystemOverviewPreview: React.FC = () => {
     }
     bootstrapStartedRef.current = true;
     void runBootstrap();
-  }, [hasViewToken, isLoggedIn]);
+  }, [hasViewToken, isLoggedIn, forceMockTopology]);
 
   const handleRetry = () => {
     if (typeof window !== "undefined") {
@@ -384,10 +418,7 @@ const SystemOverviewPreview: React.FC = () => {
   };
 
   useEffect(() => {
-    if (bootstrapState !== "idle") {
-      return;
-    }
-    if (bootstrapStartedRef.current) {
+    if (bootstrapState !== "idle" || bootstrapStartedRef.current) {
       return;
     }
     bootstrapStartedRef.current = true;
@@ -408,7 +439,7 @@ const SystemOverviewPreview: React.FC = () => {
     );
   }
 
-  return <SystemOverviewLiveKpis />;
+  return <SystemOverviewLiveKpis forceMockTopology={forceMockTopology} />;
 };
 
 export default SystemOverviewPreview;

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -276,7 +276,7 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
                 key={route.id}
                 data-route-id={route.id}
                 data-direction={route.direction}
-                className={`${styles.beamRoute} ${route.direction === "toNode" ? styles.beamToNode : styles.beamFromNode}`}
+                className={styles.beamRoute}
                 style={{ stroke: `url(#${route.gradientId})` }}
                 d={route.d}
               />

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -316,7 +316,6 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
           )}
 
           <article className={styles.capacityTile}>
-            <p className={styles.capacityLabel}>Capacity</p>
             <div className={styles.capacityTrack}><div className={styles.capacityFill} style={{ width: `${CAPACITY_PERCENT}%` }} /></div>
             <p className={styles.capacityMeta}>{CAPACITY_PERCENT}% active capacity</p>
           </article>

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -316,8 +316,11 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
           )}
 
           <article className={styles.capacityTile}>
+            <div className={styles.capacityHeaderRow}>
+              <p className={styles.capacityLabel}>Capacity</p>
+              <p className={styles.capacityValue}>{CAPACITY_PERCENT}%</p>
+            </div>
             <div className={styles.capacityTrack}><div className={styles.capacityFill} style={{ width: `${CAPACITY_PERCENT}%` }} /></div>
-            <p className={styles.capacityMeta}>{CAPACITY_PERCENT}% active capacity</p>
           </article>
         </div>
 

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -265,8 +265,9 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
                 const x2 = isToNode ? nodeX : wire.taps[route.id];
                 return (
                   <linearGradient key={route.gradientId} id={route.gradientId} gradientUnits="userSpaceOnUse" x1={x1} y1={wire.busY} x2={x2} y2={wire.busY}>
-                    <stop offset="0%" stopColor="rgba(138, 188, 248, 0.68)" />
-                    <stop offset="100%" stopColor="rgba(42, 86, 148, 0.24)" />
+                    <stop offset="0%" stopColor="rgba(136, 188, 252, 0.78)" />
+                    <stop offset="58%" stopColor="rgba(97, 159, 236, 0.56)" />
+                    <stop offset="100%" stopColor="rgba(136, 188, 252, 0.78)" />
                   </linearGradient>
                 );
               })}


### PR DESCRIPTION
### Motivation

- The landing "Live Platform Preview" topology previously anchored wires to KPI internals which caused incorrect flow directions, dangling bus ends, and fragile visuals under live/demo timing and layout shifts.
- The change introduces a deterministic anchor + routing system so flow direction rules and connector termination are always visually correct and robust to late renders and responsive breakpoints.

### Description

- Introduced dedicated anchor elements and measurement plumbing and moved all geometry to use those anchors only, measured via `ResizeObserver` + `requestAnimationFrame` batching (files changed: `SystemOverviewPreview.tsx`, CSS module). 
- Replaced segment-by-segment routing with a deterministic single-path route builder and explicit route map implementing required direction rules (Entrances/Exits → `toNode`; Occupancy/Traffic/Dwell → `fromNode`).
- Ensured bus endpoints are clipped to the min/max tap X (removes hanging ends) and lower connectors terminate at controlled anchors on the visible card edge with a small inset.
- Tuned visuals to dash-only, lower-frequency/longer-duration subtle animation in dark-blue tones, removed dot markers, and preserved `prefers-reduced-motion` support.
- Added a deterministic dev/test mode (`?topologyMock=1`) and a Playwright verification script at `frontend/scripts/topology-check.mjs`, plus an npm script `verify:topology` and Playwright dev dependency for repeatable assertions and screenshots.

### Testing

- Built the frontend with `cd frontend && npm run build`; build completed successfully.
- Installed Playwright and required browsers via `npx playwright install chromium` and `npx playwright install-deps chromium`; downloads and system deps installed successfully.
- Ran the automated topology assertions with `cd frontend && npm run verify:topology` against the deterministic mock mode; the script passed and reported: "Topology verification passed at 1440 and 1024.".
- The verification produced screenshots for manual review at `artifacts/topology-1440.png` and `artifacts/topology-1024.png` and a preview screenshot captured during the run.

Files of interest: `frontend/src/features/landing/components/SystemOverviewPreview.tsx`, `frontend/src/features/landing/components/SystemOverviewPreview.module.css`, `frontend/scripts/topology-check.mjs`, and `frontend/package.json` (script + devDependency additions).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69921c2bffc8832f9960a8db067e52c8)