### PR TITLE
Add Settings feature: My Account and Manage Access pages with secondary nav

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -24,6 +24,8 @@ const ReportsPage = React.lazy(() => import("../pages/ReportsPage"));
 const AdminPage = React.lazy(() => import("../pages/AdminPage"));
 const HomePage = React.lazy(() => import("../pages/HomePage"));
 const DocumentsPage = React.lazy(() => import("../pages/DocumentsPage"));
+const MyAccountPage = React.lazy(() => import("../features/settings/pages/MyAccountPage"));
+const ManageAccessPage = React.lazy(() => import("../features/settings/pages/ManageAccessPage"));
 const LandingPage = React.lazy(() => import("../pages/LandingPage"));
 const LoginPage = React.lazy(() => import("../pages/LoginPage"));
 const CreateAccountPage = React.lazy(() => import("../pages/CreateAccountPage"));
@@ -226,13 +228,51 @@ const AppRoutes: React.FC = () => {
           <Route
             path="/settings"
             element={
-              <Navigate
-                to={appendViewToken(
-                  `/sites/${resolveLegacySiteId()}/dashboard`,
-                )}
-                replace
-              />
+              isAuthenticatedMode ? (
+                <Navigate to="/settings/account" replace />
+              ) : (
+                <Navigate
+                  to={appendViewToken(
+                    `/sites/${resolveLegacySiteId()}/dashboard`,
+                  )}
+                  replace
+                />
+              )
             }
+          />
+          <Route
+            path="/settings/account"
+            element={
+              isAuthenticatedMode ? (
+                renderClientRoute(lazyRoute(<MyAccountPage />))
+              ) : (
+                <Navigate
+                  to={appendViewToken(
+                    `/sites/${resolveLegacySiteId()}/dashboard`,
+                  )}
+                  replace
+                />
+              )
+            }
+          />
+          <Route
+            path="/settings/access"
+            element={
+              isAuthenticatedMode ? (
+                renderClientRoute(lazyRoute(<ManageAccessPage />))
+              ) : (
+                <Navigate
+                  to={appendViewToken(
+                    `/sites/${resolveLegacySiteId()}/dashboard`,
+                  )}
+                  replace
+                />
+              )
+            }
+          />
+          <Route
+            path="/settings/alarms"
+            element={<Navigate to="/settings/account" replace />}
           />
           <Route
             path="/documents"

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -38,6 +38,7 @@ import {
   SecondarySearch,
 } from "../common/components/navigation";
 import { NavIcon } from "../common/components/icons";
+import SettingsSecondaryNav from "../features/settings/components/SettingsSecondaryNav";
 
 interface VRMLayoutProps {
   userRole?: "client" | "admin";
@@ -264,8 +265,9 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
   const isDocumentsRoute =
     location.pathname === "/documents" || location.pathname.startsWith("/documents/");
   const isSitesRoute = /^\/sites(?:\/|$)/.test(location.pathname);
+  const isSettingsRoute = location.pathname.startsWith("/settings");
   const shouldRenderSecondaryPanel =
-    !isDocumentsRoute && (!isHomeRoute || isSelectorOpen);
+    isSettingsRoute || (!isDocumentsRoute && (!isHomeRoute || isSelectorOpen));
   const shouldShowAdminMenu =
     userRole === "admin" && location.pathname.startsWith("/admin");
   const showLogout = isAuthenticated;
@@ -762,9 +764,11 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
               ariaLabel={!isPrimaryExpanded ? toggleLabel : undefined}
             />
             <NavRow
+              to={isAuthenticated ? getNavigationPath("/settings/account") : undefined}
               leftIcon={<NavIcon icon={Settings} />}
               label="Settings"
-              className="vrm-nav-row--placeholder"
+              disabled={!isAuthenticated || isDemoSession}
+              className={isAuthenticated ? undefined : "vrm-nav-row--placeholder"}
               ariaLabel={!isPrimaryExpanded ? "Settings" : undefined}
             />
             {showLogout && (
@@ -788,6 +792,10 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
           onPointerEnter={cancelSitesLeaveTimer}
           onPointerLeave={handleSitesRowLeave}
         >
+          {isSettingsRoute ? (
+            <SettingsSecondaryNav />
+          ) : (
+            <>
           <div className="vrm-secondary-header">
             <SecondarySearch />
             {!showSiteMenu && (
@@ -910,6 +918,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
                 />
               ))}
             </NavList>
+          )}
+            </>
           )}
           </nav>
         )}

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -699,11 +699,13 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
               </div>
               <div className="vrm-brand-text">
                 <div className="vrm-brand-title">camOS</div>
