### PR TITLE
Tighten Metrics/Access density and strengthen headers on landing axis

### DIFF
--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -232,7 +232,7 @@ body {
   --axis-row-min-height: 48px;
   --mx-block-top: 14px;
   --mx-header-to-row1: 40px;
-  --mx-row-gap: 32px;
+  --mx-row-gap: 26px;
   --mx-block-bottom: 38px;
 
   width: 100%;
@@ -285,7 +285,7 @@ body {
   font-size: clamp(1.24rem, 1.8vw, 1.6rem);
   line-height: 1.28;
   letter-spacing: -0.01em;
-  font-weight: 600;
+  font-weight: 700;
   margin-bottom: var(--mx-header-to-row1);
 }
 
@@ -553,7 +553,7 @@ body {
     --axis-gap: 28px;
     --mx-block-top: 56px;
     --mx-header-to-row1: 36px;
-    --mx-row-gap: 18px;
+    --mx-row-gap: 12px;
     --mx-block-bottom: 30px;
   }
 }
@@ -582,7 +582,7 @@ body {
     --axis-row-min-height: 48px;
     --mx-block-top: 12px;
     --mx-header-to-row1: 30px;
-    --mx-row-gap: 22px;
+    --mx-row-gap: 16px;
     --mx-block-bottom: 38px;
   }
 }


### PR DESCRIPTION
### Motivation
- Reduce vertical spacing in the Metrics/Access axis by ~6px (desktop-first) while preserving layout, hero, preview, and topology.  
- Increase the visual hierarchy of the Metrics/Access section headings using a modest font-weight change only, with no notable size or layout changes.

### Description
- Changed a single file: `frontend/src/styles/LandingPage.css` to keep this CSS-first and minimal.  
- Adjusted the row-gap variable values: `--mx-row-gap` base `32px → 26px`, `@media (max-width: 1100px)` `18px → 12px`, and `@media (max-width: 900px)` `22px → 16px`.  
- Increased the axis section heading weight: `.landing-axis-cell-heading` `font-weight: 600 → 700` (font-supported effective step) and left font-size and spacing unchanged.  
- No markup changes, no topology/grid/hero/preview changes, and no other files touched.

### Testing
- Launched dev server and installs: ran `npm install` and `npm run dev` to serve the app for visual and computed-style checks, which completed successfully.  
- Measured spacing with headless browser checks at three viewports and confirmed the expected deltas: at 1440px `row-gap` changed `32px → 26px` (delta -6px), at ~1100px `18px → 12px` (delta -6px), and at 900px `22px → 16px` (delta -6px).  
- Computed style checks confirm heading hierarchy: `.landing-axis-cell-heading` computed `font-weight: 700`, `.landing-axis-cell` row text `font-weight: 400`, and `.landing-axis-right-action` `font-weight: 580`, so the heading is heavier than both row text and the first action label.  
- Quick visual scan confirmed no regressions to hero, preview, or topology.  
- `git diff --name-only` output shows only `frontend/src/styles/LandingPage.css` was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6999e3c62eb08321af44bd7e269727f9)