### PR TITLE
Add authenticated Home shell page and enable Home navigation

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -22,6 +22,7 @@ const AlarmLogsPage = React.lazy(() => import("../pages/AlarmLogsPage"));
 const DeviceListPage = React.lazy(() => import("../pages/DeviceListPage"));
 const ReportsPage = React.lazy(() => import("../pages/ReportsPage"));
 const AdminPage = React.lazy(() => import("../pages/AdminPage"));
+const HomePage = React.lazy(() => import("../pages/HomePage"));
 const LandingPage = React.lazy(() => import("../pages/LandingPage"));
 const LoginPage = React.lazy(() => import("../pages/LoginPage"));
 const CreateAccountPage = React.lazy(() => import("../pages/CreateAccountPage"));
@@ -209,12 +210,16 @@ const AppRoutes: React.FC = () => {
           <Route
             path="/home"
             element={
-              <Navigate
-                to={appendViewToken(
-                  `/sites/${resolveLegacySiteId()}/dashboard`,
-                )}
-                replace
-              />
+              isAuthenticatedMode ? (
+                renderClientRoute(lazyRoute(<HomePage />))
+              ) : (
+                <Navigate
+                  to={appendViewToken(
+                    `/sites/${resolveLegacySiteId()}/dashboard`,
+                  )}
+                  replace
+                />
+              )
             }
           />
           <Route

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -166,7 +166,7 @@ const AppRoutes: React.FC = () => {
           ) : appMode === "view_token" || appMode === "demo" ? (
             <Navigate to={appendViewToken("/sites/all/dashboard")} replace />
           ) : (
-            <Navigate to="/dashboard" replace />
+            <Navigate to="/home" replace />
           )
         }
       />
@@ -177,7 +177,7 @@ const AppRoutes: React.FC = () => {
           appMode === "public" ? (
             lazyRoute(<CreateAccountPage />)
           ) : (
-            <Navigate to="/dashboard" replace />
+            <Navigate to="/home" replace />
           )
         }
       />
@@ -187,7 +187,7 @@ const AppRoutes: React.FC = () => {
           appMode === "public" ? (
             lazyRoute(<LoginPage onLogin={handleLogin} />)
           ) : (
-            <Navigate to="/dashboard" replace />
+            <Navigate to="/home" replace />
           )
         }
       />
@@ -297,7 +297,7 @@ const AppRoutes: React.FC = () => {
           ) : appMode === "view_token" || appMode === "demo" ? (
             <Navigate to={appendViewToken("/sites/all/dashboard")} replace />
           ) : (
-            <Navigate to="/dashboard" replace />
+            <Navigate to="/home" replace />
           )
         }
       />

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -67,7 +67,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const pointerZoneRef = useRef(pointerZone);
   const [isTouchMode, setIsTouchMode] = useState(false);
   const [sitesIntentOpen, setSitesIntentOpen] = useState(false);
-  const [isForceExpandedOnce, setIsForceExpandedOnce] = useState(false);
+  const [forcedSitesExpandOnceActive, setForcedSitesExpandOnceActive] = useState(false);
   const [keepMenuExpanded, setKeepMenuExpanded] = useState(() => {
     if (typeof window === "undefined") {
       return true;
@@ -87,7 +87,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   );
   const isEmbedMode = searchParams.get("embed") === "1";
   const isSelectorOpen = searchParams.get("panel") === "sites";
-  const isForceExpandIntent = searchParams.get("expand") === "1";
+  const isForceExpandIntent = searchParams.get("expand_once") === "1";
   const activeSite = findSiteById(siteId);
   const isDemoSession = isDemoSessionActive();
   const allSitesOption =
@@ -254,6 +254,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const selectedSiteForList = getStoredSiteId() ?? "all";
   const showSiteMenu = Boolean(siteId) && !isSelectorOpen;
   const isHomeRoute = location.pathname === "/home";
+  const isSitesRoute = /^\/sites(?:\/|$)/.test(location.pathname);
   const shouldRenderSecondaryPanel = !isHomeRoute || isSelectorOpen;
   const shouldShowAdminMenu =
     userRole === "admin" && location.pathname.startsWith("/admin");
@@ -279,15 +280,14 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     pointerZone === "SITES_ROW" ||
     focusZone === "PRIMARY" ||
     sitesIntentOpen;
-  const isSecondaryExpanded =
-    !shouldForceCollapse &&
-    (keepMenuExpanded ||
-      pointerZone === "SITES_ROW" ||
-      pointerZone === "SECONDARY" ||
-      focusZone === "SECONDARY" ||
-      sitesIntentOpen ||
-      isSelectorOpen ||
-      isForceExpandedOnce);
+  const isSecondaryExpanded = forcedSitesExpandOnceActive
+    ? true
+    : !shouldForceCollapse &&
+      (keepMenuExpanded ||
+        pointerZone === "SITES_ROW" ||
+        pointerZone === "SECONDARY" ||
+        focusZone === "SECONDARY" ||
+        sitesIntentOpen);
   const toggleLabel = keepMenuExpanded ? "Collapse Sidebar" : "Keep Expanded";
   const toggleIcon = keepMenuExpanded ? (
     <NavIcon icon={ChevronLeft} className="vrm-nav-chevron" />
@@ -339,8 +339,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
         return;
       }
 
-      if (isForceExpandedOnce) {
-        setIsForceExpandedOnce(false);
+      if (forcedSitesExpandOnceActive) {
+        setForcedSitesExpandOnceActive(false);
         return;
       }
 
@@ -359,15 +359,15 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     };
   }, [
     buildSearch,
-    isForceExpandedOnce,
+    forcedSitesExpandOnceActive,
     isSelectorOpen,
     location.pathname,
     navigate,
   ]);
 
   useEffect(() => {
-    if (!isSelectorOpen) {
-      setIsForceExpandedOnce(false);
+    if (!isSitesRoute || !isSelectorOpen) {
+      setForcedSitesExpandOnceActive(false);
       return;
     }
 
@@ -375,12 +375,12 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
       return;
     }
 
-    setIsForceExpandedOnce(true);
+    setForcedSitesExpandOnceActive(true);
 
     navigate(
       {
         pathname: location.pathname,
-        search: buildSearch({ expand: undefined }),
+        search: buildSearch({ panel: "sites", expand_once: undefined }),
       },
       { replace: true },
     );
@@ -388,6 +388,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     buildSearch,
     isForceExpandIntent,
     isSelectorOpen,
+    isSitesRoute,
     location.pathname,
     navigate,
   ]);