-                <div className="vrm-brand-subrow">
-                  <span className="vrm-brand-badge" aria-label="Demo">
-                    DEMO
-                  </span>
-                </div>
+                {isDemoSession && (
+                  <div className="vrm-brand-subrow">
+                    <span className="vrm-brand-badge" aria-label="Demo">
+                      DEMO
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -28,9 +28,9 @@ const CreateAccountPage: React.FC = () => {
           )}
           <form className="create-account-form" onSubmit={form.submit}>
             <div className="vrm-field">
-              <label className="vrm-label" htmlFor="create-name">Name</label>
-              <input id="create-name" className="vrm-input" value={form.name} onChange={(e) => form.setName(e.target.value)} onBlur={() => form.markTouched("name")} />
-              {form.visibleErrors.name && <div className="create-account-error">{form.visibleErrors.name}</div>}
+              <label className="vrm-label" htmlFor="create-name">Username</label>
+              <input id="create-name" className="vrm-input" value={form.username} onChange={(e) => form.setUsername(e.target.value)} onBlur={() => form.markTouched("username")} />
+              {form.visibleErrors.username && <div className="create-account-error">{form.visibleErrors.username}</div>}
             </div>
 
             <div className="vrm-field">

--- a/frontend/src/features/auth/hooks/useCreateAccountForm.ts
+++ b/frontend/src/features/auth/hooks/useCreateAccountForm.ts
@@ -4,10 +4,10 @@ import { createAccount } from '../transport/createAccount';
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^\+[1-9]\d{6,14}$/;
 
-type FieldName = 'name' | 'email' | 'phone' | 'password' | 'confirmPassword';
+type FieldName = 'username' | 'email' | 'phone' | 'password' | 'confirmPassword';
 
 export const useCreateAccountForm = (onSuccess: () => void) => {
-  const [name, setName] = useState('');
+  const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [countryCode, setCountryCode] = useState('+44');
   const [phoneLocal, setPhoneLocal] = useState('');
@@ -17,7 +17,7 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
   const [formError, setFormError] = useState<string | null>(null);
   const [submitAttempted, setSubmitAttempted] = useState(false);
   const [touched, setTouched] = useState<Record<FieldName, boolean>>({
-    name: false,
+    username: false,
     email: false,
     phone: false,
     password: false,
@@ -28,14 +28,14 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
 
   const validate = () => {
     const errors: Record<FieldName, string | undefined> = {
-      name: undefined,
+      username: undefined,
       email: undefined,
       phone: undefined,
       password: undefined,
       confirmPassword: undefined,
     };
 
-    if (!name.trim()) errors.name = 'This field is required';
+    if (!username.trim()) errors.username = 'This field is required';
 
     const normalizedEmail = email.trim().toLowerCase();
     if (!normalizedEmail) errors.email = 'This field is required';
@@ -54,7 +54,7 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
 
   const errors = useMemo(
     () => validate(),
-    [name, email, phone, password, confirmPassword],
+    [username, email, phone, password, confirmPassword],
   );
 
   const visibleErrors = useMemo(() => {
@@ -76,7 +76,7 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     setSubmitAttempted(true);
-    setTouched({ name: true, email: true, phone: true, password: true, confirmPassword: true });
+    setTouched({ username: true, email: true, phone: true, password: true, confirmPassword: true });
     setFormError(null);
 
     if (Object.values(errors).some(Boolean)) return;
@@ -84,7 +84,7 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
     setSubmitting(true);
     try {
       const result = await createAccount({
-        name: name.trim(),
+        name: username.trim(),
         email: email.trim().toLowerCase(),
         phone: phone || undefined,
         password,
@@ -104,7 +104,7 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
   };
 
   return {
-    name,
+    username,
     email,
     countryCode,
     phoneLocal,
@@ -114,7 +114,7 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
     formError,
     visibleErrors,
     canSubmit,
-    setName,
+    setUsername,
     setEmail,
     setCountryCode,
     setPhoneLocal,

--- a/frontend/src/features/events/hooks/useEventLogsQuery.ts
+++ b/frontend/src/features/events/hooks/useEventLogsQuery.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Credentials } from "../../../types/credentials";
+
+import { isDemoSessionActive } from "../../../lib/demoSession";
 import { getViewTokenFromLocation } from "../../../lib/viewToken";
+import type { Credentials } from "../../../types/credentials";
 import { searchEvents } from "../transport/searchEvents";
 import type { EventData } from "../utils/eventTypes";
 
@@ -42,26 +44,31 @@ export const useEventLogsQuery = (
   const [totalPages, setTotalPages] = useState(1);
   const [totalEvents, setTotalEvents] = useState(0);
   const skipNextFetch = useRef(false);
+
   const eventsPerPage = 20;
+  const isDemoSession = isDemoSessionActive();
   const resolvedViewToken =
     overrides.viewToken !== undefined
       ? overrides.viewToken ?? undefined
       : typeof window === "undefined"
         ? undefined
         : getViewTokenFromLocation(window.location.search);
-  const storageKey = `camOS.eventLogsState:${resolvedViewToken ?? "auth"}`;
+  const storageKey = `camOS.eventLogsState:${isDemoSession ? "demo" : "auth"}`;
+
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
+  const applyHardZeroResult = useCallback(() => {
+    setEvents([]);
+    setTotalPages(1);
+    setTotalEvents(0);
+    setCurrentPage(1);
+    setError(null);
+    setLoading(false);
+  }, []);
+
   useEffect(() => {
     if (typeof window === "undefined") {
-      return;
-    }
-    if (!resolvedViewToken) {
-      setEvents([]);
-      setTotalPages(1);
-      setTotalEvents(0);
-      setCurrentPage(1);
       return;
     }
 
@@ -69,6 +76,7 @@ export const useEventLogsQuery = (
     if (!stored) {
       return;
     }
+
     try {
       const parsed = JSON.parse(stored) as {
         events?: EventData[];
@@ -83,6 +91,7 @@ export const useEventLogsQuery = (
         appliedEndDate?: string | null;
         searchToken?: number;
       };
+
       if (Array.isArray(parsed.events)) {
         setEvents(parsed.events);
       }
@@ -120,13 +129,15 @@ export const useEventLogsQuery = (
         }
       }
     } catch {
+      // ignore malformed cache
     }
-  }, [resolvedViewToken, storageKey]);
+  }, [storageKey]);
 
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
     }
+
     const payload = {
       events,
       totalPages,
@@ -136,12 +147,11 @@ export const useEventLogsQuery = (
       appliedFilters,
       draftStartDate: draftStartDate ? draftStartDate.toISOString() : null,
       draftEndDate: draftEndDate ? draftEndDate.toISOString() : null,
-      appliedStartDate: appliedStartDate
-        ? appliedStartDate.toISOString()
-        : null,
+      appliedStartDate: appliedStartDate ? appliedStartDate.toISOString() : null,
       appliedEndDate: appliedEndDate ? appliedEndDate.toISOString() : null,
       searchToken,
     };
+
     window.sessionStorage.setItem(storageKey, JSON.stringify(payload));
   }, [
     appliedEndDate,
@@ -183,16 +193,10 @@ export const useEventLogsQuery = (
         searchParams.append("per_page", eventsPerPage.toString());
       }
       if (appliedStartDate) {
-        searchParams.append(
-          "start_date",
-          appliedStartDate.toISOString().split("T")[0],
-        );
+        searchParams.append("start_date", appliedStartDate.toISOString().split("T")[0]);
       }
       if (appliedEndDate) {
-        searchParams.append(
-          "end_date",
-          appliedEndDate.toISOString().split("T")[0],
-        );
+        searchParams.append("end_date", appliedEndDate.toISOString().split("T")[0]);
       }
       if (appliedFilters.event) {
         searchParams.append("event", appliedFilters.event);
@@ -215,29 +219,21 @@ export const useEventLogsQuery = (
       }
       return searchParams;
     },
-    [
-      appliedEndDate,
-      appliedFilters,
-      appliedStartDate,
-      currentPage,
-      eventsPerPage,
-    ],
+    [appliedEndDate, appliedFilters, appliedStartDate, currentPage, eventsPerPage],
   );
 
   const fetchEvents = useCallback(async () => {
+    if (!isDemoSession) {
+      applyHardZeroResult();
+      return;
+    }
+
     try {
       setLoading(true);
       const viewToken =
         overrides.viewToken !== undefined
           ? overrides.viewToken
           : getViewTokenFromLocation();
-      if (!viewToken) {
-        setEvents([]);
-        setTotalPages(1);
-        setTotalEvents(0);
-        setError(null);
-        return;
-      }
       const urlParams = new URLSearchParams(window.location.search);
       const clientId =
         overrides.clientId !== undefined
@@ -256,13 +252,19 @@ export const useEventLogsQuery = (
       setTotalEvents(result.total || 0);
       setError(null);
     } catch (err) {
-      setError(
-        `Failed to fetch events: ${err instanceof Error ? err.message : "Unknown error"}`,
-      );
+      setError(`Failed to fetch events: ${err instanceof Error ? err.message : "Unknown error"}`);
     } finally {
       setLoading(false);
     }
-  }, [buildSearchParams, credentials, overrides.clientId, overrides.searchEventsFn, overrides.viewToken]);
+  }, [
+    applyHardZeroResult,
+    buildSearchParams,
+    credentials,
+    isDemoSession,
+    overrides.clientId,
+    overrides.searchEventsFn,
+    overrides.viewToken,
+  ]);
 
   useEffect(() => {
     if (searchToken === 0) {
@@ -284,13 +286,14 @@ export const useEventLogsQuery = (
   };
 
   const fetchExportEvents = useCallback(async () => {
+    if (!isDemoSession) {
+      return [];
+    }
+
     const viewToken =
       overrides.viewToken !== undefined
         ? overrides.viewToken
         : getViewTokenFromLocation();
-    if (!viewToken) {
-      return [];
-    }
     const urlParams = new URLSearchParams(window.location.search);
     const clientId =
       overrides.clientId !== undefined
@@ -305,7 +308,14 @@ export const useEventLogsQuery = (
       clientId,
     });
     return (result.events as EventData[]) || [];
-  }, [buildSearchParams, credentials, overrides.clientId, overrides.searchEventsFn, overrides.viewToken]);
+  }, [
+    buildSearchParams,
+    credentials,
+    isDemoSession,
+    overrides.clientId,
+    overrides.searchEventsFn,
+    overrides.viewToken,
+  ]);
 
   return {
     events,

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -1,0 +1,98 @@
+.settings-page {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.settings-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.settings-field-row {
+  display: grid;
+  grid-template-columns: 140px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--vrm-border-subtle);
+}
+
+.settings-field-label {
+  color: var(--vrm-text-muted);
+  font-size: 14px;
+}
+
+.settings-field-value {
+  color: var(--vrm-text-primary);
+}
+
+.settings-field-edit {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-input,
+.settings-select {
+  width: 100%;
+  border: 1px solid var(--vrm-border-subtle);
+  border-radius: 8px;
+  background: var(--vrm-surface-secondary);
+  color: var(--vrm-text-primary);
+  padding: 10px 12px;
+}
+
+.settings-field-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.settings-inline-error,
+.settings-form-error {
+  color: #ff8b8b;
+  font-size: 12px;
+}
+
+.settings-empty-row {
+  text-align: center;
+  color: var(--vrm-text-muted);
+  padding: 20px;
+}
+
+.settings-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.settings-modal {
+  width: min(520px, 92vw);
+}
+
+.settings-form-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.settings-form-field {
+  display: grid;
+  gap: 6px;
+}
+
+.settings-form-label {
+  font-size: 14px;
+  color: var(--vrm-text-muted);
+}
+
+.settings-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -1,37 +1,39 @@
-.settings-page {
-  max-width: 960px;
-  margin: 0 auto;
-  display: grid;
-  gap: 24px;
-}
-
-.settings-title-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
+.settings-account-card-body,
+.settings-table-card-body {
+  padding: 0;
 }
 
 .settings-field-row {
   display: grid;
-  grid-template-columns: 140px 1fr auto;
-  gap: 12px;
-  align-items: center;
-  padding: 14px 0;
+  grid-template-columns: 160px minmax(0, 1fr) 176px;
+  gap: 16px;
+  align-items: start;
+  padding: 18px 20px;
   border-bottom: 1px solid var(--vrm-border-subtle);
+}
+
+.settings-field-row:last-child {
+  border-bottom: none;
 }
 
 .settings-field-label {
   color: var(--vrm-text-muted);
   font-size: 14px;
+  line-height: 1.5;
+  padding-top: 8px;
+}
+
+.settings-field-main {
+  min-width: 0;
+  display: grid;
+  gap: 8px;
 }
 
 .settings-field-value {
   color: var(--vrm-text-primary);
-}
-
-.settings-field-edit {
-  display: grid;
-  gap: 8px;
+  min-height: 36px;
+  display: flex;
+  align-items: center;
 }
 
 .settings-input,
@@ -42,10 +44,15 @@
   background: var(--vrm-surface-secondary);
   color: var(--vrm-text-primary);
   padding: 10px 12px;
+  min-height: 40px;
 }
 
 .settings-field-actions {
+  width: 176px;
+  min-height: 40px;
   display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: 8px;
 }
 
@@ -55,24 +62,37 @@
   font-size: 12px;
 }
 
+.settings-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.settings-table {
+  width: 100%;
+}
+
+.settings-table th {
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
 .settings-empty-row {
-  text-align: center;
+  text-align: left;
+  padding: 24px;
+}
+
+.settings-empty-title {
+  color: var(--vrm-text-primary);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.settings-empty-hint {
+  margin-top: 4px;
   color: var(--vrm-text-muted);
-  padding: 20px;
-}
-
-.settings-modal-backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.settings-modal {
-  width: min(520px, 92vw);
+  font-size: 13px;
 }
 
 .settings-form-grid {
@@ -95,4 +115,20 @@
   justify-content: flex-end;
   gap: 8px;
   margin-top: 8px;
+}
+
+@media (max-width: 900px) {
+  .settings-field-row {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .settings-field-label {
+    padding-top: 0;
+  }
+
+  .settings-field-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }

--- a/frontend/src/features/settings/api/settingsApi.ts
+++ b/frontend/src/features/settings/api/settingsApi.ts
@@ -1,5 +1,6 @@
 import { fetchMe } from "../../auth/transport/me";
 import type {
+  AccessLevel,
   ManagedUser,
   PendingInvite,
   SettingsUser,
@@ -14,6 +15,22 @@ export const getMe = async (): Promise<SettingsUser> => {
     throw new Error("Unable to load account details");
   }
   return response.data.user;
+};
+
+export const verifyCurrentPassword = async (
+  email: string,
+  password: string,
+): Promise<void> => {
+  const response = await fetch("/api/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ email: email.trim().toLowerCase(), password }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Incorrect password");
+  }
 };
 
 export const updateMe = async (_payload: UpdateMePayload): Promise<void> => {
@@ -31,7 +48,7 @@ export const getPendingInvites = async (): Promise<PendingInvite[]> => [];
 export const inviteUser = async (_payload: {
   email: string;
   site: string;
-  accessLevel: string;
+  accessLevel: AccessLevel;
 }): Promise<void> => {
   throw notImplementedError;
 };

--- a/frontend/src/features/settings/api/settingsApi.ts
+++ b/frontend/src/features/settings/api/settingsApi.ts
@@ -1,0 +1,40 @@
+import { fetchMe } from "../../auth/transport/me";
+import type {
+  ManagedUser,
+  PendingInvite,
+  SettingsUser,
+  UpdateMePayload,
+} from "../types";
+
+const notImplementedError = new Error("Not implemented yet");
+
+export const getMe = async (): Promise<SettingsUser> => {
+  const response = await fetchMe();
+  if (!response.ok) {
+    throw new Error("Unable to load account details");
+  }
+  return response.data.user;
+};
+
+export const updateMe = async (_payload: UpdateMePayload): Promise<void> => {
+  throw notImplementedError;
+};
+
+export const updatePassword = async (_password: string): Promise<void> => {
+  throw notImplementedError;
+};
+
+export const getManagedUsers = async (): Promise<ManagedUser[]> => [];
+
+export const getPendingInvites = async (): Promise<PendingInvite[]> => [];
+
+export const inviteUser = async (_payload: {
+  email: string;
+  site: string;
+  accessLevel: string;
+}): Promise<void> => {
+  throw notImplementedError;
+};
+
+export const isNotImplementedError = (error: unknown) =>
+  error instanceof Error && error.message === "Not implemented yet";

--- a/frontend/src/features/settings/components/EditableFieldRow.tsx
+++ b/frontend/src/features/settings/components/EditableFieldRow.tsx
@@ -1,11 +1,17 @@
-import React, { useState } from "react";
+import React from "react";
 
 type EditableFieldRowProps = {
   label: string;
   displayValue: string;
   value: string;
   type?: "text" | "email" | "tel" | "password";
-  onSave: (value: string) => Promise<void>;
+  isEditing: boolean;
+  isSaving: boolean;
+  error?: string | null;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+  onChange: (value: string) => void;
 };
 
 const EditableFieldRow: React.FC<EditableFieldRowProps> = ({
@@ -13,70 +19,66 @@ const EditableFieldRow: React.FC<EditableFieldRowProps> = ({
   displayValue,
   value,
   type = "text",
+  isEditing,
+  isSaving,
+  error,
+  onEdit,
+  onCancel,
   onSave,
+  onChange,
 }) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [draftValue, setDraftValue] = useState(value);
-  const [error, setError] = useState<string | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (!isSaving) {
+        onSave();
+      }
+      return;
+    }
 
-  const handleEdit = () => {
-    setDraftValue(value);
-    setError(null);
-    setIsEditing(true);
-  };
-
-  const handleCancel = () => {
-    setDraftValue(value);
-    setError(null);
-    setIsEditing(false);
-  };
-
-  const handleSave = async () => {
-    setError(null);
-    setIsSaving(true);
-    try {
-      await onSave(draftValue);
-      setIsEditing(false);
-    } catch (saveError) {
-      setError(saveError instanceof Error ? saveError.message : "Unable to save");
-    } finally {
-      setIsSaving(false);
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (!isSaving) {
+        onCancel();
+      }
     }
   };
 
   return (
-    <div className="settings-field-row">
+    <div className={`settings-field-row ${isEditing ? "settings-field-row--editing" : ""}`}>
       <div className="settings-field-label">{label}</div>
-      {!isEditing ? (
-        <>
+      <div className="settings-field-main">
+        {!isEditing ? (
           <div className="settings-field-value">{displayValue || "—"}</div>
-          <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleEdit}>
+        ) : (
+          <input
+            className="settings-input"
+            value={value}
+            type={type}
+            onChange={(event) => onChange(event.target.value)}
+            disabled={isSaving}
+            onKeyDown={handleKeyDown}
+            autoFocus
+          />
+        )}
+        {error ? <div className="settings-inline-error">{error}</div> : null}
+      </div>
+      <div className="settings-field-actions">
+        {!isEditing ? (
+          <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={onEdit}>
             Edit
           </button>
-        </>
-      ) : (
-        <>
-          <div className="settings-field-edit">
-            <input
-              className="settings-input"
-              value={draftValue}
-              type={type}
-              onChange={(event) => setDraftValue(event.target.value)}
-              disabled={isSaving}
-            />
-            {error && <div className="settings-inline-error">{error}</div>}
-          </div>
-          <div className="settings-field-actions">
-            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleCancel} disabled={isSaving}>
+        ) : (
+          <>
+            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={onCancel} disabled={isSaving}>
               Cancel
             </button>
-            <button className="vrm-btn vrm-btn-sm" onClick={handleSave} disabled={isSaving}>
+            <button className="vrm-btn vrm-btn-sm" onClick={onSave} disabled={isSaving}>
               {isSaving ? "Saving..." : "Save"}
             </button>
-          </div>
-        </>
-      )}
+          </>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/features/settings/components/EditableFieldRow.tsx
+++ b/frontend/src/features/settings/components/EditableFieldRow.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+
+type EditableFieldRowProps = {
+  label: string;
+  displayValue: string;
+  value: string;
+  type?: "text" | "email" | "tel" | "password";
+  onSave: (value: string) => Promise<void>;
+};
+
+const EditableFieldRow: React.FC<EditableFieldRowProps> = ({
+  label,
+  displayValue,
+  value,
+  type = "text",
+  onSave,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [draftValue, setDraftValue] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleEdit = () => {
+    setDraftValue(value);
+    setError(null);
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setDraftValue(value);
+    setError(null);
+    setIsEditing(false);
+  };
+
+  const handleSave = async () => {
+    setError(null);
+    setIsSaving(true);
+    try {
+      await onSave(draftValue);
+      setIsEditing(false);
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Unable to save");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="settings-field-row">
+      <div className="settings-field-label">{label}</div>
+      {!isEditing ? (
+        <>
+          <div className="settings-field-value">{displayValue || "—"}</div>
+          <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleEdit}>
+            Edit
+          </button>
+        </>
+      ) : (
+        <>
+          <div className="settings-field-edit">
+            <input
+              className="settings-input"
+              value={draftValue}
+              type={type}
+              onChange={(event) => setDraftValue(event.target.value)}
+              disabled={isSaving}
+            />
+            {error && <div className="settings-inline-error">{error}</div>}
+          </div>
+          <div className="settings-field-actions">
+            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleCancel} disabled={isSaving}>
+              Cancel
+            </button>
+            <button className="vrm-btn vrm-btn-sm" onClick={handleSave} disabled={isSaving}>
+              {isSaving ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default EditableFieldRow;

--- a/frontend/src/features/settings/components/InviteUserModal.module.css
+++ b/frontend/src/features/settings/components/InviteUserModal.module.css
@@ -1,0 +1,13 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.modal {
+  width: min(560px, 92vw);
+}

--- a/frontend/src/features/settings/components/InviteUserModal.module.css
+++ b/frontend/src/features/settings/components/InviteUserModal.module.css
@@ -11,3 +11,29 @@
 .modal {
   width: min(560px, 92vw);
 }
+
+
+.select {
+  background: var(--vrm-surface-secondary);
+  color: var(--vrm-text-primary);
+  border-color: var(--vrm-border-subtle);
+  color-scheme: dark;
+}
+
+.select:focus {
+  outline: 1px solid var(--vrm-accent-blue);
+  outline-offset: 0;
+}
+
+.select option {
+  background: var(--vrm-surface-secondary);
+  color: var(--vrm-text-primary);
+}
+
+.select option:checked {
+  background: var(--vrm-surface-tertiary, var(--vrm-hover));
+}
+
+.select option:hover {
+  background: var(--vrm-hover);
+}

--- a/frontend/src/features/settings/components/InviteUserModal.tsx
+++ b/frontend/src/features/settings/components/InviteUserModal.tsx
@@ -118,7 +118,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
               <label className="settings-form-label" htmlFor="invite-site">Site</label>
               <select
                 id="invite-site"
-                className="settings-select"
+                className={`settings-select ${styles.select}`}
                 value={site}
                 onChange={(event) => setSite(event.target.value)}
               >
@@ -129,12 +129,11 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
               <label className="settings-form-label" htmlFor="invite-level">Access level</label>
               <select
                 id="invite-level"
-                className="settings-select"
+                className={`settings-select ${styles.select}`}
                 value={accessLevel}
                 onChange={(event) => setAccessLevel(event.target.value as AccessLevel)}
               >
                 <option value="Viewer">Viewer</option>
-                <option value="Manager">Manager</option>
                 <option value="Admin">Admin</option>
               </select>
             </div>

--- a/frontend/src/features/settings/components/InviteUserModal.tsx
+++ b/frontend/src/features/settings/components/InviteUserModal.tsx
@@ -9,15 +9,15 @@ type InviteUserModalProps = {
   onSubmitted: (payload: { email: string; site: string; accessLevel: AccessLevel }) => Promise<void>;
 };
 
-type InviteState = "pristine" | "invalid" | "valid" | "submitting" | "error";
+type InviteState = "closed" | "pristine" | "invalid" | "valid" | "submitting" | "error";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSubmitted }) => {
   const [email, setEmail] = useState("");
-  const [site, setSite] = useState("");
+  const [site, setSite] = useState("all-sites");
   const [accessLevel, setAccessLevel] = useState<AccessLevel>("Viewer");
-  const [state, setState] = useState<InviteState>("pristine");
+  const [state, setState] = useState<InviteState>("closed");
   const [error, setError] = useState<string | null>(null);
   const emailInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -25,36 +25,46 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
 
   useEffect(() => {
     if (!isOpen) {
+      setState("closed");
       return;
     }
+
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
     window.setTimeout(() => emailInputRef.current?.focus(), 0);
 
+    if (!email) {
+      setState("pristine");
+    }
+
     return () => {
       document.body.style.overflow = previousOverflow;
     };
-  }, [isOpen]);
+  }, [email, isOpen]);
 
   useEffect(() => {
-    if (!isOpen) {
+    if (!isOpen || state === "submitting" || state === "error") {
       return;
     }
 
-    if (!email && !site) {
+    if (!email) {
       setState("pristine");
       return;
     }
 
     setState(isValid ? "valid" : "invalid");
-  }, [email, site, accessLevel, isOpen, isValid]);
+  }, [email, isOpen, isValid, state]);
+
+  const resetState = () => {
+    setEmail("");
+    setSite("all-sites");
+    setAccessLevel("Viewer");
+    setState("closed");
+    setError(null);
+  };
 
   const handleClose = () => {
-    setEmail("");
-    setSite("");
-    setAccessLevel("Viewer");
-    setState("pristine");
-    setError(null);
+    resetState();
     onClose();
   };
 
@@ -71,7 +81,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
     try {
       await onSubmitted({
         email: email.trim(),
-        site: site.trim(),
+        site,
         accessLevel,
       });
       handleClose();
@@ -106,14 +116,14 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
             </div>
             <div className="settings-form-field">
               <label className="settings-form-label" htmlFor="invite-site">Site</label>
-              <input
+              <select
                 id="invite-site"
-                className="settings-input"
-                type="text"
+                className="settings-select"
                 value={site}
                 onChange={(event) => setSite(event.target.value)}
-                placeholder="Enter site"
-              />
+              >
+                <option value="all-sites">All Sites</option>
+              </select>
             </div>
             <div className="settings-form-field">
               <label className="settings-form-label" htmlFor="invite-level">Access level</label>

--- a/frontend/src/features/settings/components/InviteUserModal.tsx
+++ b/frontend/src/features/settings/components/InviteUserModal.tsx
@@ -1,0 +1,155 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import type { AccessLevel } from "../types";
+import styles from "./InviteUserModal.module.css";
+
+type InviteUserModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmitted: (payload: { email: string; site: string; accessLevel: AccessLevel }) => Promise<void>;
+};
+
+type InviteState = "pristine" | "invalid" | "valid" | "submitting" | "error";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSubmitted }) => {
+  const [email, setEmail] = useState("");
+  const [site, setSite] = useState("");
+  const [accessLevel, setAccessLevel] = useState<AccessLevel>("Viewer");
+  const [state, setState] = useState<InviteState>("pristine");
+  const [error, setError] = useState<string | null>(null);
+  const emailInputRef = useRef<HTMLInputElement | null>(null);
+
+  const isValid = EMAIL_RE.test(email.trim()) && Boolean(site.trim()) && Boolean(accessLevel);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.setTimeout(() => emailInputRef.current?.focus(), 0);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    if (!email && !site) {
+      setState("pristine");
+      return;
+    }
+
+    setState(isValid ? "valid" : "invalid");
+  }, [email, site, accessLevel, isOpen, isValid]);
+
+  const handleClose = () => {
+    setEmail("");
+    setSite("");
+    setAccessLevel("Viewer");
+    setState("pristine");
+    setError(null);
+    onClose();
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!isValid || state === "submitting") {
+      setState("invalid");
+      return;
+    }
+
+    setState("submitting");
+    setError(null);
+
+    try {
+      await onSubmitted({
+        email: email.trim(),
+        site: site.trim(),
+        accessLevel,
+      });
+      handleClose();
+    } catch (submissionError) {
+      setState("error");
+      setError(submissionError instanceof Error ? submissionError.message : "Unable to submit invite");
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className={styles.backdrop}>
+      <div className={`vrm-card ${styles.modal}`} role="dialog" aria-modal="true" aria-label="Invite user modal">
+        <div className="vrm-card-header">
+          <h3 className="vrm-card-title">Invite user</h3>
+        </div>
+        <div className="vrm-card-body">
+          <form onSubmit={handleSubmit} className="settings-form-grid">
+            <div className="settings-form-field">
+              <label className="settings-form-label" htmlFor="invite-email">Email</label>
+              <input
+                id="invite-email"
+                ref={emailInputRef}
+                className="settings-input"
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+            <div className="settings-form-field">
+              <label className="settings-form-label" htmlFor="invite-site">Site</label>
+              <input
+                id="invite-site"
+                className="settings-input"
+                type="text"
+                value={site}
+                onChange={(event) => setSite(event.target.value)}
+                placeholder="Enter site"
+              />
+            </div>
+            <div className="settings-form-field">
+              <label className="settings-form-label" htmlFor="invite-level">Access level</label>
+              <select
+                id="invite-level"
+                className="settings-select"
+                value={accessLevel}
+                onChange={(event) => setAccessLevel(event.target.value as AccessLevel)}
+              >
+                <option value="Viewer">Viewer</option>
+                <option value="Manager">Manager</option>
+                <option value="Admin">Admin</option>
+              </select>
+            </div>
+            {(state === "invalid" || state === "error") && (
+              <div className="settings-form-error">
+                {error ?? "Email, site, and access level are required"}
+              </div>
+            )}
+            <div className="settings-form-actions">
+              <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleClose}>
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className="vrm-btn vrm-btn-sm"
+                disabled={!isValid || state === "submitting"}
+              >
+                {state === "submitting" ? "Sending..." : "Send invite"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default InviteUserModal;

--- a/frontend/src/features/settings/components/PendingInvitesTable.tsx
+++ b/frontend/src/features/settings/components/PendingInvitesTable.tsx
@@ -7,8 +7,8 @@ type PendingInvitesTableProps = {
 };
 
 const PendingInvitesTable: React.FC<PendingInvitesTableProps> = ({ invites }) => (
-  <div style={{ overflowX: "auto" }}>
-    <table className="vrm-table">
+  <div className="settings-table-wrap">
+    <table className="vrm-table settings-table">
       <thead>
         <tr>
           <th>Email</th>
@@ -20,7 +20,10 @@ const PendingInvitesTable: React.FC<PendingInvitesTableProps> = ({ invites }) =>
       <tbody>
         {invites.length === 0 ? (
           <tr>
-            <td colSpan={4} className="settings-empty-row">No pending invitations.</td>
+            <td colSpan={4} className="settings-empty-row">
+              <div className="settings-empty-title">No pending invitations</div>
+              <div className="settings-empty-hint">Invited users will appear here until they accept access.</div>
+            </td>
           </tr>
         ) : (
           invites.map((invite) => (

--- a/frontend/src/features/settings/components/PendingInvitesTable.tsx
+++ b/frontend/src/features/settings/components/PendingInvitesTable.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import type { PendingInvite } from "../types";
+
+type PendingInvitesTableProps = {
+  invites: PendingInvite[];
+};
+
+const PendingInvitesTable: React.FC<PendingInvitesTableProps> = ({ invites }) => (
+  <div style={{ overflowX: "auto" }}>
+    <table className="vrm-table">
+      <thead>
+        <tr>
+          <th>Email</th>
+          <th>Site</th>
+          <th>Access level</th>
+          <th>Invited</th>
+        </tr>
+      </thead>
+      <tbody>
+        {invites.length === 0 ? (
+          <tr>
+            <td colSpan={4} className="settings-empty-row">No pending invitations.</td>
+          </tr>
+        ) : (
+          invites.map((invite) => (
+            <tr key={`${invite.email}-${invite.site}`}>
+              <td>{invite.email}</td>
+              <td>{invite.site}</td>
+              <td>{invite.accessLevel}</td>
+              <td>{invite.invitedAt ?? "-"}</td>
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default PendingInvitesTable;

--- a/frontend/src/features/settings/components/ReenterPasswordModal.module.css
+++ b/frontend/src/features/settings/components/ReenterPasswordModal.module.css
@@ -1,0 +1,13 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+}
+
+.modal {
+  width: min(520px, 92vw);
+}

--- a/frontend/src/features/settings/components/ReenterPasswordModal.tsx
+++ b/frontend/src/features/settings/components/ReenterPasswordModal.tsx
@@ -1,0 +1,102 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import styles from "./ReenterPasswordModal.module.css";
+
+type ReenterPasswordModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onVerified: () => void;
+  onVerifyPassword: (password: string) => Promise<void>;
+};
+
+const ReenterPasswordModal: React.FC<ReenterPasswordModalProps> = ({
+  isOpen,
+  onClose,
+  onVerified,
+  onVerifyPassword,
+}) => {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    window.setTimeout(() => inputRef.current?.focus(), 0);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isOpen]);
+
+  const handleClose = () => {
+    setPassword("");
+    setError(null);
+    setIsSubmitting(false);
+    onClose();
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!password || isSubmitting) {
+      setError("Current password is required");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await onVerifyPassword(password);
+      setPassword("");
+      onVerified();
+    } catch (verifyError) {
+      setError(verifyError instanceof Error ? verifyError.message : "Unable to verify password");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className={styles.backdrop}>
+      <div className={`vrm-card ${styles.modal}`} role="dialog" aria-modal="true" aria-label="Re-enter password">
+        <div className="vrm-card-header">
+          <h3 className="vrm-card-title">Re-enter password</h3>
+        </div>
+        <div className="vrm-card-body">
+          <form onSubmit={handleSubmit} className="settings-form-grid">
+            <div className="settings-form-field">
+              <label className="settings-form-label" htmlFor="current-password">Current password</label>
+              <input
+                id="current-password"
+                ref={inputRef}
+                className="settings-input"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+            </div>
+            {error ? <div className="settings-form-error">{error}</div> : null}
+            <div className="settings-form-actions">
+              <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleClose}>
+                Cancel
+              </button>
+              <button type="submit" className="vrm-btn vrm-btn-sm" disabled={isSubmitting}>
+                {isSubmitting ? "Verifying..." : "Continue"}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReenterPasswordModal;

--- a/frontend/src/features/settings/components/SettingsFrame.module.css
+++ b/frontend/src/features/settings/components/SettingsFrame.module.css
@@ -1,0 +1,14 @@
+.frame {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 20px;
+}
+
+@media (max-width: 960px) {
+  .frame {
+    gap: 16px;
+  }
+}

--- a/frontend/src/features/settings/components/SettingsFrame.tsx
+++ b/frontend/src/features/settings/components/SettingsFrame.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+import styles from "./SettingsFrame.module.css";
+
+type SettingsFrameProps = {
+  children: React.ReactNode;
+};
+
+const SettingsFrame: React.FC<SettingsFrameProps> = ({ children }) => (
+  <section className={styles.frame}>{children}</section>
+);
+
+export default SettingsFrame;

--- a/frontend/src/features/settings/components/SettingsPageHeader.module.css
+++ b/frontend/src/features/settings/components/SettingsPageHeader.module.css
@@ -1,0 +1,27 @@
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.title {
+  font-size: 28px;
+  line-height: 1.2;
+  font-weight: 700;
+  color: var(--vrm-text-primary);
+}
+
+.action {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+@media (max-width: 720px) {
+  .action {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/features/settings/components/SettingsPageHeader.tsx
+++ b/frontend/src/features/settings/components/SettingsPageHeader.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+import styles from "./SettingsPageHeader.module.css";
+
+type SettingsPageHeaderProps = {
+  title: string;
+  action?: React.ReactNode;
+};
+
+const SettingsPageHeader: React.FC<SettingsPageHeaderProps> = ({ title, action }) => (
+  <header className={styles.header}>
+    <h1 className={styles.title}>{title}</h1>
+    {action ? <div className={styles.action}>{action}</div> : null}
+  </header>
+);
+
+export default SettingsPageHeader;

--- a/frontend/src/features/settings/components/SettingsSecondaryNav.tsx
+++ b/frontend/src/features/settings/components/SettingsSecondaryNav.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Bell, Settings, Shield } from "lucide-react";
+import { useLocation } from "react-router-dom";
+
+import { NavList, NavRow, SecondaryDivider } from "../../../common/components/navigation";
+import { NavIcon } from "../../../common/components/icons";
+
+const SettingsSecondaryNav: React.FC = () => {
+  const location = useLocation();
+  const isAccountRoute = location.pathname === "/settings/account";
+  const isAccessRoute = location.pathname === "/settings/access";
+
+  return (
+    <>
+      <div className="vrm-secondary-header">
+        <div className="vrm-nav-row vrm-nav-row--inert">
+          <span className="vrm-nav-row__icon"><NavIcon icon={Settings} /></span>
+          <span className="vrm-nav-row__label">Settings</span>
+        </div>
+        <SecondaryDivider />
+      </div>
+      <NavList className="vrm-secondary-list">
+        <NavRow
+          to="/settings/account"
+          leftIcon={<NavIcon icon={Settings} />}
+          label="My Account"
+          active={isAccountRoute}
+        />
+        <NavRow
+          to="/settings/access"
+          leftIcon={<NavIcon icon={Shield} />}
+          label="Manage Access"
+          active={isAccessRoute}
+        />
+        <NavRow
+          leftIcon={<NavIcon icon={Bell} />}
+          label="Create Alarm"
+          disabled
+        />
+      </NavList>
+    </>
+  );
+};
+
+export default SettingsSecondaryNav;

--- a/frontend/src/features/settings/components/UsersTable.tsx
+++ b/frontend/src/features/settings/components/UsersTable.tsx
@@ -4,9 +4,17 @@ import type { ManagedUser } from "../types";
 
 type UsersTableProps = {
   users: ManagedUser[];
+  currentUsername?: string;
+  currentUserSite: string;
+  onCurrentUserSiteChange: (site: string) => void;
 };
 
-const UsersTable: React.FC<UsersTableProps> = ({ users }) => (
+const UsersTable: React.FC<UsersTableProps> = ({
+  users,
+  currentUsername,
+  currentUserSite,
+  onCurrentUserSiteChange,
+}) => (
   <div className="settings-table-wrap">
     <table className="vrm-table settings-table">
       <thead>
@@ -18,23 +26,29 @@ const UsersTable: React.FC<UsersTableProps> = ({ users }) => (
         </tr>
       </thead>
       <tbody>
-        {users.length === 0 ? (
-          <tr>
-            <td colSpan={4} className="settings-empty-row">
-              <div className="settings-empty-title">No users yet</div>
-              <div className="settings-empty-hint">Invite a user to grant access to a site.</div>
-            </td>
-          </tr>
-        ) : (
-          users.map((user) => (
-            <tr key={`${user.username}-${user.site}`}>
+        {users.map((user) => {
+          const isCurrentUser = Boolean(currentUsername) && user.username === currentUsername;
+          return (
+            <tr key={`${user.username}-${user.email}`}>
               <td>{user.username}</td>
               <td>{user.email}</td>
-              <td>{user.site}</td>
+              <td>
+                {isCurrentUser ? (
+                  <select
+                    className="settings-select settings-site-select"
+                    value={currentUserSite}
+                    onChange={(event) => onCurrentUserSiteChange(event.target.value)}
+                  >
+                    <option value="all-sites">All Sites</option>
+                  </select>
+                ) : (
+                  user.site
+                )}
+              </td>
               <td>{user.accessLevel}</td>
             </tr>
-          ))
-        )}
+          );
+        })}
       </tbody>
     </table>
   </div>

--- a/frontend/src/features/settings/components/UsersTable.tsx
+++ b/frontend/src/features/settings/components/UsersTable.tsx
@@ -7,8 +7,8 @@ type UsersTableProps = {
 };
 
 const UsersTable: React.FC<UsersTableProps> = ({ users }) => (
-  <div style={{ overflowX: "auto" }}>
-    <table className="vrm-table">
+  <div className="settings-table-wrap">
+    <table className="vrm-table settings-table">
       <thead>
         <tr>
           <th>Username</th>
@@ -20,7 +20,10 @@ const UsersTable: React.FC<UsersTableProps> = ({ users }) => (
       <tbody>
         {users.length === 0 ? (
           <tr>
-            <td colSpan={4} className="settings-empty-row">No users found.</td>
+            <td colSpan={4} className="settings-empty-row">
+              <div className="settings-empty-title">No users yet</div>
+              <div className="settings-empty-hint">Invite a user to grant access to a site.</div>
+            </td>
           </tr>
         ) : (
           users.map((user) => (

--- a/frontend/src/features/settings/components/UsersTable.tsx
+++ b/frontend/src/features/settings/components/UsersTable.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import type { ManagedUser } from "../types";
+
+type UsersTableProps = {
+  users: ManagedUser[];
+};
+
+const UsersTable: React.FC<UsersTableProps> = ({ users }) => (
+  <div style={{ overflowX: "auto" }}>
+    <table className="vrm-table">
+      <thead>
+        <tr>
+          <th>Username</th>
+          <th>Email</th>
+          <th>Site</th>
+          <th>Access level</th>
+        </tr>
+      </thead>
+      <tbody>
+        {users.length === 0 ? (
+          <tr>
+            <td colSpan={4} className="settings-empty-row">No users found.</td>
+          </tr>
+        ) : (
+          users.map((user) => (
+            <tr key={`${user.username}-${user.site}`}>
+              <td>{user.username}</td>
+              <td>{user.email}</td>
+              <td>{user.site}</td>
+              <td>{user.accessLevel}</td>
+            </tr>
+          ))
+        )}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default UsersTable;

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import {
   getManagedUsers,
+  getMe,
   getPendingInvites,
   inviteUser,
   isNotImplementedError,
@@ -11,22 +12,34 @@ import PendingInvitesTable from "../components/PendingInvitesTable";
 import SettingsFrame from "../components/SettingsFrame";
 import SettingsPageHeader from "../components/SettingsPageHeader";
 import UsersTable from "../components/UsersTable";
-import type { AccessLevel, ManagedUser, PendingInvite } from "../types";
+import type { AccessLevel, ManagedUser, PendingInvite, SettingsUser } from "../types";
 import "../SettingsPages.css";
 
 const ManageAccessPage: React.FC = () => {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [invites, setInvites] = useState<PendingInvite[]>([]);
+  const [currentUser, setCurrentUser] = useState<SettingsUser | null>(null);
+  const [currentUserSite, setCurrentUserSite] = useState("all-sites");
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const inviteButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     const load = async () => {
-      const [loadedUsers, loadedInvites] = await Promise.all([
+      const [me, loadedUsers, loadedInvites] = await Promise.all([
+        getMe(),
         getManagedUsers(),
         getPendingInvites(),
       ]);
-      setUsers(loadedUsers);
+
+      setCurrentUser(me);
+      const currentUserRow: ManagedUser = {
+        username: me.name,
+        email: me.email,
+        site: "All Sites",
+        accessLevel: "Admin",
+      };
+
+      setUsers([currentUserRow, ...loadedUsers]);
       setInvites(loadedInvites);
     };
 
@@ -58,7 +71,11 @@ const ManageAccessPage: React.FC = () => {
       <SettingsPageHeader
         title="Manage Access"
         action={
-          <button ref={inviteButtonRef} className="vrm-btn vrm-btn-sm" onClick={() => setIsInviteOpen(true)}>
+          <button
+            ref={inviteButtonRef}
+            className="vrm-btn vrm-btn-primary vrm-btn-sm"
+            onClick={() => setIsInviteOpen(true)}
+          >
             Invite user
           </button>
         }
@@ -69,7 +86,12 @@ const ManageAccessPage: React.FC = () => {
           <h2 className="vrm-card-title">Users</h2>
         </div>
         <div className="vrm-card-body settings-table-card-body">
-          <UsersTable users={users} />
+          <UsersTable
+            users={users}
+            currentUsername={currentUser?.name}
+            currentUserSite={currentUserSite}
+            onCurrentUserSiteChange={setCurrentUserSite}
+          />
         </div>
       </div>
 
@@ -82,7 +104,11 @@ const ManageAccessPage: React.FC = () => {
         </div>
       </div>
 
-      <InviteUserModal isOpen={isInviteOpen} onClose={handleCloseModal} onSubmitted={handleInviteSubmit} />
+      <InviteUserModal
+        isOpen={isInviteOpen}
+        onClose={handleCloseModal}
+        onSubmitted={handleInviteSubmit}
+      />
     </SettingsFrame>
   );
 };

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import {
   getManagedUsers,
@@ -6,7 +6,10 @@ import {
   inviteUser,
   isNotImplementedError,
 } from "../api/settingsApi";
+import InviteUserModal from "../components/InviteUserModal";
 import PendingInvitesTable from "../components/PendingInvitesTable";
+import SettingsFrame from "../components/SettingsFrame";
+import SettingsPageHeader from "../components/SettingsPageHeader";
 import UsersTable from "../components/UsersTable";
 import type { AccessLevel, ManagedUser, PendingInvite } from "../types";
 import "../SettingsPages.css";
@@ -14,11 +17,8 @@ import "../SettingsPages.css";
 const ManageAccessPage: React.FC = () => {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [invites, setInvites] = useState<PendingInvite[]>([]);
-  const [showInviteForm, setShowInviteForm] = useState(false);
-  const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteSite, setInviteSite] = useState("");
-  const [inviteAccessLevel, setInviteAccessLevel] = useState<AccessLevel>("Viewer");
-  const [inviteError, setInviteError] = useState<string | null>(null);
+  const [isInviteOpen, setIsInviteOpen] = useState(false);
+  const inviteButtonRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     const load = async () => {
@@ -29,112 +29,61 @@ const ManageAccessPage: React.FC = () => {
       setUsers(loadedUsers);
       setInvites(loadedInvites);
     };
+
     load();
   }, []);
 
-  const handleInvite = async (event: React.FormEvent) => {
-    event.preventDefault();
-    setInviteError(null);
-
-    if (!inviteEmail.trim() || !inviteSite.trim()) {
-      setInviteError("Email, site, and access level are required");
-      return;
-    }
-
+  const handleInviteSubmit = async (payload: {
+    email: string;
+    site: string;
+    accessLevel: AccessLevel;
+  }) => {
     try {
-      await inviteUser({
-        email: inviteEmail.trim(),
-        site: inviteSite.trim(),
-        accessLevel: inviteAccessLevel,
-      });
-      setShowInviteForm(false);
-      setInviteEmail("");
-      setInviteSite("");
-      setInviteAccessLevel("Viewer");
+      await inviteUser(payload);
     } catch (error) {
       if (isNotImplementedError(error)) {
-        setInviteError("Not implemented yet");
-        return;
+        throw new Error("Not implemented yet");
       }
-      setInviteError(error instanceof Error ? error.message : "Unable to send invite");
+      throw error;
     }
   };
 
+  const handleCloseModal = () => {
+    setIsInviteOpen(false);
+    window.setTimeout(() => inviteButtonRef.current?.focus(), 0);
+  };
+
   return (
-    <section className="settings-page">
-      <div className="vrm-card">
-        <div className="vrm-card-header settings-title-row">
-          <h2 className="vrm-card-title">Manage Access</h2>
-          <button className="vrm-btn vrm-btn-sm" onClick={() => setShowInviteForm(true)}>
+    <SettingsFrame>
+      <SettingsPageHeader
+        title="Manage Access"
+        action={
+          <button ref={inviteButtonRef} className="vrm-btn vrm-btn-sm" onClick={() => setIsInviteOpen(true)}>
             Invite user
           </button>
+        }
+      />
+
+      <div className="vrm-card">
+        <div className="vrm-card-header">
+          <h2 className="vrm-card-title">Users</h2>
         </div>
-        <div className="vrm-card-body" style={{ padding: 0 }}>
+        <div className="vrm-card-body settings-table-card-body">
           <UsersTable users={users} />
         </div>
       </div>
 
       <div className="vrm-card">
         <div className="vrm-card-header">
-          <h3 className="vrm-card-title">Pending invitations</h3>
+          <h2 className="vrm-card-title">Pending invitations</h2>
         </div>
-        <div className="vrm-card-body" style={{ padding: 0 }}>
+        <div className="vrm-card-body settings-table-card-body">
           <PendingInvitesTable invites={invites} />
         </div>
       </div>
 
-      {showInviteForm && (
-        <div className="settings-modal-backdrop">
-          <div className="vrm-card settings-modal">
-            <div className="vrm-card-header">
-              <h3 className="vrm-card-title">Invite user</h3>
-            </div>
-            <div className="vrm-card-body">
-              <form onSubmit={handleInvite} className="settings-form-grid">
-                <div className="settings-form-field">
-                  <label className="settings-form-label">Email</label>
-                  <input
-                    className="settings-input"
-                    type="email"
-                    value={inviteEmail}
-                    onChange={(event) => setInviteEmail(event.target.value)}
-                  />
-                </div>
-                <div className="settings-form-field">
-                  <label className="settings-form-label">Site</label>
-                  <input
-                    className="settings-input"
-                    type="text"
-                    value={inviteSite}
-                    onChange={(event) => setInviteSite(event.target.value)}
-                    placeholder="Enter site"
-                  />
-                </div>
-                <div className="settings-form-field">
-                  <label className="settings-form-label">Access level</label>
-                  <select
-                    className="settings-select"
-                    value={inviteAccessLevel}
-                    onChange={(event) => setInviteAccessLevel(event.target.value as AccessLevel)}
-                  >
-                    <option value="Viewer">Viewer</option>
-                    <option value="Manager">Manager</option>
-                    <option value="Admin">Admin</option>
-                  </select>
-                </div>
-                {inviteError && <div className="settings-form-error">{inviteError}</div>}
-                <div className="settings-form-actions">
-                  <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => setShowInviteForm(false)}>
-                    Cancel
-                  </button>
-                  <button type="submit" className="vrm-btn vrm-btn-sm">Send invite</button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      )}
-    </section>
+      <InviteUserModal isOpen={isInviteOpen} onClose={handleCloseModal} onSubmitted={handleInviteSubmit} />
+    </SettingsFrame>
   );
 };
 

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useState } from "react";
+
+import {
+  getManagedUsers,
+  getPendingInvites,
+  inviteUser,
+  isNotImplementedError,
+} from "../api/settingsApi";
+import PendingInvitesTable from "../components/PendingInvitesTable";
+import UsersTable from "../components/UsersTable";
+import type { AccessLevel, ManagedUser, PendingInvite } from "../types";
+import "../SettingsPages.css";
+
+const ManageAccessPage: React.FC = () => {
+  const [users, setUsers] = useState<ManagedUser[]>([]);
+  const [invites, setInvites] = useState<PendingInvite[]>([]);
+  const [showInviteForm, setShowInviteForm] = useState(false);
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteSite, setInviteSite] = useState("");
+  const [inviteAccessLevel, setInviteAccessLevel] = useState<AccessLevel>("Viewer");
+  const [inviteError, setInviteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const [loadedUsers, loadedInvites] = await Promise.all([
+        getManagedUsers(),
+        getPendingInvites(),
+      ]);
+      setUsers(loadedUsers);
+      setInvites(loadedInvites);
+    };
+    load();
+  }, []);
+
+  const handleInvite = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setInviteError(null);
+
+    if (!inviteEmail.trim() || !inviteSite.trim()) {
+      setInviteError("Email, site, and access level are required");
+      return;
+    }
+
+    try {
+      await inviteUser({
+        email: inviteEmail.trim(),
+        site: inviteSite.trim(),
+        accessLevel: inviteAccessLevel,
+      });
+      setShowInviteForm(false);
+      setInviteEmail("");
+      setInviteSite("");
+      setInviteAccessLevel("Viewer");
+    } catch (error) {
+      if (isNotImplementedError(error)) {
+        setInviteError("Not implemented yet");
+        return;
+      }
+      setInviteError(error instanceof Error ? error.message : "Unable to send invite");
+    }
+  };
+
+  return (
+    <section className="settings-page">
+      <div className="vrm-card">
+        <div className="vrm-card-header settings-title-row">
+          <h2 className="vrm-card-title">Manage Access</h2>
+          <button className="vrm-btn vrm-btn-sm" onClick={() => setShowInviteForm(true)}>
+            Invite user
+          </button>
+        </div>
+        <div className="vrm-card-body" style={{ padding: 0 }}>
+          <UsersTable users={users} />
+        </div>
+      </div>
+
+      <div className="vrm-card">
+        <div className="vrm-card-header">
+          <h3 className="vrm-card-title">Pending invitations</h3>
+        </div>
+        <div className="vrm-card-body" style={{ padding: 0 }}>
+          <PendingInvitesTable invites={invites} />
+        </div>
+      </div>
+
+      {showInviteForm && (
+        <div className="settings-modal-backdrop">
+          <div className="vrm-card settings-modal">
+            <div className="vrm-card-header">
+              <h3 className="vrm-card-title">Invite user</h3>
+            </div>
+            <div className="vrm-card-body">
+              <form onSubmit={handleInvite} className="settings-form-grid">
+                <div className="settings-form-field">
+                  <label className="settings-form-label">Email</label>
+                  <input
+                    className="settings-input"
+                    type="email"
+                    value={inviteEmail}
+                    onChange={(event) => setInviteEmail(event.target.value)}
+                  />
+                </div>
+                <div className="settings-form-field">
+                  <label className="settings-form-label">Site</label>
+                  <input
+                    className="settings-input"
+                    type="text"
+                    value={inviteSite}
+                    onChange={(event) => setInviteSite(event.target.value)}
+                    placeholder="Enter site"
+                  />
+                </div>
+                <div className="settings-form-field">
+                  <label className="settings-form-label">Access level</label>
+                  <select
+                    className="settings-select"
+                    value={inviteAccessLevel}
+                    onChange={(event) => setInviteAccessLevel(event.target.value as AccessLevel)}
+                  >
+                    <option value="Viewer">Viewer</option>
+                    <option value="Manager">Manager</option>
+                    <option value="Admin">Admin</option>
+                  </select>
+                </div>
+                {inviteError && <div className="settings-form-error">{inviteError}</div>}
+                <div className="settings-form-actions">
+                  <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => setShowInviteForm(false)}>
+                    Cancel
+                  </button>
+                  <button type="submit" className="vrm-btn vrm-btn-sm">Send invite</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default ManageAccessPage;

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -1,22 +1,25 @@
 import React, { useEffect, useMemo, useState } from "react";
 
+import { getMe, isNotImplementedError, updateMe, updatePassword } from "../api/settingsApi";
 import EditableFieldRow from "../components/EditableFieldRow";
-import {
-  getMe,
-  isNotImplementedError,
-  updateMe,
-  updatePassword,
-} from "../api/settingsApi";
+import SettingsFrame from "../components/SettingsFrame";
+import SettingsPageHeader from "../components/SettingsPageHeader";
 import type { SettingsUser } from "../types";
 import "../SettingsPages.css";
+
+type EditableRowKey = "name" | "email" | "phone" | "password";
+
+type RowDraftState = Record<EditableRowKey, string>;
+type RowSavingState = Record<EditableRowKey, boolean>;
+type RowErrorState = Record<EditableRowKey, string | null>;
 
 const maskEmail = (email: string) => {
   const [localPart, domain] = email.split("@");
   if (!domain) {
     return "••••";
   }
-  const visible = localPart.slice(0, 2);
-  return `${visible}${"•".repeat(Math.max(localPart.length - 2, 2))}@${domain}`;
+  const localVisible = Math.min(2, localPart.length);
+  return `${localPart.slice(0, localVisible)}${"•".repeat(Math.max(localPart.length - localVisible, 4))}@${domain}`;
 };
 
 const maskPhone = (phone: string | null | undefined) => {
@@ -27,139 +30,190 @@ const maskPhone = (phone: string | null | undefined) => {
   return `${"•".repeat(Math.max(phone.length - 2, 4))}${visible}`;
 };
 
+const defaultSavingState: RowSavingState = {
+  name: false,
+  email: false,
+  phone: false,
+  password: false,
+};
+
+const defaultErrorState: RowErrorState = {
+  name: null,
+  email: null,
+  phone: null,
+  password: null,
+};
+
 const MyAccountPage: React.FC = () => {
   const [user, setUser] = useState<SettingsUser | null>(null);
   const [loadingError, setLoadingError] = useState<string | null>(null);
+  const [activeEditingRowId, setActiveEditingRowId] = useState<EditableRowKey | null>(null);
+  const [drafts, setDrafts] = useState<RowDraftState>({ name: "", email: "", phone: "", password: "" });
+  const [saving, setSaving] = useState<RowSavingState>(defaultSavingState);
+  const [errors, setErrors] = useState<RowErrorState>(defaultErrorState);
 
   useEffect(() => {
     const load = async () => {
       try {
         const me = await getMe();
         setUser(me);
+        setDrafts({ name: me.name, email: me.email, phone: me.phone ?? "", password: "" });
       } catch (error) {
         setLoadingError(error instanceof Error ? error.message : "Unable to load account");
       }
     };
+
     load();
   }, []);
 
+  const startEditing = (rowId: EditableRowKey) => {
+    if (!user) {
+      return;
+    }
+    setErrors((prev) => ({ ...prev, [rowId]: null }));
+    setActiveEditingRowId(rowId);
+    setDrafts((prev) => ({
+      ...prev,
+      name: user.name,
+      email: user.email,
+      phone: user.phone ?? "",
+      password: rowId === "password" ? "" : prev.password,
+    }));
+  };
+
+  const cancelEditing = (rowId: EditableRowKey) => {
+    if (!user) {
+      return;
+    }
+    setErrors((prev) => ({ ...prev, [rowId]: null }));
+    setDrafts((prev) => ({
+      ...prev,
+      name: user.name,
+      email: user.email,
+      phone: user.phone ?? "",
+      password: "",
+    }));
+    setActiveEditingRowId((prev) => (prev === rowId ? null : prev));
+  };
+
+  const handleSave = async (rowId: EditableRowKey) => {
+    if (!user) {
+      return;
+    }
+
+    const nextValue = drafts[rowId].trim();
+
+    if (rowId !== "phone" && !nextValue) {
+      setErrors((prev) => ({ ...prev, [rowId]: `${rowId[0].toUpperCase()}${rowId.slice(1)} is required` }));
+      return;
+    }
+
+    setSaving((prev) => ({ ...prev, [rowId]: true }));
+    setErrors((prev) => ({ ...prev, [rowId]: null }));
+
+    try {
+      if (rowId === "password") {
+        await updatePassword(nextValue);
+      } else if (rowId === "name") {
+        await updateMe({ name: nextValue });
+      } else if (rowId === "email") {
+        await updateMe({ email: nextValue });
+      } else {
+        await updateMe({ phone: nextValue });
+      }
+
+      setUser((prev) => {
+        if (!prev) {
+          return prev;
+        }
+        if (rowId === "password") {
+          return prev;
+        }
+        return {
+          ...prev,
+          [rowId]: rowId === "phone" ? nextValue : nextValue,
+        };
+      });
+      setActiveEditingRowId(null);
+      setDrafts((prev) => ({ ...prev, password: "" }));
+    } catch (error) {
+      if (isNotImplementedError(error)) {
+        setErrors((prev) => ({ ...prev, [rowId]: "Not implemented yet" }));
+      } else {
+        setErrors((prev) => ({
+          ...prev,
+          [rowId]: error instanceof Error ? error.message : "Unable to save",
+        }));
+      }
+    } finally {
+      setSaving((prev) => ({ ...prev, [rowId]: false }));
+    }
+  };
+
   const rows = useMemo(() => {
     if (!user) {
-      return [];
+      return [] as Array<{
+        key: EditableRowKey;
+        label: string;
+        displayValue: string;
+        type?: "text" | "email" | "tel" | "password";
+      }>;
     }
+
     return [
-      {
-        key: "name",
-        label: "Name",
-        value: user.name,
-        displayValue: user.name,
-        onSave: async (value: string) => {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            throw new Error("Name is required");
-          }
-          try {
-            await updateMe({ name: trimmed });
-            setUser((prev) => (prev ? { ...prev, name: trimmed } : prev));
-          } catch (error) {
-            if (isNotImplementedError(error)) {
-              throw new Error("Not implemented yet");
-            }
-            throw error;
-          }
-        },
-      },
-      {
-        key: "email",
-        label: "Email",
-        value: user.email,
-        displayValue: maskEmail(user.email),
-        type: "email" as const,
-        onSave: async (value: string) => {
-          const trimmed = value.trim();
-          if (!trimmed) {
-            throw new Error("Email is required");
-          }
-          try {
-            await updateMe({ email: trimmed });
-            setUser((prev) => (prev ? { ...prev, email: trimmed } : prev));
-          } catch (error) {
-            if (isNotImplementedError(error)) {
-              throw new Error("Not implemented yet");
-            }
-            throw error;
-          }
-        },
-      },
-      {
-        key: "phone",
-        label: "Phone",
-        value: user.phone ?? "",
-        displayValue: maskPhone(user.phone),
-        type: "tel" as const,
-        onSave: async (value: string) => {
-          try {
-            await updateMe({ phone: value.trim() });
-            setUser((prev) => (prev ? { ...prev, phone: value.trim() } : prev));
-          } catch (error) {
-            if (isNotImplementedError(error)) {
-              throw new Error("Not implemented yet");
-            }
-            throw error;
-          }
-        },
-      },
-      {
-        key: "password",
-        label: "Password",
-        value: "",
-        displayValue: "••••••••",
-        type: "password" as const,
-        onSave: async (value: string) => {
-          if (!value) {
-            throw new Error("Password is required");
-          }
-          try {
-            await updatePassword(value);
-          } catch (error) {
-            if (isNotImplementedError(error)) {
-              throw new Error("Not implemented yet");
-            }
-            throw error;
-          }
-        },
-      },
+      { key: "name", label: "Name", displayValue: user.name, type: "text" as const },
+      { key: "email", label: "Email", displayValue: maskEmail(user.email), type: "email" as const },
+      { key: "phone", label: "Phone", displayValue: maskPhone(user.phone), type: "tel" as const },
+      { key: "password", label: "Password", displayValue: "••••••••", type: "password" as const },
     ];
   }, [user]);
 
   if (loadingError) {
-    return <div className="settings-page">{loadingError}</div>;
+    return (
+      <SettingsFrame>
+        <SettingsPageHeader title="My Account" />
+        <div className="vrm-card">
+          <div className="vrm-card-body">{loadingError}</div>
+        </div>
+      </SettingsFrame>
+    );
   }
 
   if (!user) {
-    return <div className="settings-page">Loading account…</div>;
+    return (
+      <SettingsFrame>
+        <SettingsPageHeader title="My Account" />
+        <div className="vrm-card">
+          <div className="vrm-card-body">Loading account…</div>
+        </div>
+      </SettingsFrame>
+    );
   }
 
   return (
-    <section className="settings-page">
+    <SettingsFrame>
+      <SettingsPageHeader title="My Account" />
       <div className="vrm-card">
-        <div className="vrm-card-header">
-          <h2 className="vrm-card-title">My Account</h2>
-        </div>
-        <div className="vrm-card-body">
+        <div className="vrm-card-body settings-account-card-body">
           {rows.map((row) => (
             <EditableFieldRow
               key={row.key}
               label={row.label}
               displayValue={row.displayValue}
-              value={row.value}
-              onSave={row.onSave}
+              value={drafts[row.key]}
               type={row.type}
+              isEditing={activeEditingRowId === row.key}
+              isSaving={saving[row.key]}
+              error={errors[row.key]}
+              onEdit={() => startEditing(row.key)}
+              onCancel={() => cancelEditing(row.key)}
+              onSave={() => handleSave(row.key)}
+              onChange={(value) => setDrafts((prev) => ({ ...prev, [row.key]: value }))}
             />
           ))}
         </div>
       </div>
-    </section>
+    </SettingsFrame>
   );
 };
 

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import EditableFieldRow from "../components/EditableFieldRow";
+import {
+  getMe,
+  isNotImplementedError,
+  updateMe,
+  updatePassword,
+} from "../api/settingsApi";
+import type { SettingsUser } from "../types";
+import "../SettingsPages.css";
+
+const maskEmail = (email: string) => {
+  const [localPart, domain] = email.split("@");
+  if (!domain) {
+    return "••••";
+  }
+  const visible = localPart.slice(0, 2);
+  return `${visible}${"•".repeat(Math.max(localPart.length - 2, 2))}@${domain}`;
+};
+
+const maskPhone = (phone: string | null | undefined) => {
+  if (!phone) {
+    return "—";
+  }
+  const visible = phone.slice(-2);
+  return `${"•".repeat(Math.max(phone.length - 2, 4))}${visible}`;
+};
+
+const MyAccountPage: React.FC = () => {
+  const [user, setUser] = useState<SettingsUser | null>(null);
+  const [loadingError, setLoadingError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const me = await getMe();
+        setUser(me);
+      } catch (error) {
+        setLoadingError(error instanceof Error ? error.message : "Unable to load account");
+      }
+    };
+    load();
+  }, []);
+
+  const rows = useMemo(() => {
+    if (!user) {
+      return [];
+    }
+    return [
+      {
+        key: "name",
+        label: "Name",
+        value: user.name,
+        displayValue: user.name,
+        onSave: async (value: string) => {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            throw new Error("Name is required");
+          }
+          try {
+            await updateMe({ name: trimmed });
+            setUser((prev) => (prev ? { ...prev, name: trimmed } : prev));
+          } catch (error) {
+            if (isNotImplementedError(error)) {
+              throw new Error("Not implemented yet");
+            }
+            throw error;
+          }
+        },
+      },
+      {
+        key: "email",
+        label: "Email",
+        value: user.email,
+        displayValue: maskEmail(user.email),
+        type: "email" as const,
+        onSave: async (value: string) => {
+          const trimmed = value.trim();
+          if (!trimmed) {
+            throw new Error("Email is required");
+          }
+          try {
+            await updateMe({ email: trimmed });
+            setUser((prev) => (prev ? { ...prev, email: trimmed } : prev));
+          } catch (error) {
+            if (isNotImplementedError(error)) {
+              throw new Error("Not implemented yet");
+            }
+            throw error;
+          }
+        },
+      },
+      {
+        key: "phone",
+        label: "Phone",
+        value: user.phone ?? "",
+        displayValue: maskPhone(user.phone),
+        type: "tel" as const,
+        onSave: async (value: string) => {
+          try {
+            await updateMe({ phone: value.trim() });
+            setUser((prev) => (prev ? { ...prev, phone: value.trim() } : prev));
+          } catch (error) {
+            if (isNotImplementedError(error)) {
+              throw new Error("Not implemented yet");
+            }
+            throw error;
+          }
+        },
+      },
+      {
+        key: "password",
+        label: "Password",
+        value: "",
+        displayValue: "••••••••",
+        type: "password" as const,
+        onSave: async (value: string) => {
+          if (!value) {
+            throw new Error("Password is required");
+          }
+          try {
+            await updatePassword(value);
+          } catch (error) {
+            if (isNotImplementedError(error)) {
+              throw new Error("Not implemented yet");
+            }
+            throw error;
+          }
+        },
+      },
+    ];
+  }, [user]);
+
+  if (loadingError) {
+    return <div className="settings-page">{loadingError}</div>;
+  }
+
+  if (!user) {
+    return <div className="settings-page">Loading account…</div>;
+  }
+
+  return (
+    <section className="settings-page">
+      <div className="vrm-card">
+        <div className="vrm-card-header">
+          <h2 className="vrm-card-title">My Account</h2>
+        </div>
+        <div className="vrm-card-body">
+          {rows.map((row) => (
+            <EditableFieldRow
+              key={row.key}
+              label={row.label}
+              displayValue={row.displayValue}
+              value={row.value}
+              onSave={row.onSave}
+              type={row.type}
+            />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default MyAccountPage;

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -1,13 +1,20 @@
 import React, { useEffect, useMemo, useState } from "react";
 
-import { getMe, isNotImplementedError, updateMe, updatePassword } from "../api/settingsApi";
+import {
+  getMe,
+  isNotImplementedError,
+  updateMe,
+  updatePassword,
+  verifyCurrentPassword,
+} from "../api/settingsApi";
 import EditableFieldRow from "../components/EditableFieldRow";
+import ReenterPasswordModal from "../components/ReenterPasswordModal";
 import SettingsFrame from "../components/SettingsFrame";
 import SettingsPageHeader from "../components/SettingsPageHeader";
 import type { SettingsUser } from "../types";
 import "../SettingsPages.css";
 
-type EditableRowKey = "name" | "email" | "phone" | "password";
+type EditableRowKey = "username" | "email" | "phone" | "password";
 
 type RowDraftState = Record<EditableRowKey, string>;
 type RowSavingState = Record<EditableRowKey, boolean>;
@@ -18,8 +25,8 @@ const maskEmail = (email: string) => {
   if (!domain) {
     return "••••";
   }
-  const localVisible = Math.min(2, localPart.length);
-  return `${localPart.slice(0, localVisible)}${"•".repeat(Math.max(localPart.length - localVisible, 4))}@${domain}`;
+  const visible = Math.min(2, localPart.length);
+  return `${localPart.slice(0, visible)}${"•".repeat(Math.max(localPart.length - visible, 4))}@${domain}`;
 };
 
 const maskPhone = (phone: string | null | undefined) => {
@@ -31,14 +38,14 @@ const maskPhone = (phone: string | null | undefined) => {
 };
 
 const defaultSavingState: RowSavingState = {
-  name: false,
+  username: false,
   email: false,
   phone: false,
   password: false,
 };
 
 const defaultErrorState: RowErrorState = {
-  name: null,
+  username: null,
   email: null,
   phone: null,
   password: null,
@@ -48,7 +55,14 @@ const MyAccountPage: React.FC = () => {
   const [user, setUser] = useState<SettingsUser | null>(null);
   const [loadingError, setLoadingError] = useState<string | null>(null);
   const [activeEditingRowId, setActiveEditingRowId] = useState<EditableRowKey | null>(null);
-  const [drafts, setDrafts] = useState<RowDraftState>({ name: "", email: "", phone: "", password: "" });
+  const [pendingRowToEdit, setPendingRowToEdit] = useState<EditableRowKey | null>(null);
+  const [isPasswordGateOpen, setIsPasswordGateOpen] = useState(false);
+  const [drafts, setDrafts] = useState<RowDraftState>({
+    username: "",
+    email: "",
+    phone: "",
+    password: "",
+  });
   const [saving, setSaving] = useState<RowSavingState>(defaultSavingState);
   const [errors, setErrors] = useState<RowErrorState>(defaultErrorState);
 
@@ -57,7 +71,12 @@ const MyAccountPage: React.FC = () => {
       try {
         const me = await getMe();
         setUser(me);
-        setDrafts({ name: me.name, email: me.email, phone: me.phone ?? "", password: "" });
+        setDrafts({
+          username: me.name,
+          email: me.email,
+          phone: me.phone ?? "",
+          password: "",
+        });
       } catch (error) {
         setLoadingError(error instanceof Error ? error.message : "Unable to load account");
       }
@@ -66,29 +85,42 @@ const MyAccountPage: React.FC = () => {
     load();
   }, []);
 
-  const startEditing = (rowId: EditableRowKey) => {
+  const requestEdit = (rowId: EditableRowKey) => {
     if (!user) {
       return;
     }
     setErrors((prev) => ({ ...prev, [rowId]: null }));
-    setActiveEditingRowId(rowId);
+    setPendingRowToEdit(rowId);
+    setIsPasswordGateOpen(true);
+  };
+
+  const beginEditingApprovedRow = () => {
+    if (!user || !pendingRowToEdit) {
+      return;
+    }
+
+    const rowId = pendingRowToEdit;
     setDrafts((prev) => ({
       ...prev,
-      name: user.name,
+      username: user.name,
       email: user.email,
       phone: user.phone ?? "",
       password: rowId === "password" ? "" : prev.password,
     }));
+    setActiveEditingRowId(rowId);
+    setPendingRowToEdit(null);
+    setIsPasswordGateOpen(false);
   };
 
   const cancelEditing = (rowId: EditableRowKey) => {
     if (!user) {
       return;
     }
+
     setErrors((prev) => ({ ...prev, [rowId]: null }));
     setDrafts((prev) => ({
       ...prev,
-      name: user.name,
+      username: user.name,
       email: user.email,
       phone: user.phone ?? "",
       password: "",
@@ -102,9 +134,8 @@ const MyAccountPage: React.FC = () => {
     }
 
     const nextValue = drafts[rowId].trim();
-
     if (rowId !== "phone" && !nextValue) {
-      setErrors((prev) => ({ ...prev, [rowId]: `${rowId[0].toUpperCase()}${rowId.slice(1)} is required` }));
+      setErrors((prev) => ({ ...prev, [rowId]: "This field is required" }));
       return;
     }
 
@@ -114,7 +145,7 @@ const MyAccountPage: React.FC = () => {
     try {
       if (rowId === "password") {
         await updatePassword(nextValue);
-      } else if (rowId === "name") {
+      } else if (rowId === "username") {
         await updateMe({ name: nextValue });
       } else if (rowId === "email") {
         await updateMe({ email: nextValue });
@@ -123,16 +154,16 @@ const MyAccountPage: React.FC = () => {
       }
 
       setUser((prev) => {
-        if (!prev) {
+        if (!prev || rowId === "password") {
           return prev;
         }
-        if (rowId === "password") {
-          return prev;
+        if (rowId === "username") {
+          return { ...prev, name: nextValue };
         }
-        return {
-          ...prev,
-          [rowId]: rowId === "phone" ? nextValue : nextValue,
-        };
+        if (rowId === "email") {
+          return { ...prev, email: nextValue };
+        }
+        return { ...prev, phone: nextValue };
       });
       setActiveEditingRowId(null);
       setDrafts((prev) => ({ ...prev, password: "" }));
@@ -161,7 +192,7 @@ const MyAccountPage: React.FC = () => {
     }
 
     return [
-      { key: "name", label: "Name", displayValue: user.name, type: "text" as const },
+      { key: "username", label: "Username", displayValue: user.name, type: "text" as const },
       { key: "email", label: "Email", displayValue: maskEmail(user.email), type: "email" as const },
       { key: "phone", label: "Phone", displayValue: maskPhone(user.phone), type: "tel" as const },
       { key: "password", label: "Password", displayValue: "••••••••", type: "password" as const },
@@ -205,7 +236,7 @@ const MyAccountPage: React.FC = () => {
               isEditing={activeEditingRowId === row.key}
               isSaving={saving[row.key]}
               error={errors[row.key]}
-              onEdit={() => startEditing(row.key)}
+              onEdit={() => requestEdit(row.key)}
               onCancel={() => cancelEditing(row.key)}
               onSave={() => handleSave(row.key)}
               onChange={(value) => setDrafts((prev) => ({ ...prev, [row.key]: value }))}
@@ -213,6 +244,15 @@ const MyAccountPage: React.FC = () => {
           ))}
         </div>
       </div>
+      <ReenterPasswordModal
+        isOpen={isPasswordGateOpen}
+        onClose={() => {
+          setIsPasswordGateOpen(false);
+          setPendingRowToEdit(null);
+        }}
+        onVerified={beginEditingApprovedRow}
+        onVerifyPassword={(password) => verifyCurrentPassword(user.email, password)}
+      />
     </SettingsFrame>
   );
 };

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -1,0 +1,28 @@
+export type SettingsUser = {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string | null;
+};
+
+export type AccessLevel = "Admin" | "Manager" | "Viewer";
+
+export type ManagedUser = {
+  username: string;
+  email: string;
+  site: string;
+  accessLevel: AccessLevel;
+};
+
+export type PendingInvite = {
+  email: string;
+  site: string;
+  accessLevel: AccessLevel;
+  invitedAt?: string;
+};
+
+export type UpdateMePayload = {
+  name?: string;
+  email?: string;
+  phone?: string;
+};

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -5,7 +5,7 @@ export type SettingsUser = {
   phone?: string | null;
 };
 
-export type AccessLevel = "Admin" | "Manager" | "Viewer";
+export type AccessLevel = "Admin" | "Viewer";
 
 export type ManagedUser = {
   username: string;


### PR DESCRIPTION
### Motivation
- Introduce a basic Settings area to manage user account details and access control in the app navigation. 
- Surface settings in the secondary navigation panel and provide initial pages for editing account fields and inviting/managing users. 
- Provide API stubs and UI components so backend wiring can be implemented incrementally. 

### Description
- Added routes for settings and two settings sub-pages by updating `frontend/src/app/routes.tsx` to redirect `/settings` to `/settings/account` and register `/settings/account` and `/settings/access` pages. 
- Implemented `MyAccountPage` and `ManageAccessPage` under `frontend/src/features/settings/pages/` to render account details and user/invite management UIs, using new components `EditableFieldRow`, `UsersTable`, `PendingInvitesTable`, and `SettingsSecondaryNav`. 
- Added `SettingsSecondaryNav` and integrated it into the sidebar in `frontend/src/components/VRMLayout.tsx` so the secondary panel shows settings-specific navigation when on a `/settings` route. 
- Created settings API surface with stubs and helpers in `frontend/src/features/settings/api/settingsApi.ts` and typed data models in `frontend/src/features/settings/types.ts` to support future backend integration. 
- Added CSS for settings pages in `frontend/src/features/settings/SettingsPages.css` and small UI behaviors in the components to support edit/save flows and invite modal. 

### Testing
- No automated unit tests were added for this change. 
- Performed a TypeScript build/type-check (e.g. `yarn build`) locally against the modified frontend files and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a15db2dd08832a903269373fc0febd)