### PR TITLE
Restore Traffic Split donut rendering and align topology connector to donut geometry

### DIFF
--- a/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
@@ -2,13 +2,13 @@ import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from "recharts";
 import type { ChartPrimitiveProps } from "./types";
 import { formatNumeric } from "../utils/format";
 const sliceColors = [
-  "#2d6cdf",
-  "#4bcf9f",
-  "#f4b63d",
-  "#f97066",
-  "#7c3aed",
-  "#0ea5e9",
+  "#1f3f78",
+  "#2b5da8",
+  "#3b77c8",
 ];
+
+const DONUT_INNER_RADIUS = 42;
+const DONUT_OUTER_RADIUS = 58;
 export const TrafficDistribution = ({
   result,
   series,
@@ -44,20 +44,9 @@ export const TrafficDistribution = ({
   const contentClassName = `traffic-distribution__content${
     isVrmTraffic ? " traffic-distribution__content--vrm" : ""
   }`;
-  if (!primary || data.length === 0) {
-    return (
-      <div
-        className={`traffic-distribution kpi-tile ${className ?? ""}`}
-        style={{ minHeight: height }}
-      >
-        <div className="traffic-distribution__empty">
-          No traffic data available.
-        </div>
-      </div>
-    );
-  }
-  const legend = data.map((point, index) => {
-    const rawCamera = point.x ?? `Cam ${index + 1}`;
+  const tupleData = Array.from({ length: 3 }, (_, index) => data[index]);
+  const legend = tupleData.map((point, index) => {
+    const rawCamera = point?.x ?? `Cam ${index + 1}`;
     const normalizedCameraId = String(rawCamera)
       .replace(/^Cam\s*/i, "")
       .trim();
@@ -70,9 +59,9 @@ export const TrafficDistribution = ({
     const rawLabel =
       String(baseLabel ?? rawCamera).trim() || `Slice ${index + 1}`;
     const rawValue =
-      typeof point.value === "number"
+      typeof point?.value === "number"
         ? point.value
-        : typeof point.y === "number"
+        : typeof point?.y === "number"
           ? point.y
           : 0;
     const numericValue = Number(rawValue);
@@ -87,54 +76,6 @@ export const TrafficDistribution = ({
     };
   });
   const totalValue = legend.reduce((total, slice) => total + slice.value, 0);
-  const nonFiniteValues = legend
-    .map((entry) => entry.value)
-    .filter((value) => !Number.isFinite(value))
-    .slice(0, 5);
-  if (!legend.length || totalValue <= 0) {
-    const emptySlice = [
-      {
-        label: "No data",
-        value: 1,
-        color: "var(--vrm-border)",
-      },
-    ];
-    return (
-      <div
-        className={`traffic-distribution kpi-tile ${className ?? ""}`}
-        style={{ minHeight: height }}
-      >
-        <div className="traffic-distribution__title">{title}</div>
-        <div className={contentClassName}>
-          <ResponsiveContainer width="100%" height={140}>
-            <PieChart>
-              <Pie
-                dataKey="value"
-                data={emptySlice}
-                cx="50%"
-                cy="50%"
-                innerRadius={48}
-                outerRadius={68}
-                paddingAngle={0}
-                startAngle={90}
-                endAngle={450}
-                label={undefined}
-                labelLine={false}
-                stroke="none"
-                isAnimationActive={false}
-              >
-                <Cell
-                  key="empty"
-                  fill={emptySlice[0].color}
-                  stroke="none"
-                />
-              </Pie>
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-    );
-  }
   const renderLegend = legend.map((entry) => ({
     ...entry,
     renderValue: entry.value,
@@ -149,6 +90,10 @@ export const TrafficDistribution = ({
     ...entry,
     value: entry.renderValue,
   }));
+  const isEmptyRing = totalValue <= 0;
+  const donutData = isEmptyRing
+    ? [{ label: "Empty", value: 1, color: "rgba(61, 95, 145, 0.18)", camId: "—", displayValue: 0 }]
+    : pieLegend;
   const topCameraLabel =
     renderTopSlice.camId === null ||
     renderTopSlice.camId === undefined ||
@@ -161,7 +106,7 @@ export const TrafficDistribution = ({
       style={{ minHeight: height }}
     >
       <div className="traffic-distribution__title">{title}</div>
-      <div className={contentClassName}>
+      <div className={contentClassName} data-traffic-donut="true" data-traffic-donut-radius={DONUT_OUTER_RADIUS}>
         <ResponsiveContainer width="100%" height={140}>
           <PieChart>
             <Tooltip
@@ -182,23 +127,24 @@ export const TrafficDistribution = ({
             />
             <Pie
               dataKey="value"
-              data={pieLegend}
+              data={donutData}
               nameKey={labelKey ?? undefined}
               cx="50%"
               cy="50%"
-              innerRadius={48}
-              outerRadius={68}
-              paddingAngle={0}
+              innerRadius={DONUT_INNER_RADIUS}
+              outerRadius={DONUT_OUTER_RADIUS}
+              paddingAngle={isEmptyRing ? 0 : 1.25}
               startAngle={90}
               endAngle={450}
               label={undefined}
               labelLine={false}
-              stroke="none"
+              stroke={isEmptyRing ? "none" : "rgba(11, 24, 44, 0.9)"}
+              strokeWidth={isEmptyRing ? 0 : 1}
+              isAnimationActive={false}
             >
-              {" "}
-              {pieLegend.map((entry) => (
+              {donutData.map((entry) => (
                 <Cell key={entry.label} fill={entry.color} stroke="none" />
-              ))}{" "}
+              ))}
               <text
                 x="50%"
                 y="50%"

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -83,8 +83,8 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
     exits: null,
     footfall: null,
   });
-  const leftSlotRef = useRef<HTMLDivElement | null>(null);
-  const leftEdgeRef = useRef<HTMLSpanElement | null>(null);
+  const trafficSlotRef = useRef<HTMLDivElement | null>(null);
+  const trafficEdgeRef = useRef<HTMLSpanElement | null>(null);
   const dwellSlotRef = useRef<HTMLDivElement | null>(null);
   const dwellEdgeRef = useRef<HTMLSpanElement | null>(null);
   const nodeAnchorRef = useRef<HTMLSpanElement | null>(null);
@@ -140,7 +140,7 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
           !containerRef.current ||
           !topClusterRef.current ||
           !bottomClusterRef.current ||
-          !leftSlotRef.current ||
+          !trafficSlotRef.current ||
           !dwellSlotRef.current ||
           !nodeAnchorRef.current
         ) {
@@ -148,21 +148,36 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
         }
 
         const connectedTopEdges = CONNECTED_TOP_IDS.map((id) => topEdgeRefs.current[id]);
-        if (connectedTopEdges.some((edge) => !edge) || !leftEdgeRef.current || !dwellEdgeRef.current) {
+        if (connectedTopEdges.some((edge) => !edge) || !dwellEdgeRef.current) {
           return;
         }
 
         const containerRect = containerRef.current.getBoundingClientRect();
         const nodeRect = nodeAnchorRef.current.getBoundingClientRect();
         const topRects = connectedTopEdges.map((edge) => (edge as HTMLSpanElement).getBoundingClientRect());
-        const trafficRect = leftEdgeRef.current.getBoundingClientRect();
+        const trafficDonut = trafficSlotRef.current.querySelector<HTMLElement>("[data-traffic-donut='true']");
+        let trafficCenterX = 0;
+        let trafficNorthY = 0;
+        if (trafficDonut) {
+          const trafficRect = trafficDonut.getBoundingClientRect();
+          const trafficRadius = Number(trafficDonut.dataset.trafficDonutRadius ?? "58");
+          trafficCenterX = trafficRect.left - containerRect.left + trafficRect.width / 2;
+          const trafficCenterY = trafficRect.top - containerRect.top + trafficRect.height / 2;
+          trafficNorthY = trafficCenterY - trafficRadius;
+        } else if (trafficEdgeRef.current) {
+          const trafficRect = trafficEdgeRef.current.getBoundingClientRect();
+          trafficCenterX = trafficRect.left - containerRect.left + trafficRect.width / 2;
+          trafficNorthY = trafficRect.top - containerRect.top + trafficRect.height / 2;
+        } else {
+          return;
+        }
         const dwellRect = dwellEdgeRef.current.getBoundingClientRect();
 
         const taps: Record<RouteId, number> = {
           entrances: topRects[0].left - containerRect.left + topRects[0].width / 2,
           occupancy: topRects[1].left - containerRect.left + topRects[1].width / 2,
           exits: topRects[2].left - containerRect.left + topRects[2].width / 2,
-          traffic: trafficRect.left - containerRect.left + trafficRect.width / 2,
+          traffic: trafficCenterX,
           dwell: dwellRect.left - containerRect.left + dwellRect.width / 2,
         };
 
@@ -178,7 +193,7 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
             entrances: topRects[0].top - containerRect.top + topRects[0].height / 2,
             occupancy: topRects[1].top - containerRect.top + topRects[1].height / 2,
             exits: topRects[2].top - containerRect.top + topRects[2].height / 2,
-            traffic: trafficRect.top - containerRect.top + trafficRect.height / 2,
+            traffic: trafficNorthY,
             dwell: dwellRect.top - containerRect.top + dwellRect.height / 2,
           },
         });
@@ -198,8 +213,10 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
       if (slot) observer.observe(slot);
       if (edge) observer.observe(edge);
     });
-    if (leftSlotRef.current) observer.observe(leftSlotRef.current);
-    if (leftEdgeRef.current) observer.observe(leftEdgeRef.current);
+    if (trafficSlotRef.current) observer.observe(trafficSlotRef.current);
+    const trafficDonut = trafficSlotRef.current?.querySelector<HTMLElement>("[data-traffic-donut='true']");
+    if (trafficDonut) observer.observe(trafficDonut);
+    if (trafficEdgeRef.current) observer.observe(trafficEdgeRef.current);
     if (dwellSlotRef.current) observer.observe(dwellSlotRef.current);
     if (dwellEdgeRef.current) observer.observe(dwellEdgeRef.current);
     window.addEventListener("resize", scheduleMeasure);
@@ -331,11 +348,11 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean }> = ({ forc
         <div className={styles.bottomCluster} ref={bottomClusterRef}>
           <article className={styles.trafficTile}>
             {trafficWidget || forceMockTopology ? (
-              <div className={styles.wireAnchorSlot} ref={leftSlotRef}>
+              <div className={styles.wireAnchorSlot} ref={trafficSlotRef}>
                 {forceMockTopology
                   ? renderMockTile("Traffic Split", "41/34/25")
                   : <DashboardKpiSection mode="preview" kpiWidgets={[trafficWidget!]} onRemoveWidget={NOOP_REMOVE} />}
-                <span className={`${styles.wireEdgeAnchor} ${styles.wireEdgeAnchorTop}`} data-anchor-id="bottom-traffic" ref={leftEdgeRef} />
+                <span className={`${styles.wireEdgeAnchor} ${styles.wireEdgeAnchorTop}`} data-anchor-id="bottom-traffic" ref={trafficEdgeRef} />
               </div>
             ) : hasError ? (
               <div className={styles.inlineNotice}>Preview unavailable.</div>


### PR DESCRIPTION
### Motivation
- The Traffic Split widget must treat its input as a raw 3-value tuple and always render a donut, showing an empty ring for `[0,0,0]` rather than an error or text fallback.
- The landing topology connector must align to the donut’s true north (computed from the donut center and radius) so the bus connector and pulse meet the donut geometry precisely.

### Description
- Traffic donut rendering now plots the 3-tuple directly (always using up to three entries) and removes the previous `No traffic data available` fallback so the donut always renders, with an explicit empty-ring rendering when the total is zero; visual tuning includes a compact dark-blue palette and adjusted `innerRadius`/`outerRadius` constants in `frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx`.
- The donut exposes geometry metadata via DOM attributes (`data-traffic-donut="true"` and `data-traffic-donut-radius`) so callers can measure center and radius after render for connector alignment in `frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx`.
- The preview topology measurement in `frontend/src/features/landing/components/SystemOverviewPreview.tsx` now queries the rendered donut element, computes the center `(cx, cy)` and north endpoint `(cx, cy - r)`, and uses that point for the traffic connector endpoint with a fallback to the previous anchor span when the donut node isn't available.
- Added `ResizeObserver` observation of the donut element so geometry is re-measured on resize and layout changes, and kept a mock-mode fallback anchor to preserve preview/mock workflows.

### Testing
- Ran the frontend production build with `npm run -s build`, which completed successfully.
- Attempted the topology verification `TOPOLOGY_BASE_URL=http://127.0.0.1:4173 npm run -s verify:topology`, which failed in this environment because the `playwright` package is not installed. 
- Launched the dev server with `npm run dev` and executed an automated headless page capture to produce an updated landing screenshot for visual validation, which completed and produced an artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6998412636fc8325badb7701fe1df7da)