@@ -505,7 +506,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
       if (!keepMenuExpanded && outsideShell) {
         cancelSitesLeaveTimer();
         setSitesIntentOpen(false);
-        setIsForceExpandedOnce(false);
+        setForcedSitesExpandOnceActive(false);
         setPointerZone("OUTSIDE");
         setIsSecondaryFocused(false);
       }

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -18,7 +18,6 @@ import {
   Settings,
   Shield,
   TrendingUp,
-  Upload,
   LogOut,
 } from "lucide-react";
 import "../styles/VRMTheme.css";
@@ -91,6 +90,9 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const isDemoSession = isDemoSessionActive();
   const allSitesOption =
     SITE_OPTIONS.find((site) => site.id === "all") ?? SITE_OPTIONS[0];
+  const selectorSiteOptions = isAuthenticated
+    ? []
+    : SITE_OPTIONS.filter((site) => site.id !== "all");
   const buildSearch = (overrides?: Record<string, string | undefined>) => {
     const params = new URLSearchParams(location.search);
     if (!overrides || !Object.prototype.hasOwnProperty.call(overrides, "panel")) {
@@ -268,8 +270,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     !keepMenuExpanded &&
     pointerZone === "OUTSIDE" &&
     focusZone === "OUTSIDE" &&
-    !sitesIntentOpen &&
-    !isSelectorOpen;
+    !sitesIntentOpen;
   const isPrimaryExpanded =
     keepMenuExpanded ||
     pointerZone === "PRIMARY" ||
@@ -316,6 +317,39 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     const isFocused = secondaryPanel?.matches(":focus-within") ?? false;
     setIsSecondaryFocused(isFocused);
   }, [keepMenuExpanded, location.pathname, siteId]);
+  useEffect(() => {
+    if (!isSelectorOpen || typeof window === "undefined") {
+      return;
+    }
+
+    const handleDocumentPointerDown = (event: PointerEvent) => {
+      const target = event.target as Node | null;
+      if (!target) {
+        return;
+      }
+      const isInsideSecondary =
+        Boolean(secondaryPanelRef.current) &&
+        secondaryPanelRef.current.contains(target);
+      const isInsideSitesToggle =
+        Boolean(sitesRowRef.current) && sitesRowRef.current.contains(target);
+      if (isInsideSecondary || isInsideSitesToggle) {
+        return;
+      }
+
+      navigate(
+        {
+          pathname: location.pathname,
+          search: buildSearch({ panel: undefined }),
+        },
+        { replace: true },
+      );
+    };
+
+    document.addEventListener("pointerdown", handleDocumentPointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handleDocumentPointerDown);
+    };
+  }, [buildSearch, isSelectorOpen, location.pathname, navigate]);
   useEffect(() => {
     if (keepMenuExpanded || isTouchMode || typeof window === "undefined") {
       return;
@@ -628,12 +662,6 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
               );
             })}
             <NavRow
-              leftIcon={<NavIcon icon={Upload} />}
-              label="Upload"
-              className="vrm-nav-row--placeholder"
-              ariaLabel={!isPrimaryExpanded ? "Upload" : undefined}
-            />
-            <NavRow
               leftIcon={<NavIcon icon={FileText} />}
               label="Documents"
               className="vrm-nav-row--placeholder"
