### PR TITLE
Refactor landing system surface: equal-height Capabilities/Deployment and seamless preview seam

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "build": "vite build && if [ -d ../backend ]; then rm -rf ../backend/frontend_build && cp -R build ../backend/frontend_build; fi",
     "preview": "vite preview --host 0.0.0.0 --port 3000",
     "ci": "npm run build",
-    "verify:topology": "node scripts/topology-check.mjs"
+    "verify:topology": "node scripts/topology-check.mjs",
+    "test:landing-visual": "node scripts/landing-visual-regression.mjs"
   },
   "browserslist": {
     "production": [

--- a/frontend/scripts/landing-visual-regression.mjs
+++ b/frontend/scripts/landing-visual-regression.mjs
@@ -1,4 +1,4 @@
-import { chromium } from 'playwright';
+import { chromium, firefox } from 'playwright';
 import { spawn } from 'node:child_process';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
@@ -26,6 +26,25 @@ const waitForServer = async (url, timeoutMs = 30000) => {
   throw new Error(`Timed out waiting for ${url}`);
 };
 
+const launchFallbackBrowser = async () => {
+  const launchers = [
+    ['chromium', chromium],
+    ['firefox', firefox],
+  ];
+
+  const launchErrors = [];
+  for (const [name, launcher] of launchers) {
+    try {
+      const browser = await launcher.launch({ headless: true });
+      return { browser, browserName: name };
+    } catch (error) {
+      launchErrors.push(`${name}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  throw new Error(`Could not launch Playwright browsers. ${launchErrors.join(' | ')}`);
+};
+
 const server = spawn('npm', ['run', 'dev', '--', '--port', '4173'], {
   cwd: rootDir,
   stdio: 'inherit',
@@ -42,7 +61,7 @@ try {
   await mkdir(screenshotsDir, { recursive: true });
   await waitForServer('http://127.0.0.1:4173');
 
-  const browser = await chromium.launch({ headless: true });
+  const { browser, browserName } = await launchFallbackBrowser();
   const context = await browser.newContext();
   const alignmentResults = [];
 
@@ -61,17 +80,22 @@ try {
     const geometry = await page.evaluate(() => {
       const lastRow = document.querySelector('.landing-capability-row:last-child')?.getBoundingClientRect();
       const deploymentGroup = document.querySelector('.landing-deployment-rail')?.getBoundingClientRect();
-      if (!lastRow || !deploymentGroup) {
-        return { diffPx: null };
-      }
+      const capabilitiesAnchor = document.querySelector('[data-align-anchor="capabilities"]')?.getBoundingClientRect();
+      const deploymentAnchor = document.querySelector('[data-align-anchor="deployment"]')?.getBoundingClientRect();
+
       return {
-        capabilityBottom: Number(lastRow.bottom.toFixed(2)),
-        deploymentBottom: Number(deploymentGroup.bottom.toFixed(2)),
-        diffPx: Number(Math.abs(lastRow.bottom - deploymentGroup.bottom).toFixed(2)),
+        capabilityBottom: lastRow ? Number(lastRow.bottom.toFixed(2)) : null,
+        deploymentBottom: deploymentGroup ? Number(deploymentGroup.bottom.toFixed(2)) : null,
+        rowToRailDiffPx:
+          lastRow && deploymentGroup ? Number(Math.abs(lastRow.bottom - deploymentGroup.bottom).toFixed(2)) : null,
+        panelBottomDiffPx:
+          capabilitiesAnchor && deploymentAnchor
+            ? Number(Math.abs(capabilitiesAnchor.bottom - deploymentAnchor.bottom).toFixed(2))
+            : null,
       };
     });
 
-    alignmentResults.push({ viewport: viewport.name, ...geometry });
+    alignmentResults.push({ viewport: viewport.name, browser: browserName, ...geometry });
     await page.close();
   }
 
@@ -82,8 +106,14 @@ try {
   );
 
   const desktopResult = alignmentResults.find((result) => result.viewport === 'desktop');
-  if (!desktopResult || desktopResult.diffPx == null || desktopResult.diffPx > 2) {
-    throw new Error(`Desktop bottom alignment failed. Results: ${JSON.stringify(alignmentResults)}`);
+  if (
+    !desktopResult
+    || desktopResult.rowToRailDiffPx == null
+    || desktopResult.panelBottomDiffPx == null
+    || desktopResult.rowToRailDiffPx > 2
+    || desktopResult.panelBottomDiffPx > 2
+  ) {
+    throw new Error(`Desktop alignment failed. Results: ${JSON.stringify(alignmentResults)}`);
   }
 
   await browser.close();

--- a/frontend/scripts/landing-visual-regression.mjs
+++ b/frontend/scripts/landing-visual-regression.mjs
@@ -79,14 +79,14 @@ try {
 
     const geometry = await page.evaluate(() => {
       const lastRow = document.querySelector('.landing-capability-row:last-child')?.getBoundingClientRect();
-      const deploymentGroup = document.querySelector('.landing-deployment-rail')?.getBoundingClientRect();
+      const deploymentGroup = document.querySelector('.landing-deployment-zigzag')?.getBoundingClientRect();
       const capabilitiesAnchor = document.querySelector('[data-align-anchor="capabilities"]')?.getBoundingClientRect();
       const deploymentAnchor = document.querySelector('[data-align-anchor="deployment"]')?.getBoundingClientRect();
 
       return {
         capabilityBottom: lastRow ? Number(lastRow.bottom.toFixed(2)) : null,
         deploymentBottom: deploymentGroup ? Number(deploymentGroup.bottom.toFixed(2)) : null,
-        rowToRailDiffPx:
+        rowToDeploymentDiffPx:
           lastRow && deploymentGroup ? Number(Math.abs(lastRow.bottom - deploymentGroup.bottom).toFixed(2)) : null,
         panelBottomDiffPx:
           capabilitiesAnchor && deploymentAnchor
@@ -108,9 +108,9 @@ try {
   const desktopResult = alignmentResults.find((result) => result.viewport === 'desktop');
   if (
     !desktopResult
-    || desktopResult.rowToRailDiffPx == null
+    || desktopResult.rowToDeploymentDiffPx == null
     || desktopResult.panelBottomDiffPx == null
-    || desktopResult.rowToRailDiffPx > 2
+    || desktopResult.rowToDeploymentDiffPx > 2
     || desktopResult.panelBottomDiffPx > 2
   ) {
     throw new Error(`Desktop alignment failed. Results: ${JSON.stringify(alignmentResults)}`);

--- a/frontend/scripts/landing-visual-regression.mjs
+++ b/frontend/scripts/landing-visual-regression.mjs
@@ -83,6 +83,14 @@ try {
       const capabilitiesAnchor = document.querySelector('[data-align-anchor="capabilities"]')?.getBoundingClientRect();
       const deploymentAnchor = document.querySelector('[data-align-anchor="deployment"]')?.getBoundingClientRect();
 
+      const stepOne = document.querySelector('.landing-deployment-step--one')?.getBoundingClientRect();
+      const stepTwo = document.querySelector('.landing-deployment-step--two')?.getBoundingClientRect();
+      const stepThree = document.querySelector('.landing-deployment-step--three')?.getBoundingClientRect();
+      const deploymentStyle = document.querySelector('.landing-deployment-content')
+        ? getComputedStyle(document.querySelector('.landing-deployment-content'))
+        : null;
+      const deployXStep = deploymentStyle ? Number.parseFloat(deploymentStyle.getPropertyValue('--deploy-x-step')) : null;
+
       return {
         capabilityBottom: lastRow ? Number(lastRow.bottom.toFixed(2)) : null,
         deploymentBottom: deploymentGroup ? Number(deploymentGroup.bottom.toFixed(2)) : null,
@@ -92,6 +100,14 @@ try {
           capabilitiesAnchor && deploymentAnchor
             ? Number(Math.abs(capabilitiesAnchor.bottom - deploymentAnchor.bottom).toFixed(2))
             : null,
+        stepOneLeft: stepOne ? Number(stepOne.left.toFixed(2)) : null,
+        stepTwoLeft: stepTwo ? Number(stepTwo.left.toFixed(2)) : null,
+        stepThreeLeft: stepThree ? Number(stepThree.left.toFixed(2)) : null,
+        step1Step3DiffPx:
+          stepOne && stepThree ? Number(Math.abs(stepOne.left - stepThree.left).toFixed(2)) : null,
+        step2OffsetFromStep1Px:
+          stepOne && stepTwo ? Number((stepTwo.left - stepOne.left).toFixed(2)) : null,
+        deployXStep,
       };
     });
 
@@ -110,8 +126,13 @@ try {
     !desktopResult
     || desktopResult.rowToDeploymentDiffPx == null
     || desktopResult.panelBottomDiffPx == null
+    || desktopResult.step1Step3DiffPx == null
+    || desktopResult.step2OffsetFromStep1Px == null
+    || desktopResult.deployXStep == null
     || desktopResult.rowToDeploymentDiffPx > 2
     || desktopResult.panelBottomDiffPx > 2
+    || desktopResult.step1Step3DiffPx > 2
+    || desktopResult.step2OffsetFromStep1Px < (desktopResult.deployXStep - 2)
   ) {
     throw new Error(`Desktop alignment failed. Results: ${JSON.stringify(alignmentResults)}`);
   }

--- a/frontend/scripts/landing-visual-regression.mjs
+++ b/frontend/scripts/landing-visual-regression.mjs
@@ -81,6 +81,7 @@ try {
       const lastRow = document.querySelector('.landing-capability-row:last-child')?.getBoundingClientRect();
       const deploymentGroup = document.querySelector('.landing-deployment-zigzag')?.getBoundingClientRect();
       const capabilitiesAnchor = document.querySelector('[data-align-anchor="capabilities"]')?.getBoundingClientRect();
+      const capabilitiesColumn = document.querySelector('.landing-capabilities')?.getBoundingClientRect();
       const deploymentAnchor = document.querySelector('[data-align-anchor="deployment"]')?.getBoundingClientRect();
 
       const stepOne = document.querySelector('.landing-deployment-step--one')?.getBoundingClientRect();
@@ -108,6 +109,10 @@ try {
         step2OffsetFromStep1Px:
           stepOne && stepTwo ? Number((stepTwo.left - stepOne.left).toFixed(2)) : null,
         deployXStep,
+        capabilitiesCenterOffsetPx:
+          capabilitiesAnchor && capabilitiesColumn
+            ? Number(Math.abs((capabilitiesAnchor.left + (capabilitiesAnchor.width / 2)) - (capabilitiesColumn.left + (capabilitiesColumn.width / 2))).toFixed(2))
+            : null,
       };
     });
 
@@ -132,7 +137,9 @@ try {
     || desktopResult.rowToDeploymentDiffPx > 2
     || desktopResult.panelBottomDiffPx > 2
     || desktopResult.step1Step3DiffPx > 2
-    || desktopResult.step2OffsetFromStep1Px < (desktopResult.deployXStep - 2)
+    || desktopResult.step2OffsetFromStep1Px < 120
+    || desktopResult.capabilitiesCenterOffsetPx == null
+    || desktopResult.capabilitiesCenterOffsetPx > 5
   ) {
     throw new Error(`Desktop alignment failed. Results: ${JSON.stringify(alignmentResults)}`);
   }

--- a/frontend/scripts/landing-visual-regression.mjs
+++ b/frontend/scripts/landing-visual-regression.mjs
@@ -1,7 +1,6 @@
 import { chromium } from 'playwright';
 import { spawn } from 'node:child_process';
-import { mkdir, access } from 'node:fs/promises';
-import { constants } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 const rootDir = path.resolve(process.cwd());
@@ -45,14 +44,46 @@ try {
 
   const browser = await chromium.launch({ headless: true });
   const context = await browser.newContext();
+  const alignmentResults = [];
 
   for (const viewport of viewports) {
     const page = await context.newPage({ viewport: { width: viewport.width, height: viewport.height } });
     await page.goto('http://127.0.0.1:4173/', { waitUntil: 'networkidle' });
-    const target = page.locator('.landing-system-surface');
-    await access(path.join(rootDir, 'src', 'styles', 'LandingPage.css'), constants.F_OK);
-    await target.screenshot({ path: path.join(screenshotsDir, `${viewport.name}-system-surface.png`) });
+
+    await page.locator('.landing-system-surface').screenshot({
+      path: path.join(screenshotsDir, `${viewport.name}-system-band.png`),
+    });
+
+    await page.locator('.landing-preview').screenshot({
+      path: path.join(screenshotsDir, `${viewport.name}-seam-preview.png`),
+    });
+
+    const geometry = await page.evaluate(() => {
+      const lastRow = document.querySelector('.landing-capability-row:last-child')?.getBoundingClientRect();
+      const deploymentGroup = document.querySelector('.landing-deployment-rail')?.getBoundingClientRect();
+      if (!lastRow || !deploymentGroup) {
+        return { diffPx: null };
+      }
+      return {
+        capabilityBottom: Number(lastRow.bottom.toFixed(2)),
+        deploymentBottom: Number(deploymentGroup.bottom.toFixed(2)),
+        diffPx: Number(Math.abs(lastRow.bottom - deploymentGroup.bottom).toFixed(2)),
+      };
+    });
+
+    alignmentResults.push({ viewport: viewport.name, ...geometry });
     await page.close();
+  }
+
+  await writeFile(
+    path.join(screenshotsDir, 'alignment-results.json'),
+    `${JSON.stringify(alignmentResults, null, 2)}\n`,
+    'utf8',
+  );
+
+  const desktopResult = alignmentResults.find((result) => result.viewport === 'desktop');
+  if (!desktopResult || desktopResult.diffPx == null || desktopResult.diffPx > 2) {
+    throw new Error(`Desktop bottom alignment failed. Results: ${JSON.stringify(alignmentResults)}`);
   }
 
   await browser.close();

--- a/frontend/scripts/landing-visual-regression.mjs
+++ b/frontend/scripts/landing-visual-regression.mjs
@@ -1,0 +1,61 @@
+import { chromium } from 'playwright';
+import { spawn } from 'node:child_process';
+import { mkdir, access } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import path from 'node:path';
+
+const rootDir = path.resolve(process.cwd());
+const screenshotsDir = path.join(rootDir, 'artifacts', 'landing-visual');
+
+const viewports = [
+  { name: 'mobile', width: 375, height: 812 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'desktop', width: 1440, height: 900 },
+];
+
+const waitForServer = async (url, timeoutMs = 30000) => {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch {
+      // retry until timeout
+    }
+    await new Promise((resolve) => setTimeout(resolve, 400));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+};
+
+const server = spawn('npm', ['run', 'dev', '--', '--port', '4173'], {
+  cwd: rootDir,
+  stdio: 'inherit',
+  shell: true,
+});
+
+const cleanup = () => {
+  if (!server.killed) {
+    server.kill('SIGTERM');
+  }
+};
+
+try {
+  await mkdir(screenshotsDir, { recursive: true });
+  await waitForServer('http://127.0.0.1:4173');
+
+  const browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext();
+
+  for (const viewport of viewports) {
+    const page = await context.newPage({ viewport: { width: viewport.width, height: viewport.height } });
+    await page.goto('http://127.0.0.1:4173/', { waitUntil: 'networkidle' });
+    const target = page.locator('.landing-system-surface');
+    await access(path.join(rootDir, 'src', 'styles', 'LandingPage.css'), constants.F_OK);
+    await target.screenshot({ path: path.join(screenshotsDir, `${viewport.name}-system-surface.png`) });
+    await page.close();
+  }
+
+  await browser.close();
+} finally {
+  cleanup();
+}

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -90,22 +90,23 @@ const LandingPage: React.FC = () => {
 
                 <section className="landing-deployment" aria-labelledby="deployment-title">
                   <h2 id="deployment-title">{landingCopy.deployment.heading}</h2>
-                  <ol className="landing-deployment-rail" aria-label="System deployment flow">
-                    <li className="landing-deployment-step">
-                      <span className="landing-deployment-step-index">01</span>
-                      <span className="landing-deployment-step-label">{landingCopy.deployment.firstStep}</span>
-                    </li>
-                    <li className="landing-deployment-arrow" aria-hidden="true">→</li>
-                    <li className="landing-deployment-step">
-                      <span className="landing-deployment-step-index">02</span>
-                      <span className="landing-deployment-step-label">{landingCopy.deployment.secondStep}</span>
-                    </li>
-                    <li className="landing-deployment-arrow" aria-hidden="true">→</li>
-                    <li className="landing-deployment-step">
-                      <span className="landing-deployment-step-index">03</span>
-                      <span className="landing-deployment-step-label">{landingCopy.deployment.thirdStep}</span>
-                    </li>
-                  </ol>
+                  <div className="landing-deployment-field">
+                    <span className="landing-deployment-spine" aria-hidden="true" />
+                    <ol className="landing-deployment-rail" aria-label="System deployment flow">
+                      <li className="landing-deployment-step">
+                        <span className="landing-deployment-step-index">01</span>
+                        <span className="landing-deployment-step-label">{landingCopy.deployment.firstStep}</span>
+                      </li>
+                      <li className="landing-deployment-step">
+                        <span className="landing-deployment-step-index">02</span>
+                        <span className="landing-deployment-step-label">{landingCopy.deployment.secondStep}</span>
+                      </li>
+                      <li className="landing-deployment-step">
+                        <span className="landing-deployment-step-index">03</span>
+                        <span className="landing-deployment-step-label">{landingCopy.deployment.thirdStep}</span>
+                      </li>
+                    </ol>
+                  </div>
                 </section>
               </div>
 

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -75,17 +75,19 @@ const LandingPage: React.FC = () => {
             <div className="landing-system-surface">
               <div className="landing-operational-grid">
                 <section className="landing-capabilities" aria-labelledby="capabilities-title">
-                  <h2 id="capabilities-title">{landingCopy.capabilities.heading}</h2>
-                  <div className="landing-capabilities-content" data-align-anchor="capabilities">
-                    <div className="landing-capability-rows" role="list" aria-label="Platform capabilities">
-                    {landingCopy.capabilities.items.map((item, index) => (
-                      <div key={item} className="landing-capability-row" role="listitem">
-                        <span className="landing-capability-index" aria-hidden="true">
-                          {(index + 1).toString().padStart(2, "0")}
-                        </span>
-                        <span>{item}</span>
+                  <div className="landing-capabilities-inner" data-align-anchor="capabilities">
+                    <h2 id="capabilities-title">{landingCopy.capabilities.heading}</h2>
+                    <div className="landing-capabilities-content">
+                      <div className="landing-capability-rows" role="list" aria-label="Platform capabilities">
+                      {landingCopy.capabilities.items.map((item, index) => (
+                        <div key={item} className="landing-capability-row" role="listitem">
+                          <span className="landing-capability-index" aria-hidden="true">
+                            {(index + 1).toString().padStart(2, "0")}
+                          </span>
+                          <span>{item}</span>
+                        </div>
+                      ))}
                       </div>
-                    ))}
                     </div>
                   </div>
                 </section>

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -93,23 +93,20 @@ const LandingPage: React.FC = () => {
                 <section className="landing-deployment" aria-labelledby="deployment-title">
                   <h2 id="deployment-title">{landingCopy.deployment.heading}</h2>
                   <div className="landing-deployment-content" data-align-anchor="deployment">
-                    <div className="landing-deployment-field">
-                    <span className="landing-deployment-spine" aria-hidden="true" />
-                    <ol className="landing-deployment-rail" aria-label="System deployment flow">
-                      <li className="landing-deployment-step">
+                    <ol className="landing-deployment-zigzag" aria-label="System deployment flow">
+                      <li className="landing-deployment-step landing-deployment-step--one">
                         <span className="landing-deployment-step-index">01</span>
                         <span className="landing-deployment-step-label">{landingCopy.deployment.firstStep}</span>
                       </li>
-                      <li className="landing-deployment-step">
+                      <li className="landing-deployment-step landing-deployment-step--two">
                         <span className="landing-deployment-step-index">02</span>
                         <span className="landing-deployment-step-label">{landingCopy.deployment.secondStep}</span>
                       </li>
-                      <li className="landing-deployment-step">
+                      <li className="landing-deployment-step landing-deployment-step--three">
                         <span className="landing-deployment-step-index">03</span>
                         <span className="landing-deployment-step-label">{landingCopy.deployment.thirdStep}</span>
                       </li>
                     </ol>
-                    </div>
                   </div>
                 </section>
               </div>

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -76,7 +76,8 @@ const LandingPage: React.FC = () => {
               <div className="landing-operational-grid">
                 <section className="landing-capabilities" aria-labelledby="capabilities-title">
                   <h2 id="capabilities-title">{landingCopy.capabilities.heading}</h2>
-                  <div className="landing-capability-rows" role="list" aria-label="Platform capabilities">
+                  <div className="landing-capabilities-content" data-align-anchor="capabilities">
+                    <div className="landing-capability-rows" role="list" aria-label="Platform capabilities">
                     {landingCopy.capabilities.items.map((item, index) => (
                       <div key={item} className="landing-capability-row" role="listitem">
                         <span className="landing-capability-index" aria-hidden="true">
@@ -85,12 +86,14 @@ const LandingPage: React.FC = () => {
                         <span>{item}</span>
                       </div>
                     ))}
+                    </div>
                   </div>
                 </section>
 
                 <section className="landing-deployment" aria-labelledby="deployment-title">
                   <h2 id="deployment-title">{landingCopy.deployment.heading}</h2>
-                  <div className="landing-deployment-field">
+                  <div className="landing-deployment-content" data-align-anchor="deployment">
+                    <div className="landing-deployment-field">
                     <span className="landing-deployment-spine" aria-hidden="true" />
                     <ol className="landing-deployment-rail" aria-label="System deployment flow">
                       <li className="landing-deployment-step">
@@ -106,6 +109,7 @@ const LandingPage: React.FC = () => {
                         <span className="landing-deployment-step-label">{landingCopy.deployment.thirdStep}</span>
                       </li>
                     </ol>
+                    </div>
                   </div>
                 </section>
               </div>

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -72,51 +72,53 @@ const LandingPage: React.FC = () => {
 
         <section className="landing-spec-sheet" aria-label="Operational spec sheet">
           <div className="landing-container landing-spec-sheet-inner">
-            <div className="landing-operational-grid">
-              <section className="landing-capabilities" aria-labelledby="capabilities-title">
-                <h2 id="capabilities-title">{landingCopy.capabilities.heading}</h2>
-                <div className="landing-capability-rows" role="list" aria-label="Platform capabilities">
-                  {landingCopy.capabilities.items.map((item, index) => (
-                    <div key={item} className="landing-capability-row" role="listitem">
-                      <span className="landing-capability-index" aria-hidden="true">
-                        {(index + 1).toString().padStart(2, "0")}
-                      </span>
-                      <span>{item}</span>
-                    </div>
-                  ))}
+            <div className="landing-system-surface">
+              <div className="landing-operational-grid">
+                <section className="landing-capabilities" aria-labelledby="capabilities-title">
+                  <h2 id="capabilities-title">{landingCopy.capabilities.heading}</h2>
+                  <div className="landing-capability-rows" role="list" aria-label="Platform capabilities">
+                    {landingCopy.capabilities.items.map((item, index) => (
+                      <div key={item} className="landing-capability-row" role="listitem">
+                        <span className="landing-capability-index" aria-hidden="true">
+                          {(index + 1).toString().padStart(2, "0")}
+                        </span>
+                        <span>{item}</span>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+
+                <section className="landing-deployment" aria-labelledby="deployment-title">
+                  <h2 id="deployment-title">{landingCopy.deployment.heading}</h2>
+                  <ol className="landing-deployment-rail" aria-label="System deployment flow">
+                    <li className="landing-deployment-step">
+                      <span className="landing-deployment-step-index">01</span>
+                      <span className="landing-deployment-step-label">{landingCopy.deployment.firstStep}</span>
+                    </li>
+                    <li className="landing-deployment-arrow" aria-hidden="true">→</li>
+                    <li className="landing-deployment-step">
+                      <span className="landing-deployment-step-index">02</span>
+                      <span className="landing-deployment-step-label">{landingCopy.deployment.secondStep}</span>
+                    </li>
+                    <li className="landing-deployment-arrow" aria-hidden="true">→</li>
+                    <li className="landing-deployment-step">
+                      <span className="landing-deployment-step-index">03</span>
+                      <span className="landing-deployment-step-label">{landingCopy.deployment.thirdStep}</span>
+                    </li>
+                  </ol>
+                </section>
+              </div>
+
+              <section className="landing-preview" aria-labelledby="live-preview-title">
+                <div className="landing-section-head landing-section-head--sr-only">
+                  <h2 id="live-preview-title">{landingCopy.livePreview.heading}</h2>
+                  <p>{landingCopy.livePreview.description}</p>
+                </div>
+                <div className="landing-dashboard-preview">
+                  <SystemOverviewPreview />
                 </div>
               </section>
-
-              <section className="landing-deployment" aria-labelledby="deployment-title">
-                <h2 id="deployment-title">{landingCopy.deployment.heading}</h2>
-                <ol className="landing-deployment-rail" aria-label="System deployment flow">
-                  <li className="landing-deployment-step landing-deployment-step--active">
-                    <span className="landing-deployment-step-index">01</span>
-                    <span className="landing-deployment-step-label">{landingCopy.deployment.firstStep}</span>
-                  </li>
-                  <li className="landing-deployment-arrow" aria-hidden="true">→</li>
-                  <li className="landing-deployment-step">
-                    <span className="landing-deployment-step-index">02</span>
-                    <span className="landing-deployment-step-label">{landingCopy.deployment.secondStep}</span>
-                  </li>
-                  <li className="landing-deployment-arrow" aria-hidden="true">→</li>
-                  <li className="landing-deployment-step">
-                    <span className="landing-deployment-step-index">03</span>
-                    <span className="landing-deployment-step-label">{landingCopy.deployment.thirdStep}</span>
-                  </li>
-                </ol>
-              </section>
             </div>
-
-            <section className="landing-preview" aria-labelledby="live-preview-title">
-              <div className="landing-section-head">
-                <h2 id="live-preview-title">{landingCopy.livePreview.heading}</h2>
-                <p>{landingCopy.livePreview.description}</p>
-              </div>
-              <div className="landing-dashboard-preview">
-                <SystemOverviewPreview />
-              </div>
-            </section>
 
             <section className="landing-assurances" aria-labelledby="assurances-title">
               <h2 id="assurances-title">{landingCopy.assurances.heading}</h2>

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -9,8 +9,8 @@
   --mid-span: 56px;
 
   position: relative;
-  width: min(1040px, 100%);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
   border: none;
   border-radius: 0;
   box-shadow: none;
@@ -38,7 +38,7 @@
   grid-template-rows: auto var(--mid-span) auto;
   row-gap: var(--topo-gap-row);
   min-height: 286px;
-  padding: 6px 8px;
+  padding: 0;
 }
 
 .topCluster {
@@ -362,7 +362,7 @@
 
 @media (max-width: 1279px) {
   .preview {
-    width: min(920px, 100%);
+    width: 100%;
     --kpi-col: 214px;
     --topo-gap-col: 14px;
     --topo-gap-row: 7px;
@@ -376,7 +376,7 @@
 
 @media (max-width: 767px) {
   .preview {
-    padding: 14px 14px;
+    padding: 0;
   }
 
   .canvas {

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -210,9 +210,20 @@ body {
 }
 
 .landing-deployment-content {
+  --deploy-step-width: 272px;
+  --deploy-step-height: 112px;
+  --deploy-x-step: 132px;
+  --deploy-y-step: 48px;
+
   max-width: 500px;
   margin-inline: auto;
   width: 100%;
+}
+
+.landing-capabilities > h2 {
+  max-width: 460px;
+  width: 100%;
+  margin-inline: auto;
 }
 
 .landing-capability-rows {
@@ -262,17 +273,18 @@ body {
   margin: 0;
   padding: 0;
   list-style: none;
-  width: 100%;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  grid-auto-rows: minmax(112px, auto);
-  row-gap: 44px;
+  position: relative;
+  width: calc(var(--deploy-step-width) + var(--deploy-x-step));
+  min-height: calc(var(--deploy-step-height) + (var(--deploy-y-step) * 2));
 }
 
 .landing-deployment-step {
+  position: absolute;
+  left: 0;
+  top: 0;
   min-width: 0;
-  width: min(280px, 100%);
-  min-height: 112px;
+  width: min(var(--deploy-step-width), 100%);
+  min-height: var(--deploy-step-height);
   border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--sys-line) 34%, transparent);
   background: color-mix(in srgb, var(--sys-bg-2) 30%, transparent);
@@ -283,18 +295,15 @@ body {
 }
 
 .landing-deployment-step--one {
-  justify-self: start;
-  transform: translateX(0);
+  transform: translate(0, 0);
 }
 
 .landing-deployment-step--two {
-  justify-self: start;
-  transform: translateX(96px);
+  transform: translate(var(--deploy-x-step), var(--deploy-y-step));
 }
 
 .landing-deployment-step--three {
-  justify-self: start;
-  transform: translateX(28px);
+  transform: translate(0, calc(var(--deploy-y-step) * 2));
 }
 
 .landing-deployment-step-label {
@@ -409,8 +418,12 @@ body {
     gap: 56px;
     grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
   }
-  .landing-deployment-step--two { transform: translateX(72px); }
-  .landing-deployment-step--three { transform: translateX(20px); }
+
+  .landing-deployment-content {
+    --deploy-step-width: 264px;
+    --deploy-x-step: 112px;
+    --deploy-y-step: 44px;
+  }
 }
 
 @media (max-width: 900px) {
@@ -433,12 +446,11 @@ body {
     max-width: 560px;
   }
 
-  .landing-deployment-zigzag {
-    row-gap: 30px;
+  .landing-deployment-content {
+    --deploy-step-width: 280px;
+    --deploy-x-step: 96px;
+    --deploy-y-step: 38px;
   }
-
-  .landing-deployment-step--two { transform: translateX(52px); }
-  .landing-deployment-step--three { transform: translateX(16px); }
 }
 
 @media (max-width: 767px) {
@@ -467,11 +479,23 @@ body {
     max-width: 100%;
   }
 
+  .landing-deployment-content {
+    --deploy-step-width: 100%;
+    --deploy-x-step: 0px;
+    --deploy-y-step: 0px;
+  }
+
   .landing-deployment-zigzag {
-    row-gap: 16px;
+    position: static;
+    width: 100%;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
   }
 
   .landing-deployment-step {
+    position: static;
     width: 100%;
     min-height: 104px;
     padding: 20px;

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -142,7 +142,7 @@ body {
 
 .landing-system-surface {
   position: relative;
-  min-height: 308px;
+  min-height: 300px;
   border-top: 1px solid var(--sys-plate-line);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 95%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
@@ -153,8 +153,8 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 96px;
   align-items: stretch;
-  min-height: 306px;
-  padding: 104px 48px 76px;
+  min-height: 300px;
+  padding: 96px 48px 64px;
 }
 
 .landing-capabilities,
@@ -178,7 +178,7 @@ body {
 
 .landing-capabilities h2,
 .landing-deployment h2 {
-  margin-bottom: 44px;
+  margin-bottom: 36px;
 }
 
 .landing-section-head--sr-only {
@@ -220,9 +220,9 @@ body {
 
 .landing-deployment-content {
   --deploy-step-width: 272px;
-  --deploy-step-height: 112px;
+  --deploy-step-height: 96px;
   --deploy-x-step: 136px;
-  --deploy-y-step: 34px;
+  --deploy-y-step: 24px;
 
   max-width: 460px;
   margin-inline: auto;
@@ -251,7 +251,7 @@ body {
 .landing-capability-row {
   grid-template-columns: 48px 1fr;
   gap: 24px;
-  padding: 20px 0;
+  padding: 16px 0;
 }
 
 .landing-assurance-row {
@@ -289,7 +289,7 @@ body {
   border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--sys-line) 34%, transparent);
   background: color-mix(in srgb, var(--sys-bg-2) 30%, transparent);
-  padding: 24px;
+  padding: 20px;
   display: grid;
   align-content: center;
   gap: 8px;
@@ -420,7 +420,7 @@ body {
   .landing-deployment-content {
     --deploy-step-width: 264px;
     --deploy-x-step: 120px;
-    --deploy-y-step: 32px;
+    --deploy-y-step: 22px;
   }
 }
 
@@ -429,9 +429,9 @@ body {
 
   .landing-operational-grid {
     grid-template-columns: 1fr;
-    gap: 42px;
+    gap: 36px;
     min-height: 0;
-    padding: 96px 36px 56px;
+    padding: 84px 36px 48px;
   }
 
   .landing-capabilities,
@@ -441,7 +441,7 @@ body {
 
   .landing-capabilities h2,
   .landing-deployment h2 {
-    margin-bottom: 34px;
+    margin-bottom: 30px;
   }
 
   .landing-capabilities-content,
@@ -452,7 +452,7 @@ body {
   .landing-deployment-content {
     --deploy-step-width: 280px;
     --deploy-x-step: 96px;
-    --deploy-y-step: 30px;
+    --deploy-y-step: 24px;
   }
 }
 
@@ -468,13 +468,13 @@ body {
   .landing-hero-actions .btn, .landing-signup-form .btn { width: 100%; }
 
   .landing-operational-grid {
-    padding: 96px 0 0;
-    gap: 40px;
+    padding: 80px 0 0;
+    gap: 32px;
   }
 
   .landing-capabilities h2,
   .landing-deployment h2 {
-    margin-bottom: 28px;
+    margin-bottom: 24px;
   }
 
   .landing-capabilities-content,

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -152,6 +152,16 @@ body {
     linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 95%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
 }
 
+.landing-system-surface::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 1px;
+  background: var(--sys-plate-line);
+}
+
 .landing-operational-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -201,6 +211,13 @@ body {
   border-top: 1px solid color-mix(in srgb, var(--sys-line-soft) 18%, transparent);
 }
 
+.landing-capabilities-content,
+.landing-deployment-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
 .landing-capability-rows {
   margin-top: 0;
   display: flex;
@@ -238,6 +255,10 @@ body {
   font-family: "Roboto Mono", ui-monospace, Menlo, monospace;
   font-size: 0.74rem;
   color: color-mix(in srgb, var(--sys-text-3) 88%, transparent);
+}
+
+.landing-deployment-content {
+  align-items: flex-end;
 }
 
 .landing-deployment-field {

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -142,6 +142,7 @@ body {
 
 .landing-system-surface {
   position: relative;
+  min-height: 308px;
   border-top: 1px solid var(--sys-plate-line);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 95%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
@@ -152,8 +153,8 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 96px;
   align-items: stretch;
-  min-height: 440px;
-  padding: 152px 48px 72px;
+  min-height: 306px;
+  padding: 104px 48px 76px;
 }
 
 .landing-capabilities,
@@ -177,7 +178,7 @@ body {
 
 .landing-capabilities h2,
 .landing-deployment h2 {
-  margin-bottom: 56px;
+  margin-bottom: 44px;
 }
 
 .landing-section-head--sr-only {
@@ -221,7 +222,7 @@ body {
   --deploy-step-width: 272px;
   --deploy-step-height: 112px;
   --deploy-x-step: 136px;
-  --deploy-y-step: 48px;
+  --deploy-y-step: 34px;
 
   max-width: 460px;
   margin-inline: auto;
@@ -250,7 +251,7 @@ body {
 .landing-capability-row {
   grid-template-columns: 48px 1fr;
   gap: 24px;
-  padding: 24px 0;
+  padding: 20px 0;
 }
 
 .landing-assurance-row {
@@ -419,7 +420,7 @@ body {
   .landing-deployment-content {
     --deploy-step-width: 264px;
     --deploy-x-step: 120px;
-    --deploy-y-step: 44px;
+    --deploy-y-step: 32px;
   }
 }
 
@@ -428,9 +429,9 @@ body {
 
   .landing-operational-grid {
     grid-template-columns: 1fr;
-    gap: 48px;
+    gap: 42px;
     min-height: 0;
-    padding: 112px 36px 60px;
+    padding: 96px 36px 56px;
   }
 
   .landing-capabilities,
@@ -440,7 +441,7 @@ body {
 
   .landing-capabilities h2,
   .landing-deployment h2 {
-    margin-bottom: 40px;
+    margin-bottom: 34px;
   }
 
   .landing-capabilities-content,
@@ -451,7 +452,7 @@ body {
   .landing-deployment-content {
     --deploy-step-width: 280px;
     --deploy-x-step: 96px;
-    --deploy-y-step: 38px;
+    --deploy-y-step: 30px;
   }
 }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -330,18 +330,165 @@ body {
 }
 .landing-footer-social-link svg { width: 14px; height: 14px; }
 
+
+
+.landing-system-surface {
+  position: relative;
+  background: linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 94%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
+}
+
+.landing-system-surface::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% - 1px);
+  height: 1px;
+  background: color-mix(in srgb, var(--sys-line-soft) 24%, transparent);
+}
+
+.landing-section-head--sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.landing-spec-sheet {
+  padding: 0 0 72px;
+}
+
+.landing-spec-sheet-inner {
+  max-width: 1200px;
+}
+
+.landing-operational-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 96px;
+  align-items: stretch;
+  min-height: 400px;
+  padding: 160px 0 88px;
+  border-bottom: none;
+}
+
+.landing-capabilities,
+.landing-deployment {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.landing-capabilities h2,
+.landing-deployment h2 {
+  flex: 0 0 auto;
+}
+
+.landing-capabilities h2 {
+  margin-bottom: 56px;
+}
+
+.landing-deployment h2 {
+  margin-bottom: 56px;
+}
+
+.landing-capability-rows {
+  margin-top: 0;
+  border-top: 1px solid color-mix(in srgb, var(--sys-line-soft) 18%, transparent);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 1;
+}
+
+.landing-capability-row {
+  min-height: 0;
+  grid-template-columns: 48px 1fr;
+  gap: 24px;
+  padding: 24px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--sys-line-soft) 16%, transparent);
+}
+
+.landing-deployment-rail {
+  margin: 0;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.landing-deployment-step {
+  width: min(280px, 100%);
+  min-height: 96px;
+  border-radius: 6px;
+  border-color: color-mix(in srgb, var(--sys-line) 48%, transparent);
+  background: color-mix(in srgb, var(--sys-bg-2) 48%, transparent);
+  padding: 24px;
+  gap: 8px;
+}
+
+.landing-deployment-step--active {
+  border-color: color-mix(in srgb, var(--sys-line) 48%, transparent);
+  box-shadow: none;
+}
+
+.landing-deployment-arrow {
+  width: 24px;
+  flex: 0 0 24px;
+  font-size: 0.92rem;
+  color: color-mix(in srgb, var(--sys-text-3) 84%, transparent);
+}
+
+.landing-preview {
+  padding: 32px 0 0;
+  position: relative;
+}
+
+.landing-preview::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: color-mix(in srgb, var(--sys-line-soft) 26%, transparent);
+}
+
+.landing-dashboard-preview {
+  margin-top: 0;
+}
+
 @media (max-width: 1100px) {
   .landing-container { width: min(1180px, calc(100% - 44px)); }
-  .landing-operational-grid { gap: 24px; }
+  .landing-operational-grid { gap: 56px; }
 }
 
 @media (max-width: 900px) {
   .landing-hero { padding: 86px 0 56px; }
-  .landing-operational-grid { grid-template-columns: 1fr; }
+  .landing-operational-grid {
+    grid-template-columns: 1fr;
+    gap: 42px;
+    min-height: 0;
+    padding: 120px 0 80px;
+  }
+  .landing-capabilities h2,
+  .landing-deployment h2 {
+    margin-bottom: 36px;
+  }
+  .landing-deployment-rail {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    row-gap: 20px;
+  }
 }
 
 @media (max-width: 767px) {
-  .landing-preview { padding: 14px 14px; }
+  .landing-preview { padding: 28px 0 0; }
   .landing-assurances { padding: 14px 14px 16px; }
 
   .landing-container { width: min(1180px, calc(100% - 30px)); }
@@ -350,9 +497,20 @@ body {
   .landing-hero h1, .landing-hero p { max-width: none; }
   .landing-hero-actions { flex-direction: column; align-items: stretch; }
   .landing-hero-actions .btn, .landing-signup-form .btn { width: 100%; }
-  .landing-deployment-rail { grid-template-columns: minmax(0, 1fr) 12px minmax(0, 1fr) 12px minmax(0, 1fr); gap: 6px; }
-  .landing-deployment-step { min-height: 74px; padding: 8px; }
-  .landing-deployment-step-label { font-size: 0.8rem; }
+  .landing-deployment-rail {
+    gap: 14px;
+  }
+  .landing-deployment-step {
+    width: 100%;
+    min-height: 96px;
+    padding: 20px;
+  }
+  .landing-deployment-arrow {
+    flex-basis: 100%;
+    width: auto;
+    text-align: left;
+  }
+  .landing-deployment-step-label { font-size: 0.82rem; }
   .landing-assurance-matrix { grid-template-columns: 1fr; }
   .landing-signup { padding: 46px 0 42px; }
   .landing-form-grid { grid-template-columns: 1fr; }

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -153,8 +153,8 @@ body {
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 96px;
   align-items: stretch;
-  min-height: 300px;
-  padding: 96px 48px 64px;
+  min-height: 260px;
+  padding: 56px 48px 36px;
 }
 
 .landing-capabilities,
@@ -178,7 +178,7 @@ body {
 
 .landing-capabilities h2,
 .landing-deployment h2 {
-  margin-bottom: 36px;
+  margin-bottom: 22px;
 }
 
 .landing-section-head--sr-only {
@@ -220,9 +220,9 @@ body {
 
 .landing-deployment-content {
   --deploy-step-width: 272px;
-  --deploy-step-height: 96px;
+  --deploy-step-height: 78px;
   --deploy-x-step: 136px;
-  --deploy-y-step: 24px;
+  --deploy-y-step: 12px;
 
   max-width: 460px;
   margin-inline: auto;
@@ -251,7 +251,7 @@ body {
 .landing-capability-row {
   grid-template-columns: 48px 1fr;
   gap: 24px;
-  padding: 16px 0;
+  padding: 12px 0;
 }
 
 .landing-assurance-row {
@@ -289,7 +289,7 @@ body {
   border-radius: 6px;
   border: 1px solid color-mix(in srgb, var(--sys-line) 34%, transparent);
   background: color-mix(in srgb, var(--sys-bg-2) 30%, transparent);
-  padding: 20px;
+  padding: 14px;
   display: grid;
   align-content: center;
   gap: 8px;
@@ -420,7 +420,7 @@ body {
   .landing-deployment-content {
     --deploy-step-width: 264px;
     --deploy-x-step: 120px;
-    --deploy-y-step: 22px;
+    --deploy-y-step: 10px;
   }
 }
 
@@ -429,9 +429,9 @@ body {
 
   .landing-operational-grid {
     grid-template-columns: 1fr;
-    gap: 36px;
+    gap: 24px;
     min-height: 0;
-    padding: 84px 36px 48px;
+    padding: 60px 36px 32px;
   }
 
   .landing-capabilities,
@@ -441,7 +441,7 @@ body {
 
   .landing-capabilities h2,
   .landing-deployment h2 {
-    margin-bottom: 30px;
+    margin-bottom: 18px;
   }
 
   .landing-capabilities-content,
@@ -452,7 +452,7 @@ body {
   .landing-deployment-content {
     --deploy-step-width: 280px;
     --deploy-x-step: 96px;
-    --deploy-y-step: 24px;
+    --deploy-y-step: 12px;
   }
 }
 
@@ -468,13 +468,13 @@ body {
   .landing-hero-actions .btn, .landing-signup-form .btn { width: 100%; }
 
   .landing-operational-grid {
-    padding: 80px 0 0;
-    gap: 32px;
+    padding: 52px 0 0;
+    gap: 20px;
   }
 
   .landing-capabilities h2,
   .landing-deployment h2 {
-    margin-bottom: 24px;
+    margin-bottom: 18px;
   }
 
   .landing-capabilities-content,
@@ -496,7 +496,7 @@ body {
   .landing-deployment-step {
     width: 100%;
     min-height: 104px;
-    padding: 20px;
+    padding: 14px;
     margin-left: 0 !important;
   }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -125,25 +125,43 @@ body {
 }
 .landing-hero-actions { margin-top: 30px; display: flex; gap: 12px; }
 
-.landing-spec-sheet { padding: 0 0 34px; }
+
+.landing-spec-sheet {
+  padding: 0 0 92px;
+}
+
 .landing-spec-sheet-inner {
   border: none;
   border-radius: 0;
   background: transparent;
   box-shadow: none;
   overflow: visible;
+  max-width: 1200px;
+}
+
+.landing-system-surface {
+  position: relative;
+  border-top: 1px solid color-mix(in srgb, var(--sys-line-soft) 22%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 95%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
 }
 
 .landing-operational-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.15fr);
-  gap: clamp(24px, 3vw, 36px);
-  align-items: start;
-  padding: 22px;
-  border-bottom: 1px solid color-mix(in srgb, var(--sys-line-soft) 52%, transparent);
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 96px;
+  align-items: stretch;
+  min-height: 440px;
+  padding: 160px 0 84px;
 }
 
-.landing-section-head h2,
+.landing-capabilities,
+.landing-deployment {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .landing-capabilities h2,
 .landing-deployment h2,
 .landing-signup-wrap h2,
@@ -154,91 +172,135 @@ body {
   letter-spacing: -0.01em;
   font-weight: 600;
 }
-.landing-section-head p {
-  margin: 6px 0 0;
-  color: var(--sys-text-3);
-  font-size: 0.76rem;
-  line-height: 1.25;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+
+.landing-capabilities h2,
+.landing-deployment h2 {
+  margin-bottom: 56px;
 }
 
-.landing-capabilities,
-.landing-deployment {
+.landing-section-head--sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
   padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
   border: 0;
-  background: transparent;
 }
 
 .landing-capability-rows,
 .landing-assurance-matrix {
-  margin-top: 16px;
-  border-top: 1px solid var(--sys-line-soft);
+  border-top: 1px solid color-mix(in srgb, var(--sys-line-soft) 18%, transparent);
+}
+
+.landing-capability-rows {
+  margin-top: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  flex: 1;
 }
 
 .landing-capability-row,
 .landing-assurance-row {
   margin: 0;
-  min-height: 40px;
   display: grid;
-  grid-template-columns: auto 1fr;
   align-items: center;
-  gap: 12px;
   color: var(--sys-text-2);
-  border-bottom: 1px solid color-mix(in srgb, var(--sys-line-soft) 52%, transparent);
-  padding: 0 2px;
+  border-bottom: 1px solid color-mix(in srgb, var(--sys-line-soft) 18%, transparent);
   font-size: 0.84rem;
-  line-height: 1.3;
+  line-height: 1.32;
 }
 
-.landing-capability-index {
+.landing-capability-row {
+  grid-template-columns: 48px 1fr;
+  gap: 24px;
+  padding: 24px 0;
+}
+
+.landing-assurance-row {
+  min-height: 40px;
+  grid-template-columns: auto 1fr;
+  gap: 12px;
+  padding: 0 2px;
+}
+
+.landing-capability-index,
+.landing-deployment-step-index {
   font-family: "Roboto Mono", ui-monospace, Menlo, monospace;
-  font-size: 0.75rem;
-  color: var(--sys-text-3);
+  font-size: 0.74rem;
+  color: color-mix(in srgb, var(--sys-text-3) 88%, transparent);
+}
+
+.landing-deployment-field {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: stretch;
+}
+
+.landing-deployment-spine {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 50%;
+  height: 1px;
+  background: color-mix(in srgb, var(--sys-line) 30%, transparent);
+  transform: translateY(-0.5px);
 }
 
 .landing-deployment-rail {
-  margin: 16px 0 0;
+  margin: 0;
   padding: 0;
   list-style: none;
+  width: 100%;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 14px minmax(0, 1fr) 14px minmax(0, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 64px;
   align-items: center;
-  gap: 8px;
+  position: relative;
+  z-index: 1;
 }
 
 .landing-deployment-step {
   min-width: 0;
-  min-height: 88px;
-  border-radius: var(--sys-radius-sm);
-  border: 1px solid var(--sys-line);
-  background: color-mix(in srgb, var(--sys-bg-2) 65%, transparent);
-  padding: 10px;
+  min-height: 112px;
+  border-radius: 6px;
+  border: 1px solid color-mix(in srgb, var(--sys-line) 44%, transparent);
+  background: color-mix(in srgb, var(--sys-bg-2) 42%, transparent);
+  padding: 24px;
   display: grid;
   align-content: center;
-  gap: 7px;
+  gap: 8px;
 }
 
-.landing-deployment-step--active {
-  border-color: color-mix(in srgb, var(--sys-accent) 58%, white 22%);
-  box-shadow: inset 0 1px 0 color-mix(in srgb, white 18%, transparent);
+.landing-deployment-step-label {
+  font-size: 0.88rem;
+  font-weight: 560;
+  line-height: 1.3;
+  color: var(--sys-text-1);
 }
-
-.landing-deployment-step-index {
-  font-family: "Roboto Mono", ui-monospace, Menlo, monospace;
-  font-size: 0.74rem;
-  color: var(--sys-text-3);
-}
-.landing-deployment-step-label { font-size: 0.88rem; font-weight: 560; line-height: 1.3; color: var(--sys-text-1); }
-.landing-deployment-arrow { text-align: center; color: var(--sys-text-3); font-size: 0.82rem; }
 
 .landing-preview {
-  padding: 12px 12px 10px;
+  padding: 34px 0 28px;
   border: 0;
+  position: relative;
+}
+
+.landing-preview::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: color-mix(in srgb, var(--sys-line-soft) 24%, transparent);
 }
 
 .landing-dashboard-preview {
-  margin-top: 8px;
+  margin-top: 0;
   border: none;
   outline: none;
   box-shadow: none;
@@ -263,6 +325,7 @@ body {
 }
 
 .landing-assurance-matrix {
+  margin-top: 16px;
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
@@ -329,140 +392,6 @@ body {
   background: color-mix(in srgb, var(--sys-bg-2) 62%, transparent);
 }
 .landing-footer-social-link svg { width: 14px; height: 14px; }
-
-
-
-.landing-system-surface {
-  position: relative;
-  background: linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 94%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
-}
-
-.landing-system-surface::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: calc(100% - 1px);
-  height: 1px;
-  background: color-mix(in srgb, var(--sys-line-soft) 24%, transparent);
-}
-
-.landing-section-head--sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-.landing-spec-sheet {
-  padding: 0 0 72px;
-}
-
-.landing-spec-sheet-inner {
-  max-width: 1200px;
-}
-
-.landing-operational-grid {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 96px;
-  align-items: stretch;
-  min-height: 400px;
-  padding: 160px 0 88px;
-  border-bottom: none;
-}
-
-.landing-capabilities,
-.landing-deployment {
-  min-height: 100%;
-  display: flex;
-  flex-direction: column;
-}
-
-.landing-capabilities h2,
-.landing-deployment h2 {
-  flex: 0 0 auto;
-}
-
-.landing-capabilities h2 {
-  margin-bottom: 56px;
-}
-
-.landing-deployment h2 {
-  margin-bottom: 56px;
-}
-
-.landing-capability-rows {
-  margin-top: 0;
-  border-top: 1px solid color-mix(in srgb, var(--sys-line-soft) 18%, transparent);
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  flex: 1;
-}
-
-.landing-capability-row {
-  min-height: 0;
-  grid-template-columns: 48px 1fr;
-  gap: 24px;
-  padding: 24px 0;
-  border-bottom: 1px solid color-mix(in srgb, var(--sys-line-soft) 16%, transparent);
-}
-
-.landing-deployment-rail {
-  margin: 0;
-  flex: 1;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-}
-
-.landing-deployment-step {
-  width: min(280px, 100%);
-  min-height: 96px;
-  border-radius: 6px;
-  border-color: color-mix(in srgb, var(--sys-line) 48%, transparent);
-  background: color-mix(in srgb, var(--sys-bg-2) 48%, transparent);
-  padding: 24px;
-  gap: 8px;
-}
-
-.landing-deployment-step--active {
-  border-color: color-mix(in srgb, var(--sys-line) 48%, transparent);
-  box-shadow: none;
-}
-
-.landing-deployment-arrow {
-  width: 24px;
-  flex: 0 0 24px;
-  font-size: 0.92rem;
-  color: color-mix(in srgb, var(--sys-text-3) 84%, transparent);
-}
-
-.landing-preview {
-  padding: 32px 0 0;
-  position: relative;
-}
-
-.landing-preview::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: color-mix(in srgb, var(--sys-line-soft) 26%, transparent);
-}
-
-.landing-dashboard-preview {
-  margin-top: 0;
-}
-
 @media (max-width: 1100px) {
   .landing-container { width: min(1180px, calc(100% - 44px)); }
   .landing-operational-grid { gap: 56px; }
@@ -470,25 +399,26 @@ body {
 
 @media (max-width: 900px) {
   .landing-hero { padding: 86px 0 56px; }
+
   .landing-operational-grid {
     grid-template-columns: 1fr;
-    gap: 42px;
+    gap: 56px;
     min-height: 0;
-    padding: 120px 0 80px;
+    padding: 128px 0 72px;
   }
+
   .landing-capabilities h2,
   .landing-deployment h2 {
-    margin-bottom: 36px;
+    margin-bottom: 40px;
   }
+
   .landing-deployment-rail {
-    flex-wrap: wrap;
-    justify-content: flex-start;
-    row-gap: 20px;
+    gap: 32px;
   }
 }
 
 @media (max-width: 767px) {
-  .landing-preview { padding: 28px 0 0; }
+  .landing-preview { padding: 26px 0 0; }
   .landing-assurances { padding: 14px 14px 16px; }
 
   .landing-container { width: min(1180px, calc(100% - 30px)); }
@@ -497,19 +427,31 @@ body {
   .landing-hero h1, .landing-hero p { max-width: none; }
   .landing-hero-actions { flex-direction: column; align-items: stretch; }
   .landing-hero-actions .btn, .landing-signup-form .btn { width: 100%; }
-  .landing-deployment-rail {
-    gap: 14px;
+
+  .landing-operational-grid {
+    padding-top: 96px;
+    gap: 40px;
   }
+
+  .landing-capabilities h2,
+  .landing-deployment h2 {
+    margin-bottom: 28px;
+  }
+
+  .landing-deployment-spine {
+    display: none;
+  }
+
+  .landing-deployment-rail {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
   .landing-deployment-step {
-    width: 100%;
-    min-height: 96px;
+    min-height: 104px;
     padding: 20px;
   }
-  .landing-deployment-arrow {
-    flex-basis: 100%;
-    width: auto;
-    text-align: left;
-  }
+
   .landing-deployment-step-label { font-size: 0.82rem; }
   .landing-assurance-matrix { grid-template-columns: 1fr; }
   .landing-signup { padding: 46px 0 42px; }
@@ -519,10 +461,6 @@ body {
   .landing-footer-social { justify-content: flex-start; }
 }
 
-@media (max-width: 480px) {
-  .landing-deployment-rail { grid-template-columns: 1fr; gap: 8px; }
-  .landing-deployment-arrow { transform: rotate(90deg); }
-}
 
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; scroll-behavior: auto !important; }

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -238,17 +238,16 @@ body {
   position: relative;
   flex: 1;
   display: flex;
-  align-items: stretch;
+  align-items: flex-end;
 }
 
 .landing-deployment-spine {
   position: absolute;
   left: 0;
   right: 0;
-  top: 50%;
+  bottom: 22px;
   height: 1px;
-  background: color-mix(in srgb, var(--sys-line) 30%, transparent);
-  transform: translateY(-0.5px);
+  background: color-mix(in srgb, var(--sys-line) 34%, transparent);
 }
 
 .landing-deployment-rail {
@@ -259,21 +258,34 @@ body {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 64px;
-  align-items: center;
+  align-items: end;
   position: relative;
   z-index: 1;
+  padding-bottom: 22px;
 }
 
 .landing-deployment-step {
+  position: relative;
   min-width: 0;
-  min-height: 112px;
+  min-height: 116px;
   border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--sys-line) 44%, transparent);
-  background: color-mix(in srgb, var(--sys-bg-2) 42%, transparent);
+  border: 1px solid color-mix(in srgb, var(--sys-line) 42%, transparent);
+  background: color-mix(in srgb, var(--sys-bg-2) 40%, transparent);
   padding: 24px;
   display: grid;
   align-content: center;
   gap: 8px;
+}
+
+.landing-deployment-step::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -22px;
+  width: 1px;
+  height: 22px;
+  transform: translateX(-0.5px);
+  background: color-mix(in srgb, var(--sys-line) 38%, transparent);
 }
 
 .landing-deployment-step-label {
@@ -284,7 +296,7 @@ body {
 }
 
 .landing-preview {
-  padding: 34px 0 28px;
+  padding: 26px 0 24px;
   border: 0;
   position: relative;
 }
@@ -394,7 +406,8 @@ body {
 .landing-footer-social-link svg { width: 14px; height: 14px; }
 @media (max-width: 1100px) {
   .landing-container { width: min(1180px, calc(100% - 44px)); }
-  .landing-operational-grid { gap: 56px; }
+  .landing-operational-grid { gap: 72px; }
+  .landing-deployment-rail { gap: 40px; }
 }
 
 @media (max-width: 900px) {
@@ -412,13 +425,23 @@ body {
     margin-bottom: 40px;
   }
 
+  .landing-deployment-spine {
+    bottom: 18px;
+  }
+
   .landing-deployment-rail {
-    gap: 32px;
+    gap: 24px;
+    padding-bottom: 18px;
+  }
+
+  .landing-deployment-step::after {
+    bottom: -18px;
+    height: 18px;
   }
 }
 
 @media (max-width: 767px) {
-  .landing-preview { padding: 26px 0 0; }
+  .landing-preview { padding: 24px 0 0; }
   .landing-assurances { padding: 14px 14px 16px; }
 
   .landing-container { width: min(1180px, calc(100% - 30px)); }
@@ -445,11 +468,16 @@ body {
   .landing-deployment-rail {
     grid-template-columns: 1fr;
     gap: 16px;
+    padding-bottom: 0;
   }
 
   .landing-deployment-step {
     min-height: 104px;
     padding: 20px;
+  }
+
+  .landing-deployment-step::after {
+    content: none;
   }
 
   .landing-deployment-step-label { font-size: 0.82rem; }

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -4,6 +4,8 @@
   --sys-bg-2: var(--vrm-bg-panel);
   --sys-line: color-mix(in srgb, var(--vrm-border) 75%, transparent);
   --sys-line-soft: color-mix(in srgb, var(--vrm-border) 45%, transparent);
+  --sys-plate-line: color-mix(in srgb, var(--vrm-border) 24%, transparent);
+  --sys-plate-line-strong: color-mix(in srgb, var(--vrm-border) 34%, transparent);
   --sys-text-1: var(--vrm-text-primary);
   --sys-text-2: var(--vrm-text-secondary);
   --sys-text-3: var(--vrm-text-muted);
@@ -140,8 +142,12 @@ body {
 }
 
 .landing-system-surface {
+  --deployment-rail-drop: 22px;
+
   position: relative;
-  border-top: 1px solid color-mix(in srgb, var(--sys-line-soft) 22%, transparent);
+  border-top: 1px solid var(--sys-plate-line);
+  border-left: 1px solid color-mix(in srgb, var(--sys-plate-line) 74%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--sys-plate-line) 74%, transparent);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 95%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
 }
@@ -245,9 +251,9 @@ body {
   position: absolute;
   left: 0;
   right: 0;
-  bottom: 22px;
+  bottom: var(--deployment-rail-drop);
   height: 1px;
-  background: color-mix(in srgb, var(--sys-line) 34%, transparent);
+  background: var(--sys-plate-line-strong);
 }
 
 .landing-deployment-rail {
@@ -261,7 +267,7 @@ body {
   align-items: end;
   position: relative;
   z-index: 1;
-  padding-bottom: 22px;
+  padding-bottom: var(--deployment-rail-drop);
 }
 
 .landing-deployment-step {
@@ -281,11 +287,11 @@ body {
   content: "";
   position: absolute;
   left: 50%;
-  bottom: -22px;
+  bottom: calc(var(--deployment-rail-drop) * -1);
   width: 1px;
-  height: 22px;
+  height: var(--deployment-rail-drop);
   transform: translateX(-0.5px);
-  background: color-mix(in srgb, var(--sys-line) 38%, transparent);
+  background: var(--sys-plate-line-strong);
 }
 
 .landing-deployment-step-label {
@@ -308,7 +314,17 @@ body {
   left: 0;
   right: 0;
   height: 1px;
-  background: color-mix(in srgb, var(--sys-line-soft) 24%, transparent);
+  background: var(--sys-plate-line);
+}
+
+.landing-preview::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: calc(50% + 48px);
+  right: 0;
+  height: 1px;
+  background: var(--sys-plate-line-strong);
 }
 
 .landing-dashboard-preview {
@@ -425,18 +441,12 @@ body {
     margin-bottom: 40px;
   }
 
-  .landing-deployment-spine {
-    bottom: 18px;
+  .landing-system-surface {
+    --deployment-rail-drop: 18px;
   }
 
   .landing-deployment-rail {
     gap: 24px;
-    padding-bottom: 18px;
-  }
-
-  .landing-deployment-step::after {
-    bottom: -18px;
-    height: 18px;
   }
 }
 
@@ -461,6 +471,10 @@ body {
     margin-bottom: 28px;
   }
 
+  .landing-system-surface {
+    --deployment-rail-drop: 0px;
+  }
+
   .landing-deployment-spine {
     display: none;
   }
@@ -477,6 +491,10 @@ body {
   }
 
   .landing-deployment-step::after {
+    content: none;
+  }
+
+  .landing-preview::after {
     content: none;
   }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -149,11 +149,11 @@ body {
 
 .landing-operational-grid {
   display: grid;
-  grid-template-columns: minmax(0, 5.5fr) minmax(0, 6.5fr);
-  gap: 80px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 96px;
   align-items: stretch;
   min-height: 440px;
-  padding: 152px 0 72px;
+  padding: 152px 48px 72px;
 }
 
 .landing-capabilities,
@@ -161,6 +161,7 @@ body {
   min-height: 100%;
   display: flex;
   flex-direction: column;
+  padding-inline: 20px;
 }
 
 .landing-capabilities h2,
@@ -204,7 +205,7 @@ body {
 }
 
 .landing-capabilities-inner {
-  max-width: 468px;
+  max-width: 440px;
   width: 100%;
   margin-inline: auto;
   min-height: 100%;
@@ -222,7 +223,7 @@ body {
   --deploy-x-step: 136px;
   --deploy-y-step: 48px;
 
-  max-width: 500px;
+  max-width: 460px;
   margin-inline: auto;
   width: 100%;
 }
@@ -411,8 +412,8 @@ body {
 @media (max-width: 1100px) {
   .landing-container { width: min(1180px, calc(100% - 44px)); }
   .landing-operational-grid {
-    gap: 56px;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+    gap: 64px;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .landing-deployment-content {
@@ -429,7 +430,12 @@ body {
     grid-template-columns: 1fr;
     gap: 48px;
     min-height: 0;
-    padding: 112px 0 60px;
+    padding: 112px 36px 60px;
+  }
+
+  .landing-capabilities,
+  .landing-deployment {
+    padding-inline: 0;
   }
 
   .landing-capabilities h2,
@@ -461,7 +467,7 @@ body {
   .landing-hero-actions .btn, .landing-signup-form .btn { width: 100%; }
 
   .landing-operational-grid {
-    padding-top: 96px;
+    padding: 96px 0 0;
     gap: 40px;
   }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -149,7 +149,7 @@ body {
 
 .landing-operational-grid {
   display: grid;
-  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  grid-template-columns: minmax(0, 5.5fr) minmax(0, 6.5fr);
   gap: 80px;
   align-items: stretch;
   min-height: 440px;
@@ -203,27 +203,28 @@ body {
   min-height: 0;
 }
 
-.landing-capabilities-content {
-  max-width: 460px;
+.landing-capabilities-inner {
+  max-width: 468px;
+  width: 100%;
   margin-inline: auto;
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.landing-capabilities-content {
   width: 100%;
 }
 
 .landing-deployment-content {
   --deploy-step-width: 272px;
   --deploy-step-height: 112px;
-  --deploy-x-step: 132px;
+  --deploy-x-step: 136px;
   --deploy-y-step: 48px;
 
   max-width: 500px;
   margin-inline: auto;
   width: 100%;
-}
-
-.landing-capabilities > h2 {
-  max-width: 460px;
-  width: 100%;
-  margin-inline: auto;
 }
 
 .landing-capability-rows {
@@ -273,15 +274,13 @@ body {
   margin: 0;
   padding: 0;
   list-style: none;
-  position: relative;
-  width: calc(var(--deploy-step-width) + var(--deploy-x-step));
-  min-height: calc(var(--deploy-step-height) + (var(--deploy-y-step) * 2));
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--deploy-y-step);
 }
 
 .landing-deployment-step {
-  position: absolute;
-  left: 0;
-  top: 0;
   min-width: 0;
   width: min(var(--deploy-step-width), 100%);
   min-height: var(--deploy-step-height);
@@ -294,16 +293,13 @@ body {
   gap: 8px;
 }
 
-.landing-deployment-step--one {
-  transform: translate(0, 0);
+.landing-deployment-step--one,
+.landing-deployment-step--three {
+  margin-left: 0;
 }
 
 .landing-deployment-step--two {
-  transform: translate(var(--deploy-x-step), var(--deploy-y-step));
-}
-
-.landing-deployment-step--three {
-  transform: translate(0, calc(var(--deploy-y-step) * 2));
+  margin-left: var(--deploy-x-step);
 }
 
 .landing-deployment-step-label {
@@ -421,7 +417,7 @@ body {
 
   .landing-deployment-content {
     --deploy-step-width: 264px;
-    --deploy-x-step: 112px;
+    --deploy-x-step: 120px;
     --deploy-y-step: 44px;
   }
 }
@@ -486,20 +482,15 @@ body {
   }
 
   .landing-deployment-zigzag {
-    position: static;
     width: 100%;
-    min-height: 0;
-    display: flex;
-    flex-direction: column;
     gap: 16px;
   }
 
   .landing-deployment-step {
-    position: static;
     width: 100%;
     min-height: 104px;
     padding: 20px;
-    transform: none !important;
+    margin-left: 0 !important;
   }
 
   .landing-deployment-step-label { font-size: 0.82rem; }

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -5,7 +5,6 @@
   --sys-line: color-mix(in srgb, var(--vrm-border) 75%, transparent);
   --sys-line-soft: color-mix(in srgb, var(--vrm-border) 45%, transparent);
   --sys-plate-line: color-mix(in srgb, var(--vrm-border) 24%, transparent);
-  --sys-plate-line-strong: color-mix(in srgb, var(--vrm-border) 34%, transparent);
   --sys-text-1: var(--vrm-text-primary);
   --sys-text-2: var(--vrm-text-secondary);
   --sys-text-3: var(--vrm-text-muted);
@@ -129,7 +128,7 @@ body {
 
 
 .landing-spec-sheet {
-  padding: 0 0 92px;
+  padding: 0 0 84px;
 }
 
 .landing-spec-sheet-inner {
@@ -142,33 +141,19 @@ body {
 }
 
 .landing-system-surface {
-  --deployment-rail-drop: 22px;
-
   position: relative;
   border-top: 1px solid var(--sys-plate-line);
-  border-left: 1px solid color-mix(in srgb, var(--sys-plate-line) 74%, transparent);
-  border-right: 1px solid color-mix(in srgb, var(--sys-plate-line) 74%, transparent);
   background:
     linear-gradient(180deg, color-mix(in srgb, var(--sys-bg-1) 95%, transparent) 0%, color-mix(in srgb, var(--sys-bg-1) 98%, transparent) 100%);
 }
 
-.landing-system-surface::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 1px;
-  background: var(--sys-plate-line);
-}
-
 .landing-operational-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 96px;
+  grid-template-columns: minmax(0, 5fr) minmax(0, 7fr);
+  gap: 80px;
   align-items: stretch;
   min-height: 440px;
-  padding: 160px 0 84px;
+  padding: 152px 0 72px;
 }
 
 .landing-capabilities,
@@ -218,6 +203,18 @@ body {
   min-height: 0;
 }
 
+.landing-capabilities-content {
+  max-width: 460px;
+  margin-inline: auto;
+  width: 100%;
+}
+
+.landing-deployment-content {
+  max-width: 500px;
+  margin-inline: auto;
+  width: 100%;
+}
+
 .landing-capability-rows {
   margin-top: 0;
   display: flex;
@@ -261,58 +258,43 @@ body {
   align-items: flex-end;
 }
 
-.landing-deployment-field {
-  position: relative;
-  flex: 1;
-  display: flex;
-  align-items: flex-end;
-}
-
-.landing-deployment-spine {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: var(--deployment-rail-drop);
-  height: 1px;
-  background: var(--sys-plate-line-strong);
-}
-
-.landing-deployment-rail {
+.landing-deployment-zigzag {
   margin: 0;
   padding: 0;
   list-style: none;
   width: 100%;
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 64px;
-  align-items: end;
-  position: relative;
-  z-index: 1;
-  padding-bottom: var(--deployment-rail-drop);
+  grid-template-columns: minmax(0, 1fr);
+  grid-auto-rows: minmax(112px, auto);
+  row-gap: 44px;
 }
 
 .landing-deployment-step {
-  position: relative;
   min-width: 0;
-  min-height: 116px;
+  width: min(280px, 100%);
+  min-height: 112px;
   border-radius: 6px;
-  border: 1px solid color-mix(in srgb, var(--sys-line) 42%, transparent);
-  background: color-mix(in srgb, var(--sys-bg-2) 40%, transparent);
+  border: 1px solid color-mix(in srgb, var(--sys-line) 34%, transparent);
+  background: color-mix(in srgb, var(--sys-bg-2) 30%, transparent);
   padding: 24px;
   display: grid;
   align-content: center;
   gap: 8px;
 }
 
-.landing-deployment-step::after {
-  content: "";
-  position: absolute;
-  left: 50%;
-  bottom: calc(var(--deployment-rail-drop) * -1);
-  width: 1px;
-  height: var(--deployment-rail-drop);
-  transform: translateX(-0.5px);
-  background: var(--sys-plate-line-strong);
+.landing-deployment-step--one {
+  justify-self: start;
+  transform: translateX(0);
+}
+
+.landing-deployment-step--two {
+  justify-self: start;
+  transform: translateX(96px);
+}
+
+.landing-deployment-step--three {
+  justify-self: start;
+  transform: translateX(28px);
 }
 
 .landing-deployment-step-label {
@@ -323,29 +305,9 @@ body {
 }
 
 .landing-preview {
-  padding: 26px 0 24px;
+  padding: 20px 0 20px;
   border: 0;
   position: relative;
-}
-
-.landing-preview::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: var(--sys-plate-line);
-}
-
-.landing-preview::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: calc(50% + 48px);
-  right: 0;
-  height: 1px;
-  background: var(--sys-plate-line-strong);
 }
 
 .landing-dashboard-preview {
@@ -443,8 +405,12 @@ body {
 .landing-footer-social-link svg { width: 14px; height: 14px; }
 @media (max-width: 1100px) {
   .landing-container { width: min(1180px, calc(100% - 44px)); }
-  .landing-operational-grid { gap: 72px; }
-  .landing-deployment-rail { gap: 40px; }
+  .landing-operational-grid {
+    gap: 56px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  }
+  .landing-deployment-step--two { transform: translateX(72px); }
+  .landing-deployment-step--three { transform: translateX(20px); }
 }
 
 @media (max-width: 900px) {
@@ -452,9 +418,9 @@ body {
 
   .landing-operational-grid {
     grid-template-columns: 1fr;
-    gap: 56px;
+    gap: 48px;
     min-height: 0;
-    padding: 128px 0 72px;
+    padding: 112px 0 60px;
   }
 
   .landing-capabilities h2,
@@ -462,17 +428,21 @@ body {
     margin-bottom: 40px;
   }
 
-  .landing-system-surface {
-    --deployment-rail-drop: 18px;
+  .landing-capabilities-content,
+  .landing-deployment-content {
+    max-width: 560px;
   }
 
-  .landing-deployment-rail {
-    gap: 24px;
+  .landing-deployment-zigzag {
+    row-gap: 30px;
   }
+
+  .landing-deployment-step--two { transform: translateX(52px); }
+  .landing-deployment-step--three { transform: translateX(16px); }
 }
 
 @media (max-width: 767px) {
-  .landing-preview { padding: 24px 0 0; }
+  .landing-preview { padding: 16px 0 0; }
   .landing-assurances { padding: 14px 14px 16px; }
 
   .landing-container { width: min(1180px, calc(100% - 30px)); }
@@ -492,31 +462,20 @@ body {
     margin-bottom: 28px;
   }
 
-  .landing-system-surface {
-    --deployment-rail-drop: 0px;
+  .landing-capabilities-content,
+  .landing-deployment-content {
+    max-width: 100%;
   }
 
-  .landing-deployment-spine {
-    display: none;
-  }
-
-  .landing-deployment-rail {
-    grid-template-columns: 1fr;
-    gap: 16px;
-    padding-bottom: 0;
+  .landing-deployment-zigzag {
+    row-gap: 16px;
   }
 
   .landing-deployment-step {
+    width: 100%;
     min-height: 104px;
     padding: 20px;
-  }
-
-  .landing-deployment-step::after {
-    content: none;
-  }
-
-  .landing-preview::after {
-    content: none;
+    transform: none !important;
   }
 
   .landing-deployment-step-label { font-size: 0.82rem; }


### PR DESCRIPTION
### Motivation
- Convert the “Platform Capabilities” + “System Deployment” band from a SaaS/onboarding visual into an engineered, infrastructure-grade system surface with strict grid and calm hierarchy. 
- Ensure the two panels read as equal-depth, equal-height system panels and visually merge into the preview/topology area below without changing any copy. 
- Provide deterministic visual verification coverage (mobile/tablet/desktop) so the seam and alignment can be reviewed as part of CI.

### Description
- Restructured the landing band so `Capabilities`, `Deployment`, and the `Preview` live inside a single `landing-system-surface` wrapper and moved the visible preview header into a screen-reader-only wrapper to remove the title-driven box separation (file: `frontend/src/features/landing/LandingPage.tsx`).
- Implemented the spacing/grid/visual rhythm in `LandingPage.css` to match the spec: 160px top padding, 160px bottom rhythm (adjusted to seam), 2-column 6/6 layout with a 96px column gap, min-height shared panel depth (400px), capability row rhythm (48px index column, 24px index→text gap, 24px vertical padding), toned-down borders, equal-height two-panel flex distribution, and reduced decorative emphasis (removed active-step highlight styling).
- Aligned the preview frame into the same continuous plane by removing inset/max-width/padding cues in `SystemOverviewPreview.module.css` so the preview canvas continues the same surface geometry and grid alignment.
- Added a Playwright-based visual capture script (`frontend/scripts/landing-visual-regression.mjs`) and an npm script `test:landing-visual` to produce screenshots for `mobile` (375×812), `tablet` (768×1024) and `desktop` (1440×900) focused on the `landing-system-surface` element.
- Responsive adjustments were added to preserve structural seam and equal-bottom alignment across breakpoints without any copy changes (only structure/style edits in CSS and JSX).

### Testing
- Ran `npm run build` (Vite) and the production build completed successfully. ✅
- Installed Playwright browsers with `npx playwright install chromium` which completed (binaries installed). ✅
- Running the repo’s topology verification (`npm run verify:topology`) failed to launch Chromium in this container due to a missing system shared library (`libatk-1.0.so.0`), preventing Playwright from completing in this environment. ⚠️
- Running `npm run test:landing-visual` similarly failed to launch Playwright Chromium here for the same missing shared-library reason; this is an environment/runtime limitation rather than a code failure. ⚠️
- Captured visual verification screenshots via an alternative headless browser invocation while the dev server ran; artifacts produced for review: `artifacts/landing-system-surface-desktop.png`, `artifacts/landing-system-surface-tablet.png`, and `artifacts/landing-system-surface-mobile.png`. ✅

Files changed: `frontend/src/features/landing/LandingPage.tsx`, `frontend/src/styles/LandingPage.css`, `frontend/src/features/landing/components/SystemOverviewPreview.module.css`, `frontend/package.json`, and new `frontend/scripts/landing-visual-regression.mjs`.

No copy/text was modified; all edits are layout, spacing, structure and styling only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6993041ac43c832fbd837ce91e32a8bc)