@@ -706,7 +734,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
           </div>
           {!showSiteMenu && (
             <NavList className="vrm-secondary-list">
-              {SITE_OPTIONS.filter((site) => site.id !== "all").map((site) => {
+              {selectorSiteOptions.map((site) => {
                 const siteSubPath = (() => {
                   const match = location.pathname.match(/^\/sites\/[^/]+(\/.*)?$/);
                   const trailing = match?.[1];

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -250,7 +250,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const selectedSiteForList = getStoredSiteId() ?? "all";
   const showSiteMenu = Boolean(siteId) && !isSelectorOpen;
   const isHomeRoute = location.pathname === "/home";
-  const shouldRenderSecondaryPanel = !isHomeRoute;
+  const shouldRenderSecondaryPanel = !isHomeRoute || isSelectorOpen;
   const shouldShowAdminMenu =
     userRole === "admin" && location.pathname.startsWith("/admin");
   const showLogout = isAuthenticated;

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -268,7 +268,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     !keepMenuExpanded &&
     pointerZone === "OUTSIDE" &&
     focusZone === "OUTSIDE" &&
-    !sitesIntentOpen;
+    !sitesIntentOpen &&
+    !isSelectorOpen;
   const isPrimaryExpanded =
     keepMenuExpanded ||
     pointerZone === "PRIMARY" ||
@@ -281,7 +282,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
       pointerZone === "SITES_ROW" ||
       pointerZone === "SECONDARY" ||
       focusZone === "SECONDARY" ||
-      sitesIntentOpen);
+      sitesIntentOpen ||
+      isSelectorOpen);
   const toggleLabel = keepMenuExpanded ? "Collapse Sidebar" : "Keep Expanded";
   const toggleIcon = keepMenuExpanded ? (
     <NavIcon icon={ChevronLeft} className="vrm-nav-chevron" />

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -67,6 +67,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const pointerZoneRef = useRef(pointerZone);
   const [isTouchMode, setIsTouchMode] = useState(false);
   const [sitesIntentOpen, setSitesIntentOpen] = useState(false);
+  const [isForceExpandedOnce, setIsForceExpandedOnce] = useState(false);
   const [keepMenuExpanded, setKeepMenuExpanded] = useState(() => {
     if (typeof window === "undefined") {
       return true;
@@ -86,6 +87,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   );
   const isEmbedMode = searchParams.get("embed") === "1";
   const isSelectorOpen = searchParams.get("panel") === "sites";
+  const isForceExpandIntent = searchParams.get("expand") === "1";
   const activeSite = findSiteById(siteId);
   const isDemoSession = isDemoSessionActive();
   const allSitesOption =
@@ -284,7 +286,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
       pointerZone === "SECONDARY" ||
       focusZone === "SECONDARY" ||
       sitesIntentOpen ||
-      isSelectorOpen);
+      isSelectorOpen ||
+      isForceExpandedOnce);
   const toggleLabel = keepMenuExpanded ? "Collapse Sidebar" : "Keep Expanded";
   const toggleIcon = keepMenuExpanded ? (
     <NavIcon icon={ChevronLeft} className="vrm-nav-chevron" />
@@ -336,6 +339,11 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
         return;
       }
 
+      if (isForceExpandedOnce) {
+        setIsForceExpandedOnce(false);
+        return;
+      }
+
       navigate(
         {
           pathname: location.pathname,
@@ -349,7 +357,40 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     return () => {
       document.removeEventListener("pointerdown", handleDocumentPointerDown);
     };
-  }, [buildSearch, isSelectorOpen, location.pathname, navigate]);
+  }, [
+    buildSearch,
+    isForceExpandedOnce,
+    isSelectorOpen,
+    location.pathname,
+    navigate,
+  ]);
+
+  useEffect(() => {
+    if (!isSelectorOpen) {
+      setIsForceExpandedOnce(false);
+      return;
+    }
+
+    if (!isForceExpandIntent) {
+      return;
+    }
+
+    setIsForceExpandedOnce(true);
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: buildSearch({ expand: undefined }),
+      },
+      { replace: true },
+    );
+  }, [
+    buildSearch,
+    isForceExpandIntent,
+    isSelectorOpen,
+    location.pathname,
+    navigate,
+  ]);
   useEffect(() => {
     if (keepMenuExpanded || isTouchMode || typeof window === "undefined") {
       return;
@@ -464,6 +505,7 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
       if (!keepMenuExpanded && outsideShell) {
         cancelSitesLeaveTimer();
         setSitesIntentOpen(false);
+        setIsForceExpandedOnce(false);
         setPointerZone("OUTSIDE");
         setIsSecondaryFocused(false);
       }

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -171,9 +171,9 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const primaryNavigationItems = useMemo(
     () => [
       {
+        path: "/home",
         label: "Home",
         icon: <NavIcon icon={Home} />,
-        placeholder: true,
       },
       {
         path: "/sites",
@@ -249,6 +249,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const isSiteSelection = isSelectorOpen;
   const selectedSiteForList = getStoredSiteId() ?? "all";
   const showSiteMenu = Boolean(siteId) && !isSelectorOpen;
+  const isHomeRoute = location.pathname === "/home";
+  const shouldRenderSecondaryPanel = !isHomeRoute;
   const shouldShowAdminMenu =
     userRole === "admin" && location.pathname.startsWith("/admin");
   const showLogout = isAuthenticated;
@@ -600,9 +602,6 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
                   leftIcon={item.icon}
                   label={item.label}
                   active={isActive}
-                  className={
-                    item.placeholder ? "vrm-nav-row--placeholder" : undefined
-                  }
                   ariaLabel={!isPrimaryExpanded ? item.label : undefined}
                   rightSlot={
                     item.path === "/sites" ? (
@@ -663,7 +662,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
             )}
           </NavList>
         </nav>
-        <nav
+        {shouldRenderSecondaryPanel && (
+          <nav
           className="vrm-extended-panel"
           aria-label="Secondary"
           ref={secondaryPanelRef}
@@ -795,7 +795,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
               ))}
             </NavList>
           )}
-        </nav>
+          </nav>
+        )}
       </div>
       <main className="vrm-main">
         <div className="vrm-content">{children || <Outlet />}</div>

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -1,0 +1,54 @@
+.home-page {
+  min-height: 100%;
+}
+
+.home-page__content {
+  gap: var(--vrm-spacing-6);
+}
+
+.home-page__header {
+  align-items: center;
+}
+
+.home-page__title {
+  margin: 0;
+  font-size: var(--vrm-typography-font-size-heading);
+  line-height: var(--vrm-typography-line-height-tight);
+  font-weight: 600;
+  color: var(--sys-text-1, var(--vrm-text-primary));
+}
+
+.home-page__search {
+  width: min(360px, 100%);
+}
+
+.home-page__grid {
+  display: grid;
+  gap: var(--vrm-spacing-5);
+}
+
+.home-page__grid--top {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.home-page__grid--bottom {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.home-page__card .analytics-card__body {
+  min-height: 220px;
+}
+
+.home-page__card--wide .analytics-card__body {
+  min-height: 180px;
+}
+
+.home-page__card-body {
+  min-height: 100%;
+}
+
+@media (max-width: 1100px) {
+  .home-page__grid--top {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -3,11 +3,13 @@
 }
 
 .home-page__content {
-  gap: var(--vrm-spacing-6);
+  gap: var(--vrm-spacing-5);
 }
 
 .home-page__header {
   align-items: center;
+  padding-top: var(--vrm-spacing-3);
+  padding-bottom: var(--vrm-spacing-3);
 }
 
 .home-page__title {
@@ -19,36 +21,164 @@
 }
 
 .home-page__search {
-  width: min(360px, 100%);
+  width: min(420px, 100%);
 }
 
-.home-page__grid {
+.home-page__layout {
   display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-areas:
+    "fleet sites news"
+    "favorites favorites news"
+    "recent recent news";
   gap: var(--vrm-spacing-5);
 }
 
-.home-page__grid--top {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+.home-page__card-button,
+.home-page__panel {
+  min-width: 0;
 }
 
-.home-page__grid--bottom {
-  grid-template-columns: minmax(0, 1fr);
+.home-page__card-button {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.home-page__card-button:focus-visible {
+  outline: 2px solid rgba(59, 130, 246, 0.5);
+  outline-offset: 4px;
+  border-radius: var(--sys-radius-md, var(--vrm-radii-card));
+}
+
+.home-page__card-button--fleet {
+  grid-area: fleet;
+}
+
+.home-page__card-button--sites {
+  grid-area: sites;
+}
+
+.home-page__panel--news {
+  grid-area: news;
+}
+
+.home-page__panel--favorites {
+  grid-area: favorites;
+}
+
+.home-page__panel--recent {
+  grid-area: recent;
+}
+
+.home-page__card {
+  height: 100%;
+}
+
+.home-page__card--interactive:hover {
+  border-color: rgba(59, 130, 246, 0.3);
 }
 
 .home-page__card .analytics-card__body {
-  min-height: 220px;
+  min-height: 198px;
+  padding-top: var(--vrm-spacing-1);
 }
 
-.home-page__card--wide .analytics-card__body {
-  min-height: 180px;
+.home-page__card--news .analytics-card__body {
+  min-height: 612px;
+}
+
+.home-page__card--favorites .analytics-card__body {
+  min-height: 112px;
+}
+
+.home-page__card--recent .analytics-card__body {
+  min-height: 260px;
 }
 
 .home-page__card-body {
   min-height: 100%;
 }
 
-@media (max-width: 1100px) {
-  .home-page__grid--top {
+.home-page__card-body--icon {
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-end;
+}
+
+.home-page__footer-icon {
+  width: 52px;
+  height: 52px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.26);
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.8);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-page__card-body--text p {
+  margin: 0;
+  max-width: 760px;
+  color: var(--sys-text-2, var(--vrm-text-secondary));
+  font-size: var(--vrm-typography-font-size-subtitle);
+  line-height: 1.45;
+}
+
+.home-page__card-body--recent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--vrm-spacing-4);
+}
+
+.home-page__tab {
+  align-self: flex-start;
+  height: 34px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--sys-text-1, var(--vrm-text-primary));
+  padding: 0 var(--vrm-spacing-4);
+  font-size: var(--vrm-typography-font-size-body);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.home-page__tab:hover {
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.4);
+}
+
+.home-page__recent-empty {
+  flex: 1;
+}
+
+@media (max-width: 1280px) {
+  .home-page__layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-areas:
+      "fleet sites"
+      "favorites favorites"
+      "recent recent"
+      "news news";
+  }
+
+  .home-page__card--news .analytics-card__body {
+    min-height: 260px;
+  }
+}
+
+@media (max-width: 900px) {
+  .home-page__layout {
     grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "fleet"
+      "sites"
+      "favorites"
+      "recent"
+      "news";
   }
 }

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -3,7 +3,7 @@
 }
 
 .home-page__content {
-  gap: var(--vrm-spacing-5);
+  gap: var(--vrm-spacing-6);
 }
 
 .home-page__header {
@@ -31,7 +31,7 @@
     "fleet sites news"
     "favorites favorites news"
     "recent recent news";
-  gap: var(--vrm-spacing-5);
+  gap: var(--vrm-spacing-6);
 }
 
 .home-page__card-button,
@@ -82,7 +82,7 @@
 }
 
 .home-page__card .analytics-card__body {
-  min-height: 174px;
+  min-height: 160px;
   padding-top: var(--vrm-spacing-1);
 }
 
@@ -91,11 +91,11 @@
 }
 
 .home-page__card--favorites .analytics-card__body {
-  min-height: 96px;
+  min-height: 0;
 }
 
 .home-page__card--recent .analytics-card__body {
-  min-height: 274px;
+  min-height: 248px;
 }
 
 .home-page__card-body {
@@ -111,7 +111,7 @@
 .home-page__footer-icon {
   width: 52px;
   height: 52px;
-  border-radius: 10px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.26);
   background: rgba(255, 255, 255, 0.06);
   color: rgba(255, 255, 255, 0.8);
@@ -122,10 +122,9 @@
 
 .home-page__card-body--text p {
   margin: 0;
-  max-width: 760px;
   color: var(--sys-text-2, var(--vrm-text-secondary));
   font-size: var(--vrm-typography-font-size-subtitle);
-  line-height: 1.45;
+  line-height: 1.4;
 }
 
 .home-page__card-body--recent {
@@ -162,7 +161,7 @@
 .home-page__recent-row {
   width: 100%;
   min-height: 58px;
-  border-radius: 10px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   background: rgba(255, 255, 255, 0.04);
   color: var(--sys-text-1, var(--vrm-text-primary));
@@ -185,7 +184,7 @@
   color: var(--sys-text-3, var(--vrm-text-muted));
 }
 
-@media (max-width: 1280px) {
+@media (max-width: 1024px) {
   .home-page__layout {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-areas:
@@ -196,11 +195,11 @@
   }
 
   .home-page__card--news .analytics-card__body {
-    min-height: 274px;
+    min-height: 248px;
   }
 }
 
-@media (max-width: 900px) {
+@media (max-width: 760px) {
   .home-page__layout {
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas:

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -81,13 +81,22 @@
   border-color: rgba(59, 130, 246, 0.3);
 }
 
+.home-page__card--compact.analytics-card {
+  padding: 14px 16px;
+}
+
+.home-page__card--compact .analytics-card__header {
+  padding-bottom: 8px;
+  gap: var(--vrm-spacing-2);
+}
+
 .home-page__card .analytics-card__body {
   min-height: 160px;
   padding-top: var(--vrm-spacing-1);
 }
 
 .home-page__card--compact .analytics-card__body {
-  min-height: 132px;
+  min-height: 96px;
 }
 
 .home-page__card--news .analytics-card__body {

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -139,8 +139,10 @@
   gap: var(--vrm-spacing-2);
 }
 
-.home-page__tab {
+.home-page__tab-label {
   align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
   height: 30px;
   border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.2);
@@ -151,12 +153,8 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  cursor: pointer;
 }
 
-.home-page__tab:hover {
-  background: rgba(255, 255, 255, 0.12);
-}
 
 .home-page__recent-row {
   width: 100%;

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -86,6 +86,10 @@
   padding-top: var(--vrm-spacing-1);
 }
 
+.home-page__card--compact .analytics-card__body {
+  min-height: 132px;
+}
+
 .home-page__card--news .analytics-card__body {
   min-height: 620px;
 }
@@ -95,7 +99,7 @@
 }
 
 .home-page__card--recent .analytics-card__body {
-  min-height: 248px;
+  min-height: 164px;
 }
 
 .home-page__card-body {
@@ -130,33 +134,10 @@
 .home-page__card-body--recent {
   display: flex;
   flex-direction: column;
-  gap: var(--vrm-spacing-4);
+  gap: var(--vrm-spacing-3);
 }
 
-.home-page__tab-row {
-  display: flex;
-  align-items: center;
-  gap: var(--vrm-spacing-2);
-}
-
-.home-page__tab-label {
-  align-self: flex-start;
-  display: inline-flex;
-  align-items: center;
-  height: 30px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.06);
-  color: var(--sys-text-1, var(--vrm-text-primary));
-  padding: 0 var(--vrm-spacing-3);
-  font-size: var(--vrm-typography-font-size-caption);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
-
-.home-page__recent-row {
+.home-page__list-row {
   width: 100%;
   min-height: 58px;
   border-radius: 8px;
@@ -173,16 +154,16 @@
   cursor: pointer;
 }
 
-.home-page__recent-row:hover {
+.home-page__list-row:hover {
   background: rgba(255, 255, 255, 0.09);
   border-color: rgba(255, 255, 255, 0.22);
 }
 
-.home-page__recent-row svg {
+.home-page__list-row svg {
   color: var(--sys-text-3, var(--vrm-text-muted));
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 900px) {
   .home-page__layout {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-template-areas:

--- a/frontend/src/features/home/HomePage.css
+++ b/frontend/src/features/home/HomePage.css
@@ -26,7 +26,7 @@
 
 .home-page__layout {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(360px, 1.15fr);
   grid-template-areas:
     "fleet sites news"
     "favorites favorites news"
@@ -82,20 +82,20 @@
 }
 
 .home-page__card .analytics-card__body {
-  min-height: 198px;
+  min-height: 174px;
   padding-top: var(--vrm-spacing-1);
 }
 
 .home-page__card--news .analytics-card__body {
-  min-height: 612px;
+  min-height: 620px;
 }
 
 .home-page__card--favorites .analytics-card__body {
-  min-height: 112px;
+  min-height: 96px;
 }
 
 .home-page__card--recent .analytics-card__body {
-  min-height: 260px;
+  min-height: 274px;
 }
 
 .home-page__card-body {
@@ -134,26 +134,55 @@
   gap: var(--vrm-spacing-4);
 }
 
+.home-page__tab-row {
+  display: flex;
+  align-items: center;
+  gap: var(--vrm-spacing-2);
+}
+
 .home-page__tab {
   align-self: flex-start;
-  height: 34px;
-  border-radius: 999px;
+  height: 30px;
+  border-radius: 8px;
   border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.06);
   color: var(--sys-text-1, var(--vrm-text-primary));
-  padding: 0 var(--vrm-spacing-4);
-  font-size: var(--vrm-typography-font-size-body);
-  font-weight: 500;
+  padding: 0 var(--vrm-spacing-3);
+  font-size: var(--vrm-typography-font-size-caption);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
   cursor: pointer;
 }
 
 .home-page__tab:hover {
-  background: rgba(59, 130, 246, 0.2);
-  border-color: rgba(59, 130, 246, 0.4);
+  background: rgba(255, 255, 255, 0.12);
 }
 
-.home-page__recent-empty {
-  flex: 1;
+.home-page__recent-row {
+  width: 100%;
+  min-height: 58px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--sys-text-1, var(--vrm-text-primary));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--vrm-spacing-3);
+  padding: 0 var(--vrm-spacing-4);
+  text-align: left;
+  font-size: var(--vrm-typography-font-size-subtitle);
+  cursor: pointer;
+}
+
+.home-page__recent-row:hover {
+  background: rgba(255, 255, 255, 0.09);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+.home-page__recent-row svg {
+  color: var(--sys-text-3, var(--vrm-text-muted));
 }
 
 @media (max-width: 1280px) {
@@ -167,7 +196,7 @@
   }
 
   .home-page__card--news .analytics-card__body {
-    min-height: 260px;
+    min-height: 274px;
   }
 }
 

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Search } from "lucide-react";
+import { Activity, Building2, Search } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { Card } from "../../analytics/components/Card/Card";
 import { fetchMe } from "../auth/transport/me";
 import "../dashboard/styles/DashboardPage.css";
@@ -8,6 +9,7 @@ import "./HomePage.css";
 const HomePage: React.FC = () => {
   const [userName, setUserName] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadUser = async () => {
@@ -33,33 +35,76 @@ const HomePage: React.FC = () => {
       <div className="dashboard-v2__content home-page__content">
         <header className="dashboard-v2__header home-page__header">
           <h1 className="home-page__title">Welcome, {userName}</h1>
-          <label className="vrm-secondary-search home-page__search" aria-label="Search">
+          <label className="vrm-secondary-search home-page__search" aria-label="Search installations">
             <span className="vrm-secondary-search__icon" aria-hidden="true">
               <Search />
             </span>
-            <input type="search" placeholder="Search" readOnly />
+            <input type="search" placeholder="Search installations" readOnly />
           </label>
         </header>
 
-        <section className="home-page__grid home-page__grid--top" aria-label="Home highlights">
-          <Card title="Fleet monitor" className="home-page__card">
-            <div className="home-page__card-body" />
-          </Card>
-          <Card title="My installations" className="home-page__card">
-            <div className="home-page__card-body" />
-          </Card>
-          <Card title="Product news" className="home-page__card">
-            <div className="home-page__card-body" />
-          </Card>
-        </section>
+        <section className="home-page__layout" aria-label="Home modules">
+          <button
+            type="button"
+            className="home-page__card-button home-page__card-button--fleet"
+            onClick={() => navigate("/sites/all/alarm-logs")}
+            aria-label="Open Monitor Fleet"
+          >
+            <Card title="Monitor Fleet" className="home-page__card home-page__card--interactive">
+              <div className="home-page__card-body home-page__card-body--icon">
+                <span className="home-page__footer-icon" aria-hidden="true">
+                  <Activity size={22} />
+                </span>
+              </div>
+            </Card>
+          </button>
 
-        <section className="home-page__grid home-page__grid--bottom" aria-label="Recent sections">
-          <Card title="Favorite installations" className="home-page__card home-page__card--wide">
-            <div className="home-page__card-body" />
-          </Card>
-          <Card title="Recently viewed" className="home-page__card home-page__card--wide">
-            <div className="home-page__card-body" />
-          </Card>
+          <button
+            type="button"
+            className="home-page__card-button home-page__card-button--sites"
+            onClick={() => navigate("/sites")}
+            aria-label="Open My Sites"
+          >
+            <Card title="My Sites" className="home-page__card home-page__card--interactive">
+              <div className="home-page__card-body home-page__card-body--icon">
+                <span className="home-page__footer-icon" aria-hidden="true">
+                  <Building2 size={22} />
+                </span>
+              </div>
+            </Card>
+          </button>
+
+          <div className="home-page__panel home-page__panel--news">
+            <Card title="Product News" className="home-page__card home-page__card--news">
+              <div className="home-page__card-body" />
+            </Card>
+          </div>
+
+          <div className="home-page__panel home-page__panel--favorites">
+            <Card title="Favourite Sites" className="home-page__card home-page__card--favorites">
+              <div className="home-page__card-body home-page__card-body--text">
+                <p>
+                  You don't have any Sites installations yet. Get started by marking a Site as
+                  favorite from the dashboard page.
+                </p>
+              </div>
+            </Card>
+          </div>
+
+          <div className="home-page__panel home-page__panel--recent">
+            <Card title="Recently Viewed" className="home-page__card home-page__card--recent">
+              <div className="home-page__card-body home-page__card-body--recent">
+                <button
+                  type="button"
+                  className="home-page__tab"
+                  onClick={() => navigate("/sites/all/dashboard")}
+                >
+                  All sites
+                </button>
+                <div className="home-page__recent-empty" />
+              </div>
+            </Card>
+          </div>
         </section>
       </div>
     </div>

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -50,7 +50,10 @@ const HomePage: React.FC = () => {
             onClick={() => navigate("/sites/all/alarm-logs")}
             aria-label="Open Monitor Fleet"
           >
-            <Card title="Monitor Fleet" className="home-page__card home-page__card--interactive">
+            <Card
+              title="Monitor Fleet"
+              className="home-page__card home-page__card--interactive home-page__card--compact"
+            >
               <div className="home-page__card-body home-page__card-body--icon">
                 <span className="home-page__footer-icon" aria-hidden="true">
                   <Activity size={22} />
@@ -62,10 +65,13 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--sites"
-            onClick={() => navigate("/sites/all/dashboard")}
+            onClick={() => navigate("/sites/all/dashboard?panel=sites")}
             aria-label="Open My Sites"
           >
-            <Card title="My Sites" className="home-page__card home-page__card--interactive">
+            <Card
+              title="My Sites"
+              className="home-page__card home-page__card--interactive home-page__card--compact"
+            >
               <div className="home-page__card-body home-page__card-body--icon">
                 <span className="home-page__footer-icon" aria-hidden="true">
                   <Building2 size={22} />
@@ -84,8 +90,8 @@ const HomePage: React.FC = () => {
             <Card title="Favourite Sites" className="home-page__card home-page__card--favorites">
               <div className="home-page__card-body home-page__card-body--text">
                 <p>
-                  You don't have any Sites installations yet. Get started by marking a Site as
-                  favorite from the dashboard page.
+                  You don't have any Favorite Sites yet. Get started by marking a Site as favorite
+                  from the dashboard page.
                 </p>
               </div>
             </Card>
@@ -94,31 +100,12 @@ const HomePage: React.FC = () => {
           <div className="home-page__panel home-page__panel--recent">
             <Card title="Recently Viewed" className="home-page__card home-page__card--recent">
               <div className="home-page__card-body home-page__card-body--recent">
-                <div className="home-page__tab-row" aria-label="Recently viewed scope">
-                  <span className="home-page__tab-label">All Sites</span>
-                </div>
                 <button
                   type="button"
-                  className="home-page__recent-row"
-                  onClick={() => navigate("/sites/all/dashboard")}
+                  className="home-page__list-row"
+                  onClick={() => navigate("/sites/all/dashboard?panel=sites")}
                 >
-                  <span>SoEnergy-Site-001</span>
-                  <ChevronRight size={18} aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className="home-page__recent-row"
-                  onClick={() => navigate("/sites/all/dashboard")}
-                >
-                  <span>SoEnergy-Site-002</span>
-                  <ChevronRight size={18} aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  className="home-page__recent-row"
-                  onClick={() => navigate("/sites/all/dashboard")}
-                >
-                  <span>SoEnergy-Site-003</span>
+                  <span>All Sites</span>
                   <ChevronRight size={18} aria-hidden="true" />
                 </button>
               </div>

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -94,14 +94,8 @@ const HomePage: React.FC = () => {
           <div className="home-page__panel home-page__panel--recent">
             <Card title="Recently Viewed" className="home-page__card home-page__card--recent">
               <div className="home-page__card-body home-page__card-body--recent">
-                <div className="home-page__tab-row">
-                  <button
-                    type="button"
-                    className="home-page__tab"
-                    onClick={() => navigate("/sites/all/dashboard")}
-                  >
-                    All Sites
-                  </button>
+                <div className="home-page__tab-row" aria-label="Recently viewed scope">
+                  <span className="home-page__tab-label">All Sites</span>
                 </div>
                 <button
                   type="button"

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState } from "react";
+import { Search } from "lucide-react";
+import { Card } from "../../analytics/components/Card/Card";
+import { fetchMe } from "../auth/transport/me";
+import "../dashboard/styles/DashboardPage.css";
+import "./HomePage.css";
+
+const HomePage: React.FC = () => {
+  const [userName, setUserName] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const loadUser = async () => {
+      try {
+        const me = await fetchMe();
+        if (me.ok) {
+          setUserName(me.data.user.name);
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadUser();
+  }, []);
+
+  if (isLoading) {
+    return null;
+  }
+
+  return (
+    <div className="dashboard-v2 home-page">
+      <div className="dashboard-v2__content home-page__content">
+        <header className="dashboard-v2__header home-page__header">
+          <h1 className="home-page__title">Welcome, {userName}</h1>
+          <label className="vrm-secondary-search home-page__search" aria-label="Search">
+            <span className="vrm-secondary-search__icon" aria-hidden="true">
+              <Search />
+            </span>
+            <input type="search" placeholder="Search" readOnly />
+          </label>
+        </header>
+
+        <section className="home-page__grid home-page__grid--top" aria-label="Home highlights">
+          <Card title="Fleet monitor" className="home-page__card">
+            <div className="home-page__card-body" />
+          </Card>
+          <Card title="My installations" className="home-page__card">
+            <div className="home-page__card-body" />
+          </Card>
+          <Card title="Product news" className="home-page__card">
+            <div className="home-page__card-body" />
+          </Card>
+        </section>
+
+        <section className="home-page__grid home-page__grid--bottom" aria-label="Recent sections">
+          <Card title="Favorite installations" className="home-page__card home-page__card--wide">
+            <div className="home-page__card-body" />
+          </Card>
+          <Card title="Recently viewed" className="home-page__card home-page__card--wide">
+            <div className="home-page__card-body" />
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+};
+
+export default HomePage;

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -47,7 +47,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--fleet"
-            onClick={() => navigate("/sites/all/alarm-logs?panel=sites")}
+            onClick={() => navigate("/sites/all/alarm-logs?panel=sites&expand=1")}
             aria-label="Open Monitor Fleet"
           >
             <Card
@@ -65,7 +65,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--sites"
-            onClick={() => navigate("/sites/all/dashboard?panel=sites")}
+            onClick={() => navigate("/sites/all/dashboard?panel=sites&expand=1")}
             aria-label="Open My Sites"
           >
             <Card

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Activity, Building2, ChevronRight, Search } from "lucide-react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Card } from "../../analytics/components/Card/Card";
 import { fetchMe } from "../auth/transport/me";
 import "../dashboard/styles/DashboardPage.css";
@@ -10,7 +10,6 @@ const HomePage: React.FC = () => {
   const [userName, setUserName] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
-  const location = useLocation();
 
   useEffect(() => {
     const loadUser = async () => {
@@ -48,7 +47,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--fleet"
-            onClick={() => navigate("/sites/all/dashboard")}
+            onClick={() => navigate("/sites/all/alarm-logs")}
             aria-label="Open Monitor Fleet"
           >
             <Card title="Monitor Fleet" className="home-page__card home-page__card--interactive">
@@ -63,11 +62,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--sites"
-            onClick={() => {
-              const params = new URLSearchParams(location.search);
-              params.set("panel", "sites");
-              navigate({ pathname: location.pathname, search: `?${params.toString()}` });
-            }}
+            onClick={() => navigate("/sites/all/dashboard")}
             aria-label="Open My Sites"
           >
             <Card title="My Sites" className="home-page__card home-page__card--interactive">
@@ -105,7 +100,7 @@ const HomePage: React.FC = () => {
                     className="home-page__tab"
                     onClick={() => navigate("/sites/all/dashboard")}
                   >
-                    All sites
+                    All Sites
                   </button>
                 </div>
                 <button

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -34,7 +34,7 @@ const HomePage: React.FC = () => {
     <div className="dashboard-v2 home-page">
       <div className="dashboard-v2__content home-page__content">
         <header className="dashboard-v2__header home-page__header">
-          <h1 className="home-page__title">Welcome, {userName}</h1>
+          <h1 className="home-page__title">Welcome {userName}</h1>
           <label className="vrm-secondary-search home-page__search" aria-label="Search installations">
             <span className="vrm-secondary-search__icon" aria-hidden="true">
               <Search />
@@ -47,7 +47,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--fleet"
-            onClick={() => navigate("/sites/all/alarm-logs")}
+            onClick={() => navigate("/sites/all/alarm-logs?panel=sites")}
             aria-label="Open Monitor Fleet"
           >
             <Card

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -47,7 +47,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--fleet"
-            onClick={() => navigate("/sites/all/alarm-logs?panel=sites&expand=1")}
+            onClick={() => navigate("/sites/all/alarm-logs?panel=sites&expand_once=1")}
             aria-label="Open Monitor Fleet"
           >
             <Card
@@ -65,7 +65,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--sites"
-            onClick={() => navigate("/sites/all/dashboard?panel=sites&expand=1")}
+            onClick={() => navigate("/sites/all/dashboard?panel=sites&expand_once=1")}
             aria-label="Open My Sites"
           >
             <Card

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Activity, Building2, Search } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Activity, Building2, ChevronRight, Search } from "lucide-react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Card } from "../../analytics/components/Card/Card";
 import { fetchMe } from "../auth/transport/me";
 import "../dashboard/styles/DashboardPage.css";
@@ -10,6 +10,7 @@ const HomePage: React.FC = () => {
   const [userName, setUserName] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const navigate = useNavigate();
+  const location = useLocation();
 
   useEffect(() => {
     const loadUser = async () => {
@@ -47,7 +48,7 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--fleet"
-            onClick={() => navigate("/sites/all/alarm-logs")}
+            onClick={() => navigate("/sites/all/dashboard")}
             aria-label="Open Monitor Fleet"
           >
             <Card title="Monitor Fleet" className="home-page__card home-page__card--interactive">
@@ -62,7 +63,11 @@ const HomePage: React.FC = () => {
           <button
             type="button"
             className="home-page__card-button home-page__card-button--sites"
-            onClick={() => navigate("/sites")}
+            onClick={() => {
+              const params = new URLSearchParams(location.search);
+              params.set("panel", "sites");
+              navigate({ pathname: location.pathname, search: `?${params.toString()}` });
+            }}
             aria-label="Open My Sites"
           >
             <Card title="My Sites" className="home-page__card home-page__card--interactive">
@@ -94,14 +99,39 @@ const HomePage: React.FC = () => {
           <div className="home-page__panel home-page__panel--recent">
             <Card title="Recently Viewed" className="home-page__card home-page__card--recent">
               <div className="home-page__card-body home-page__card-body--recent">
+                <div className="home-page__tab-row">
+                  <button
+                    type="button"
+                    className="home-page__tab"
+                    onClick={() => navigate("/sites/all/dashboard")}
+                  >
+                    All sites
+                  </button>
+                </div>
                 <button
                   type="button"
-                  className="home-page__tab"
+                  className="home-page__recent-row"
                   onClick={() => navigate("/sites/all/dashboard")}
                 >
-                  All sites
+                  <span>SoEnergy-Site-001</span>
+                  <ChevronRight size={18} aria-hidden="true" />
                 </button>
-                <div className="home-page__recent-empty" />
+                <button
+                  type="button"
+                  className="home-page__recent-row"
+                  onClick={() => navigate("/sites/all/dashboard")}
+                >
+                  <span>SoEnergy-Site-002</span>
+                  <ChevronRight size={18} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  className="home-page__recent-row"
+                  onClick={() => navigate("/sites/all/dashboard")}
+                >
+                  <span>SoEnergy-Site-003</span>
+                  <ChevronRight size={18} aria-hidden="true" />
+                </button>
               </div>
             </Card>
           </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,3 @@
+import HomePage from "../features/home/HomePage";
+
+export default HomePage;


### PR DESCRIPTION
### Motivation
- Provide an authenticated-only Home page shell that replaces the inactive Home button and serves as the structural foundation for the authenticated workspace while preserving demo/public/dashboard behavior.
- Keep visual and spacing parity with the existing dashboard card/grid system and reuse established components and tokens to avoid global CSS or style regressions.

### Description
- Added a new authenticated Home page component at `frontend/src/features/home/HomePage.tsx` with scoped styles in `frontend/src/features/home/HomePage.css` that renders the required header (`Welcome, {name}`), static search bar, three-card top row and two full-width cards using the existing `Card` component and dashboard layout classes.
- Exported the page via `frontend/src/pages/HomePage.tsx` and registered a lazy route `HomePage` in `frontend/src/app/routes.tsx` so `/home` navigates to the new page only when the app is in authenticated mode and redirects non-authenticated flows back to the dashboard as before.
- Activated the primary navigation Home item and wired it to `/home` by updating `frontend/src/components/VRMLayout.tsx`, and added logic to suppress the secondary sidebar when the current route is `/home` while leaving the primary sidebar intact.
- No new dependencies, no global CSS edits, and no data-fetching logic beyond reading the current authenticated user name via the existing `fetchMe` helper.

### Testing
- Ran `npm run build` in the `frontend/` workspace and the build completed successfully without errors.
- Launched the dev server and executed an automated Playwright script that mocked `/api/me`, navigated to `/home`, and produced a screenshot verifying the page layout and the displayed welcome name.
- Verified the app preserves demo/view-token/public routing by confirming non-authenticated `/home` requests were redirected to the dashboard during testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ef1ebcec08329b4a4dd76b106903d)