### PR TITLE
Add decorative camera SVG overlay to auth right panes

### DIFF
--- a/backend/ENVIRONMENT.md
+++ b/backend/ENVIRONMENT.md
@@ -1,0 +1,11 @@
+# Backend runtime environment variables
+
+## Signup email verification (Postmark)
+
+These variables are required for the mandatory email-verification signup flow:
+
+- `POSTMARK_SERVER_TOKEN`
+- `POSTMARK_FROM_EMAIL` (set to `noreply@camos.app`)
+- `ADMIN_NOTIFY_EMAIL` (set to `ali@camos.app`)
+
+If any required variable is missing, signup email endpoints return an explicit `503` configuration error.

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -6,8 +6,9 @@ import json
 import logging
 import os
 import re
+import secrets
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 
@@ -19,11 +20,15 @@ from backend.app.auth import (
     set_auth_cookie,
     verify_password,
 )
+from backend.app.config import INTEREST_SUBMISSIONS_FILE
 from backend.app.data.json_store import (
     create_account_user,
     find_user_by_email,
+    hash_password,
+    load_pending_signups,
     load_users,
     normalize_email,
+    save_pending_signups,
     save_users,
 )
 from backend.app.models import (
@@ -35,14 +40,52 @@ from backend.app.models import (
     LoginResponse,
     RegisterInterestRequest,
     RegisterInterestResponse,
+    SignupResendRequest,
+    SignupResendResponse,
+    SignupStartResponse,
+    SignupVerifyRequest,
 )
 from backend.app.services.auth_context import org_id_for_user_record
-from backend.app.config import INTEREST_SUBMISSIONS_FILE
+from backend.app.services.postmark_email import (
+    PostmarkConfigurationError,
+    PostmarkDeliveryError,
+    send_admin_signup_notification,
+    send_verification_email,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 PHONE_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+SIGNUP_CODE_TTL_SECONDS = 15 * 60
+SIGNUP_MAX_VERIFY_ATTEMPTS = 5
+SIGNUP_RESEND_COOLDOWN_SECONDS = 30
+SIGNUP_MAX_RESENDS = 5
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_iso(timestamp: datetime) -> str:
+    return timestamp.astimezone(timezone.utc).isoformat()
+
+
+def _parse_iso(timestamp: str | None) -> datetime | None:
+    if not timestamp:
+        return None
+    try:
+        parsed = datetime.fromisoformat(timestamp)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+    except Exception:
+        return None
+
+
+def _generate_verification_code() -> str:
+    return f"{secrets.randbelow(1_000_000):06d}"
 
 
 def _validate_email(email: str) -> str:
@@ -54,6 +97,25 @@ def _validate_email(email: str) -> str:
     return normalized
 
 
+def _validate_signup_payload(payload: CreateAccountRequest) -> tuple[str, str, str | None]:
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="This field is required")
+
+    email = _validate_email(payload.email)
+
+    phone = payload.phone.strip() if payload.phone else None
+    if phone and not PHONE_RE.match(phone):
+        raise HTTPException(status_code=422, detail="Not a valid phone number")
+
+    if not payload.password:
+        raise HTTPException(status_code=422, detail="This field is required")
+    if len(payload.password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+
+    return name, email, phone
+
+
 def _safe_auth_user(user_data: dict) -> AuthUser:
     return AuthUser(
         id=user_data["id"],
@@ -61,6 +123,32 @@ def _safe_auth_user(user_data: dict) -> AuthUser:
         email=user_data["email"],
         phone=user_data.get("phone"),
     )
+
+
+def _prune_expired_pending_signups(pending_signups: dict, now: datetime) -> bool:
+    to_delete: list[str] = []
+    for email, record in pending_signups.items():
+        expires_at = _parse_iso(record.get("code_expires_at"))
+        if expires_at is None or expires_at <= now:
+            to_delete.append(email)
+    for email in to_delete:
+        del pending_signups[email]
+    return bool(to_delete)
+
+
+def _load_pending_signups_pruned() -> tuple[dict, datetime, bool]:
+    pending_signups = load_pending_signups()
+    now = _utc_now()
+    modified = _prune_expired_pending_signups(pending_signups, now)
+    return pending_signups, now, modified
+
+
+def _raise_mail_delivery_error(exc: Exception) -> None:
+    if isinstance(exc, PostmarkConfigurationError):
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if isinstance(exc, PostmarkDeliveryError):
+        raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
+    raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
 
 
 @router.post("/api/register-interest", response_model=RegisterInterestResponse)
@@ -103,22 +191,179 @@ async def register_interest(submission: RegisterInterestRequest):
         raise HTTPException(status_code=500, detail="Unable to process submission") from exc
 
 
-@router.post("/api/create-account", response_model=AuthUserResponse, status_code=201)
-async def create_account(payload: CreateAccountRequest):
-    name = payload.name.strip()
-    if not name:
-        raise HTTPException(status_code=422, detail="This field is required")
+@router.post("/api/signup/start", response_model=SignupStartResponse, status_code=202)
+async def signup_start(payload: CreateAccountRequest):
+    name, email, phone = _validate_signup_payload(payload)
 
+    users = load_users()
+    existing_username, _ = find_user_by_email(users, email)
+    if existing_username:
+        raise HTTPException(status_code=409, detail="Email already in use")
+
+    pending_signups, now, modified = _load_pending_signups_pruned()
+
+    code = _generate_verification_code()
+    now_iso = _to_iso(now)
+    expires_at_iso = _to_iso(now + timedelta(seconds=SIGNUP_CODE_TTL_SECONDS))
+
+    pending_signups[email] = {
+        "name": name,
+        "email": email,
+        "phone": phone,
+        "password_hash": hash_password(payload.password),
+        "verification_code_hash": hash_password(code),
+        "code_expires_at": expires_at_iso,
+        "verify_attempts": 0,
+        "resend_count": 0,
+        "last_code_sent_at": now_iso,
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+
+    try:
+        send_verification_email(to_email=email, code=code)
+    except Exception as exc:
+        _raise_mail_delivery_error(exc)
+
+    save_pending_signups(pending_signups)
+
+    return SignupStartResponse(
+        ok=True,
+        email=email,
+        expiresInSeconds=SIGNUP_CODE_TTL_SECONDS,
+        resendCooldownSeconds=SIGNUP_RESEND_COOLDOWN_SECONDS,
+    )
+
+
+@router.post("/api/signup/resend", response_model=SignupResendResponse)
+async def signup_resend(payload: SignupResendRequest):
     email = _validate_email(payload.email)
 
-    phone = payload.phone.strip() if payload.phone else None
-    if phone and not PHONE_RE.match(phone):
-        raise HTTPException(status_code=422, detail="Not a valid phone number")
+    pending_signups, now, modified = _load_pending_signups_pruned()
 
-    if not payload.password:
-        raise HTTPException(status_code=422, detail="This field is required")
-    if len(payload.password) < 8:
-        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+    record = pending_signups.get(email)
+    if not record:
+        if modified:
+            save_pending_signups(pending_signups)
+        raise HTTPException(status_code=404, detail="No pending signup found for this email.")
+
+    expires_at = _parse_iso(record.get("code_expires_at"))
+    if not expires_at or expires_at <= now:
+        del pending_signups[email]
+        save_pending_signups(pending_signups)
+        raise HTTPException(status_code=410, detail="Verification code expired. Please restart signup.")
+
+    last_sent_at = _parse_iso(record.get("last_code_sent_at"))
+    if last_sent_at and (now - last_sent_at).total_seconds() < SIGNUP_RESEND_COOLDOWN_SECONDS:
+        if modified:
+            save_pending_signups(pending_signups)
+        raise HTTPException(status_code=429, detail="Please wait before requesting another code.")
+
+    resend_count = int(record.get("resend_count", 0))
+    if resend_count >= SIGNUP_MAX_RESENDS:
+        if modified:
+            save_pending_signups(pending_signups)
+        raise HTTPException(status_code=429, detail="Maximum resend attempts reached.")
+
+    code = _generate_verification_code()
+    now_iso = _to_iso(now)
+    record["verification_code_hash"] = hash_password(code)
+    record["code_expires_at"] = _to_iso(now + timedelta(seconds=SIGNUP_CODE_TTL_SECONDS))
+    record["resend_count"] = resend_count + 1
+    record["last_code_sent_at"] = now_iso
+    record["updated_at"] = now_iso
+
+    try:
+        send_verification_email(to_email=email, code=code)
+    except Exception as exc:
+        _raise_mail_delivery_error(exc)
+
+    save_pending_signups(pending_signups)
+
+    return SignupResendResponse(
+        ok=True,
+        expiresInSeconds=SIGNUP_CODE_TTL_SECONDS,
+        resendCooldownSeconds=SIGNUP_RESEND_COOLDOWN_SECONDS,
+        resendsRemaining=max(SIGNUP_MAX_RESENDS - int(record["resend_count"]), 0),
+    )
+
+
+@router.post("/api/signup/verify", response_model=AuthUserResponse, status_code=201)
+async def signup_verify(payload: SignupVerifyRequest):
+    email = _validate_email(payload.email)
+    code = payload.code.strip()
+    if not code:
+        raise HTTPException(status_code=422, detail="Verification code is required")
+
+    pending_signups, now, modified = _load_pending_signups_pruned()
+
+    record = pending_signups.get(email)
+    if not record:
+        if modified:
+            save_pending_signups(pending_signups)
+        raise HTTPException(status_code=404, detail="No pending signup found for this email.")
+
+    expires_at = _parse_iso(record.get("code_expires_at"))
+    if not expires_at or expires_at <= now:
+        del pending_signups[email]
+        save_pending_signups(pending_signups)
+        raise HTTPException(status_code=410, detail="Verification code expired. Please request a new code.")
+
+    current_attempts = int(record.get("verify_attempts", 0))
+    if current_attempts >= SIGNUP_MAX_VERIFY_ATTEMPTS:
+        del pending_signups[email]
+        save_pending_signups(pending_signups)
+        raise HTTPException(status_code=429, detail="Too many verification attempts. Please restart signup.")
+
+    code_hash = str(record.get("verification_code_hash", ""))
+    if not verify_password(code, code_hash):
+        record["verify_attempts"] = current_attempts + 1
+        record["updated_at"] = _to_iso(now)
+        if int(record["verify_attempts"]) >= SIGNUP_MAX_VERIFY_ATTEMPTS:
+            del pending_signups[email]
+            save_pending_signups(pending_signups)
+            raise HTTPException(status_code=429, detail="Too many verification attempts. Please restart signup.")
+        save_pending_signups(pending_signups)
+        raise HTTPException(status_code=400, detail="Invalid verification code.")
+
+    users = load_users()
+    existing_username, _ = find_user_by_email(users, email)
+    if existing_username:
+        del pending_signups[email]
+        save_pending_signups(pending_signups)
+        raise HTTPException(status_code=409, detail="Email already in use")
+
+    username, user_data = create_account_user(
+        users,
+        str(record.get("name", "")).strip(),
+        email,
+        record.get("phone"),
+        str(record.get("password_hash", "")),
+        password_is_hashed=True,
+    )
+    user_data["updated_at"] = _to_iso(now)
+    users[username] = user_data
+    save_users(users)
+
+    del pending_signups[email]
+    save_pending_signups(pending_signups)
+
+    try:
+        send_admin_signup_notification(
+            verified_email=email,
+            name=user_data.get("name", ""),
+            username=username,
+            timestamp=_to_iso(now),
+        )
+    except Exception:
+        logger.exception("Failed to send admin signup notification", extra={"email": email})
+
+    return AuthUserResponse(user=_safe_auth_user(user_data))
+
+
+@router.post("/api/create-account", response_model=AuthUserResponse, status_code=201)
+async def create_account(payload: CreateAccountRequest):
+    name, email, phone = _validate_signup_payload(payload)
 
     users = load_users()
     existing_username, _ = find_user_by_email(users, email)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -143,11 +143,33 @@ def _load_pending_signups_pruned() -> tuple[dict, datetime, bool]:
     return pending_signups, now, modified
 
 
-def _raise_mail_delivery_error(exc: Exception) -> None:
+def _raise_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
     if isinstance(exc, PostmarkConfigurationError):
+        logger.error(
+            "signup.email.config_error request_id=%s has_server_token=%s has_from_email=%s has_admin_notify_email=%s detail=%s",
+            request_id,
+            bool(os.getenv("POSTMARK_SERVER_TOKEN", "").strip()),
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            bool(os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()),
+            str(exc),
+        )
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     if isinstance(exc, PostmarkDeliveryError):
+        logger.error(
+            "signup.email.delivery_error request_id=%s status_code=%s error_code=%s message=%s from_email=%s to_email=%s has_server_token=%s has_from_email=%s has_admin_notify_email=%s response_body=%s",
+            request_id,
+            exc.status_code,
+            exc.error_code,
+            exc.error_message,
+            exc.from_email,
+            exc.to_email_masked,
+            bool(os.getenv("POSTMARK_SERVER_TOKEN", "").strip()),
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            bool(os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()),
+            exc.response_body,
+        )
         raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
+    logger.exception("signup.email.unknown_error request_id=%s", request_id)
     raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
 
 
@@ -193,6 +215,7 @@ async def register_interest(submission: RegisterInterestRequest):
 
 @router.post("/api/signup/start", response_model=SignupStartResponse, status_code=202)
 async def signup_start(payload: CreateAccountRequest):
+    request_id = str(uuid.uuid4())
     name, email, phone = _validate_signup_payload(payload)
 
     users = load_users()
@@ -223,7 +246,7 @@ async def signup_start(payload: CreateAccountRequest):
     try:
         send_verification_email(to_email=email, code=code)
     except Exception as exc:
-        _raise_mail_delivery_error(exc)
+        _raise_mail_delivery_error(exc, request_id=request_id)
 
     save_pending_signups(pending_signups)
 
@@ -237,6 +260,7 @@ async def signup_start(payload: CreateAccountRequest):
 
 @router.post("/api/signup/resend", response_model=SignupResendResponse)
 async def signup_resend(payload: SignupResendRequest):
+    request_id = str(uuid.uuid4())
     email = _validate_email(payload.email)
 
     pending_signups, now, modified = _load_pending_signups_pruned()
@@ -276,7 +300,7 @@ async def signup_resend(payload: SignupResendRequest):
     try:
         send_verification_email(to_email=email, code=code)
     except Exception as exc:
-        _raise_mail_delivery_error(exc)
+        _raise_mail_delivery_error(exc, request_id=request_id)
 
     save_pending_signups(pending_signups)
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -11,6 +11,7 @@ DEVICE_LISTS_FILE = 'backend/data/device_lists.json'
 INTEREST_SUBMISSIONS_FILE = 'backend/data/interest_submissions.json'
 DOCUMENTS_FILE = 'backend/data/documents.json'
 DOCUMENT_BLOBS_DIR = 'backend/data/document_blobs'
+PENDING_SIGNUPS_FILE = 'backend/data/pending_signups.json'
 
 
 

--- a/backend/app/data/json_store.py
+++ b/backend/app/data/json_store.py
@@ -13,7 +13,7 @@ import secrets
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from backend.app.config import USERS_FILE, ALARM_LOGS_FILE, DEVICE_LISTS_FILE
+from backend.app.config import USERS_FILE, ALARM_LOGS_FILE, DEVICE_LISTS_FILE, PENDING_SIGNUPS_FILE
 
 
 def hash_password(password: str) -> str:
@@ -42,12 +42,20 @@ def find_user_by_email(users: dict, email: str):
     return None, None
 
 
-def create_account_user(users: dict, name: str, email: str, phone: str | None, password: str):
+def create_account_user(
+    users: dict,
+    name: str,
+    email: str,
+    phone: str | None,
+    password: str,
+    *,
+    password_is_hashed: bool = False,
+):
     now = datetime.now(timezone.utc).isoformat()
     user_id = str(uuid4())
     username = f"u_{user_id.replace('-', '')[:12]}"
     normalized_email = normalize_email(email)
-    password_hash = hash_password(password)
+    password_hash = password if password_is_hashed else hash_password(password)
     users[username] = {
         "id": user_id,
         "name": name,
@@ -150,6 +158,30 @@ def save_users(users_data: dict):
         with os.fdopen(temp_fd, 'w') as f:
             json.dump(users_data, f, indent=2)
         shutil.move(temp_path, USERS_FILE)
+    except Exception as e:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise e
+
+
+def load_pending_signups() -> dict:
+    """Load pending signup records from JSON file."""
+    if not os.path.exists(PENDING_SIGNUPS_FILE):
+        return {}
+    with open(PENDING_SIGNUPS_FILE, 'r') as f:
+        return json.load(f)
+
+
+def save_pending_signups(pending_data: dict):
+    """Save pending signup data to JSON file using atomic write."""
+    file_dir = os.path.dirname(PENDING_SIGNUPS_FILE) or '.'
+    os.makedirs(file_dir, exist_ok=True)
+
+    temp_fd, temp_path = tempfile.mkstemp(dir=file_dir, suffix='.tmp')
+    try:
+        with os.fdopen(temp_fd, 'w') as f:
+            json.dump(pending_data, f, indent=2)
+        shutil.move(temp_path, PENDING_SIGNUPS_FILE)
     except Exception as e:
         if os.path.exists(temp_path):
             os.unlink(temp_path)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -69,6 +69,29 @@ class ViewTokenResponse(BaseModel):
     client_id: str
 
 
+class SignupStartResponse(BaseModel):
+    ok: bool
+    email: str
+    expiresInSeconds: int
+    resendCooldownSeconds: int
+
+
+class SignupVerifyRequest(BaseModel):
+    email: str
+    code: str
+
+
+class SignupResendRequest(BaseModel):
+    email: str
+
+
+class SignupResendResponse(BaseModel):
+    ok: bool
+    expiresInSeconds: int
+    resendCooldownSeconds: int
+    resendsRemaining: int
+
+
 class RegisterInterestRequest(BaseModel):
     name: str
     email: str

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -1,0 +1,109 @@
+"""Postmark email integration for signup verification flows."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from urllib import error, request
+
+POSTMARK_EMAIL_ENDPOINT = "https://api.postmarkapp.com/email"
+
+
+class PostmarkConfigurationError(RuntimeError):
+    """Raised when required Postmark env vars are missing."""
+
+
+class PostmarkDeliveryError(RuntimeError):
+    """Raised when Postmark rejects or fails to deliver an email."""
+
+
+@dataclass(frozen=True)
+class PostmarkConfig:
+    server_token: str
+    from_email: str
+    admin_notify_email: str
+
+
+
+def _load_config() -> PostmarkConfig:
+    server_token = os.getenv("POSTMARK_SERVER_TOKEN", "").strip()
+    from_email = os.getenv("POSTMARK_FROM_EMAIL", "").strip()
+    admin_notify_email = os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()
+    missing = [
+        name
+        for name, value in (
+            ("POSTMARK_SERVER_TOKEN", server_token),
+            ("POSTMARK_FROM_EMAIL", from_email),
+            ("ADMIN_NOTIFY_EMAIL", admin_notify_email),
+        )
+        if not value
+    ]
+    if missing:
+        joined = ", ".join(missing)
+        raise PostmarkConfigurationError(
+            f"Email service is not configured. Missing {joined}."
+        )
+    return PostmarkConfig(
+        server_token=server_token,
+        from_email=from_email,
+        admin_notify_email=admin_notify_email,
+    )
+
+
+def _postmark_send(*, token: str, payload: dict) -> None:
+    req = request.Request(
+        POSTMARK_EMAIL_ENDPOINT,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "X-Postmark-Server-Token": token,
+        },
+        method="POST",
+    )
+    try:
+        with request.urlopen(req, timeout=10) as response:
+            if response.status >= 300:
+                body = response.read().decode("utf-8", errors="replace")
+                raise PostmarkDeliveryError(
+                    f"Postmark send failed with status {response.status}: {body}"
+                )
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise PostmarkDeliveryError(
+            f"Postmark send failed with status {exc.code}: {body}"
+        ) from exc
+    except error.URLError as exc:
+        raise PostmarkDeliveryError(f"Postmark send failed: {exc}") from exc
+
+
+def send_verification_email(*, to_email: str, code: str) -> None:
+    config = _load_config()
+    payload = {
+        "From": config.from_email,
+        "To": to_email,
+        "Subject": "Your camOS verification code",
+        "TextBody": (
+            f"Your camOS verification code is {code}.\n\n"
+            "It expires in 15 minutes."
+        ),
+    }
+    _postmark_send(token=config.server_token, payload=payload)
+
+
+def send_admin_signup_notification(*, verified_email: str, name: str, username: str, timestamp: str) -> None:
+    config = _load_config()
+    payload = {
+        "From": config.from_email,
+        "To": config.admin_notify_email,
+        "Subject": f"New verified signup: {verified_email}",
+        "TextBody": (
+            "A new user has verified their email and completed signup.\n\n"
+            f"Email: {verified_email}\n"
+            f"Name: {name}\n"
+            f"Username: {username}\n"
+            f"Timestamp (UTC): {timestamp}\n"
+        ),
+    }
+    _postmark_send(token=config.server_token, payload=payload)

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from dataclasses import dataclass
 from urllib import error, request
 
 POSTMARK_EMAIL_ENDPOINT = "https://api.postmarkapp.com/email"
+
+logger = logging.getLogger(__name__)
 
 
 class PostmarkConfigurationError(RuntimeError):
@@ -17,6 +20,26 @@ class PostmarkConfigurationError(RuntimeError):
 class PostmarkDeliveryError(RuntimeError):
     """Raised when Postmark rejects or fails to deliver an email."""
 
+    def __init__(
+        self,
+        *,
+        status_code: int | None,
+        response_body: str,
+        error_code: int | None,
+        error_message: str | None,
+        from_email: str,
+        to_email_masked: str,
+    ):
+        self.status_code = status_code
+        self.response_body = response_body
+        self.error_code = error_code
+        self.error_message = error_message
+        self.from_email = from_email
+        self.to_email_masked = to_email_masked
+        super().__init__(
+            f"Postmark send failed status={status_code} error_code={error_code} message={error_message}"
+        )
+
 
 @dataclass(frozen=True)
 class PostmarkConfig:
@@ -24,6 +47,26 @@ class PostmarkConfig:
     from_email: str
     admin_notify_email: str
 
+
+def _mask_email(email: str) -> str:
+    if "@" not in email:
+        return "***"
+    local, domain = email.split("@", 1)
+    if len(local) <= 2:
+        masked_local = f"{local[:1]}***"
+    else:
+        masked_local = f"{local[:2]}***"
+    return f"{masked_local}@{domain}"
+
+
+def _parse_postmark_error(body: str) -> tuple[int | None, str | None]:
+    try:
+        data = json.loads(body)
+        error_code = data.get("ErrorCode")
+        message = data.get("Message")
+        return (int(error_code) if isinstance(error_code, int) else None, message if isinstance(message, str) else None)
+    except Exception:
+        return None, None
 
 
 def _load_config() -> PostmarkConfig:
@@ -51,7 +94,7 @@ def _load_config() -> PostmarkConfig:
     )
 
 
-def _postmark_send(*, token: str, payload: dict) -> None:
+def _postmark_send(*, token: str, payload: dict, from_email: str, to_email: str) -> None:
     req = request.Request(
         POSTMARK_EMAIL_ENDPOINT,
         data=json.dumps(payload).encode("utf-8"),
@@ -62,20 +105,64 @@ def _postmark_send(*, token: str, payload: dict) -> None:
         },
         method="POST",
     )
+    to_email_masked = _mask_email(to_email)
     try:
         with request.urlopen(req, timeout=10) as response:
             if response.status >= 300:
                 body = response.read().decode("utf-8", errors="replace")
+                error_code, error_message = _parse_postmark_error(body)
+                logger.error(
+                    "postmark.send.failed status=%s error_code=%s message=%s from_email=%s to_email=%s response_body=%s",
+                    response.status,
+                    error_code,
+                    error_message,
+                    from_email,
+                    to_email_masked,
+                    body,
+                )
                 raise PostmarkDeliveryError(
-                    f"Postmark send failed with status {response.status}: {body}"
+                    status_code=response.status,
+                    response_body=body,
+                    error_code=error_code,
+                    error_message=error_message,
+                    from_email=from_email,
+                    to_email_masked=to_email_masked,
                 )
     except error.HTTPError as exc:
         body = exc.read().decode("utf-8", errors="replace")
+        error_code, error_message = _parse_postmark_error(body)
+        logger.error(
+            "postmark.send.http_error status=%s error_code=%s message=%s from_email=%s to_email=%s response_body=%s",
+            exc.code,
+            error_code,
+            error_message,
+            from_email,
+            to_email_masked,
+            body,
+        )
         raise PostmarkDeliveryError(
-            f"Postmark send failed with status {exc.code}: {body}"
+            status_code=exc.code,
+            response_body=body,
+            error_code=error_code,
+            error_message=error_message,
+            from_email=from_email,
+            to_email_masked=to_email_masked,
         ) from exc
     except error.URLError as exc:
-        raise PostmarkDeliveryError(f"Postmark send failed: {exc}") from exc
+        logger.error(
+            "postmark.send.url_error from_email=%s to_email=%s reason=%s",
+            from_email,
+            to_email_masked,
+            exc,
+        )
+        raise PostmarkDeliveryError(
+            status_code=None,
+            response_body=str(exc),
+            error_code=None,
+            error_message=str(exc),
+            from_email=from_email,
+            to_email_masked=to_email_masked,
+        ) from exc
 
 
 def send_verification_email(*, to_email: str, code: str) -> None:
@@ -89,7 +176,12 @@ def send_verification_email(*, to_email: str, code: str) -> None:
             "It expires in 15 minutes."
         ),
     }
-    _postmark_send(token=config.server_token, payload=payload)
+    _postmark_send(
+        token=config.server_token,
+        payload=payload,
+        from_email=config.from_email,
+        to_email=to_email,
+    )
 
 
 def send_admin_signup_notification(*, verified_email: str, name: str, username: str, timestamp: str) -> None:
@@ -106,4 +198,9 @@ def send_admin_signup_notification(*, verified_email: str, name: str, username: 
             f"Timestamp (UTC): {timestamp}\n"
         ),
     }
-    _postmark_send(token=config.server_token, payload=payload)
+    _postmark_send(
+        token=config.server_token,
+        payload=payload,
+        from_email=config.from_email,
+        to_email=config.admin_notify_email,
+    )

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -29,6 +29,7 @@ const ManageAccessPage = React.lazy(() => import("../features/settings/pages/Man
 const LandingPage = React.lazy(() => import("../pages/LandingPage"));
 const LoginPage = React.lazy(() => import("../pages/LoginPage"));
 const CreateAccountPage = React.lazy(() => import("../pages/CreateAccountPage"));
+const VerifyEmailPage = React.lazy(() => import("../pages/VerifyEmailPage"));
 const DemoPage = React.lazy(() => import("../pages/DemoPage"));
 
 const AppRoutes: React.FC = () => {
@@ -212,6 +213,16 @@ const AppRoutes: React.FC = () => {
         element={
           appMode === "public" ? (
             lazyRoute(<LoginPage onLogin={handleLogin} />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/verify-email"
+        element={
+          appMode === "public" ? (
+            lazyRoute(<VerifyEmailPage />)
           ) : (
             <Navigate to="/home" replace />
           )

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -161,10 +161,24 @@
 }
 
 .create-account-right-pane {
+  position: relative;
+  overflow: hidden;
   border-left: 1px solid rgba(255, 255, 255, 0.12);
   background:
     radial-gradient(circle at 22% 20%, rgba(105, 145, 215, 0.12), transparent 48%),
     linear-gradient(145deg, #151a22 0%, #101722 60%, #0e1520 100%);
+}
+
+.auth-right-pane-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  opacity: 0.28;
+  pointer-events: none;
+  user-select: none;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState } from 'react';
 import { ArrowLeft, Eye, EyeOff } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import AuthTopBar from '../../components/auth/AuthTopBar';
+import camsvg from '../../assets/camsvg.svg';
 import { useCreateAccountForm } from './hooks/useCreateAccountForm';
 import './CreateAccountPage.css';
 
@@ -225,7 +226,15 @@ const CreateAccountPage: React.FC = () => {
           </div>
         </section>
 
-        <aside className="create-account-right-pane" aria-label="System visual placeholder" />
+        <aside className="create-account-right-pane" aria-label="System visual placeholder">
+          <img
+            src={camsvg}
+            alt=""
+            aria-hidden="true"
+            focusable="false"
+            className="auth-right-pane-overlay"
+          />
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -20,8 +20,8 @@ const stopNavigation: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
 
 const CreateAccountPage: React.FC = () => {
   const navigate = useNavigate();
-  const form = useCreateAccountForm(() => {
-    navigate('/login');
+  const form = useCreateAccountForm((email) => {
+    navigate(`/verify-email?email=${encodeURIComponent(email)}`);
   });
 
   const [showPassword, setShowPassword] = useState(false);

--- a/frontend/src/features/auth/LoginPage.css
+++ b/frontend/src/features/auth/LoginPage.css
@@ -119,10 +119,24 @@
 }
 
 .login-right-pane {
+  position: relative;
+  overflow: hidden;
   border-left: 1px solid rgba(255, 255, 255, 0.12);
   background:
     radial-gradient(circle at 22% 20%, rgba(105, 145, 215, 0.12), transparent 48%),
     linear-gradient(145deg, #151a22 0%, #101722 60%, #0e1520 100%);
+}
+
+.auth-right-pane-overlay {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  opacity: 0.28;
+  pointer-events: none;
+  user-select: none;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import AuthTopBar from "../../components/auth/AuthTopBar";
+import camsvg from "../../assets/camsvg.svg";
 import { useLoginForm } from "./hooks/useLoginForm";
 import "./LoginPage.css";
 
@@ -139,7 +140,15 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
           </div>
         </section>
 
-        <aside className="login-right-pane" aria-label="System visual placeholder" />
+        <aside className="login-right-pane" aria-label="System visual placeholder">
+          <img
+            src={camsvg}
+            alt=""
+            aria-hidden="true"
+            focusable="false"
+            className="auth-right-pane-overlay"
+          />
+        </aside>
       </div>
     </div>
   );

--- a/frontend/src/features/auth/VerifyEmailPage.css
+++ b/frontend/src/features/auth/VerifyEmailPage.css
@@ -1,0 +1,125 @@
+.verify-email-page {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: #0f131a;
+  color: #fff;
+}
+
+.verify-email-shell {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.verify-email-left-pane {
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  padding: 34px 32px 40px;
+}
+
+.verify-email-content {
+  width: 100%;
+  max-width: 520px;
+  display: grid;
+  gap: 10px;
+}
+
+.verify-email-title {
+  color: #c9d2e1;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.verify-email-hero {
+  font-size: 38px;
+  line-height: 1.14;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+}
+
+.verify-email-copy {
+  color: #aab6c9;
+  margin-bottom: 4px;
+}
+
+.verify-email-form {
+  display: grid;
+  gap: 10px;
+}
+
+.verify-email-error {
+  color: #f4b63d;
+  font-size: 13px;
+}
+
+.verify-email-message {
+  color: #8ad9a2;
+  font-size: 13px;
+}
+
+.verify-email-submit {
+  width: 100%;
+  min-height: 42px;
+}
+
+.verify-email-resend-row,
+.verify-email-back-row {
+  margin-top: 4px;
+}
+
+.verify-email-resend {
+  border: 0;
+  background: transparent;
+  color: #89b4ff;
+  padding: 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.verify-email-resend:disabled {
+  color: #7f8ba1;
+  text-decoration: none;
+  cursor: not-allowed;
+}
+
+.verify-email-link {
+  color: #89b4ff;
+}
+
+.verify-email-right-pane {
+  border-left: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    radial-gradient(circle at 22% 20%, rgba(105, 145, 215, 0.12), transparent 48%),
+    linear-gradient(145deg, #151a22 0%, #101722 60%, #0e1520 100%);
+}
+
+@media (max-width: 900px) {
+  .verify-email-page {
+    grid-template-rows: auto auto;
+  }
+
+  .verify-email-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .verify-email-left-pane {
+    padding: 24px 20px 28px;
+  }
+
+  .verify-email-content {
+    max-width: 560px;
+  }
+
+  .verify-email-hero {
+    font-size: 32px;
+  }
+
+  .verify-email-right-pane {
+    min-height: 140px;
+    border-left: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+  }
+}

--- a/frontend/src/features/auth/VerifyEmailPage.tsx
+++ b/frontend/src/features/auth/VerifyEmailPage.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import AuthTopBar from "../../components/auth/AuthTopBar";
+import { signupResend } from "./transport/signupResend";
+import { signupVerify } from "./transport/signupVerify";
+import "./VerifyEmailPage.css";
+
+const VerifyEmailPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const email = useMemo(() => searchParams.get("email")?.trim().toLowerCase() ?? "", [searchParams]);
+
+  const [code, setCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [resending, setResending] = useState(false);
+  const [cooldownRemaining, setCooldownRemaining] = useState(0);
+
+  useEffect(() => {
+    if (cooldownRemaining <= 0) return;
+    const timer = window.setInterval(() => {
+      setCooldownRemaining((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [cooldownRemaining]);
+
+  const mapVerifyError = (status: number, detail?: string) => {
+    if (status === 400) return "The verification code is incorrect.";
+    if (status === 404) return "No pending signup found. Please create your account again.";
+    if (status === 410) return "Your verification code has expired. Please resend a new code.";
+    if (status === 422) return detail || "Please enter the 6-digit code.";
+    if (status === 429) return detail || "Too many attempts. Please restart signup.";
+    if (status === 503) return detail || "Email service is not configured.";
+    if (status === 502) return detail || "Email delivery failed. Please try again.";
+    return detail || "Unable to verify code. Please try again.";
+  };
+
+  const mapResendError = (status: number, detail?: string) => {
+    if (status === 404) return "No pending signup found. Please create your account again.";
+    if (status === 410) return "Your code expired. Please restart signup.";
+    if (status === 429) return detail || "Please wait before requesting another code.";
+    if (status === 503) return detail || "Email service is not configured.";
+    if (status === 502) return detail || "Failed to send verification email.";
+    return detail || "Unable to resend code.";
+  };
+
+  const handleVerify = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    setMessage(null);
+
+    if (!email) {
+      setError("Missing email. Return to create account and try again.");
+      return;
+    }
+
+    if (!/^\d{6}$/.test(code.trim())) {
+      setError("Enter your 6-digit verification code.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await signupVerify(email, code);
+      if (result.ok) {
+        navigate("/login");
+        return;
+      }
+      setError(mapVerifyError(result.status, result.message));
+    } catch {
+      setError("Unable to verify code. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleResend = async () => {
+    if (!email || cooldownRemaining > 0 || resending) {
+      return;
+    }
+
+    setResending(true);
+    setError(null);
+    setMessage(null);
+    try {
+      const result = await signupResend(email);
+      if (result.ok) {
+        setCooldownRemaining(result.data.resendCooldownSeconds);
+        setMessage("A new verification code was sent.");
+      } else {
+        setError(mapResendError(result.status, result.message));
+      }
+    } catch {
+      setError("Unable to resend verification code.");
+    } finally {
+      setResending(false);
+    }
+  };
+
+  return (
+    <div className="verify-email-page">
+      <AuthTopBar />
+
+      <div className="verify-email-shell">
+        <section className="verify-email-left-pane" aria-label="Email verification panel">
+          <div className="verify-email-content">
+            <p className="verify-email-title">Verify Email</p>
+            <h1 className="verify-email-hero">Enter the 6-digit code</h1>
+            <p className="verify-email-copy">
+              We sent a verification code to <strong>{email || "your email"}</strong>.
+            </p>
+
+            <form className="verify-email-form" onSubmit={handleVerify}>
+              <div className="vrm-field verify-email-field">
+                <label className="vrm-label" htmlFor="verify-code">Verification code</label>
+                <input
+                  id="verify-code"
+                  className="vrm-input"
+                  inputMode="numeric"
+                  autoComplete="one-time-code"
+                  value={code}
+                  onChange={(event) => {
+                    setCode(event.target.value.replace(/\D/g, "").slice(0, 6));
+                    if (error) {
+                      setError(null);
+                    }
+                  }}
+                  placeholder="123456"
+                  aria-invalid={Boolean(error)}
+                />
+              </div>
+
+              {error && (
+                <div className="verify-email-error" role="alert" aria-live="assertive">
+                  {error}
+                </div>
+              )}
+
+              {message && (
+                <div className="verify-email-message" role="status" aria-live="polite">
+                  {message}
+                </div>
+              )}
+
+              <div className="verify-email-actions">
+                <button type="submit" className="vrm-btn vrm-btn-primary verify-email-submit" disabled={loading}>
+                  {loading ? "Verifying…" : "Verify email"}
+                </button>
+              </div>
+            </form>
+
+            <div className="verify-email-resend-row">
+              <button
+                type="button"
+                className="verify-email-resend"
+                onClick={handleResend}
+                disabled={resending || cooldownRemaining > 0 || !email}
+              >
+                {cooldownRemaining > 0
+                  ? `Resend code in ${cooldownRemaining}s`
+                  : resending
+                    ? "Sending…"
+                    : "Resend code"}
+              </button>
+            </div>
+
+            <p className="verify-email-back-row">
+              Wrong email? <Link to="/create-account" className="verify-email-link">Create account again</Link>
+            </p>
+          </div>
+        </section>
+
+        <aside className="verify-email-right-pane" aria-hidden="true" />
+      </div>
+    </div>
+  );
+};
+
+export default VerifyEmailPage;

--- a/frontend/src/features/auth/hooks/useCreateAccountForm.ts
+++ b/frontend/src/features/auth/hooks/useCreateAccountForm.ts
@@ -1,12 +1,12 @@
 import { type FormEvent, useMemo, useState } from 'react';
-import { createAccount } from '../transport/createAccount';
+import { signupStart } from '../transport/signupStart';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^\+[1-9]\d{6,14}$/;
 
 type FieldName = 'username' | 'email' | 'phone' | 'password' | 'confirmPassword';
 
-export const useCreateAccountForm = (onSuccess: () => void) => {
+export const useCreateAccountForm = (onSuccess: (email: string) => void) => {
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [countryCode, setCountryCode] = useState('+44');
@@ -83,18 +83,22 @@ export const useCreateAccountForm = (onSuccess: () => void) => {
 
     setSubmitting(true);
     try {
-      const result = await createAccount({
+      const result = await signupStart({
         name: username.trim(),
         email: email.trim().toLowerCase(),
         phone: phone || undefined,
         password,
       });
       if (result.ok) {
-        onSuccess();
+        onSuccess(result.data.email);
       } else if (result.status === 409) {
         setFormError('Email already in use.');
+      } else if (result.status === 503) {
+        setFormError(result.message || 'Email service is not configured.');
+      } else if (result.status === 502) {
+        setFormError(result.message || 'Failed to send verification email. Please try again.');
       } else {
-        setFormError('Unable to complete request. Please try again.');
+        setFormError(result.message || 'Unable to complete request. Please try again.');
       }
     } catch {
       setFormError('Unable to complete request. Please try again.');

--- a/frontend/src/features/auth/transport/signupResend.ts
+++ b/frontend/src/features/auth/transport/signupResend.ts
@@ -1,0 +1,35 @@
+export type SignupResendData = {
+  ok: boolean;
+  expiresInSeconds: number;
+  resendCooldownSeconds: number;
+  resendsRemaining: number;
+};
+
+export type SignupResendResult =
+  | { ok: true; data: SignupResendData }
+  | { ok: false; status: number; message?: string };
+
+export const signupResend = async (email: string): Promise<SignupResendResult> => {
+  const response = await fetch("/api/signup/resend", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify({ email: email.trim().toLowerCase() }),
+  });
+
+  if (!response.ok) {
+    let message: string | undefined;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      message = data.detail;
+    } catch {
+      message = undefined;
+    }
+    return { ok: false, status: response.status, message };
+  }
+
+  const data = (await response.json()) as SignupResendData;
+  return { ok: true, data };
+};

--- a/frontend/src/features/auth/transport/signupStart.ts
+++ b/frontend/src/features/auth/transport/signupStart.ts
@@ -1,0 +1,46 @@
+export type SignupStartPayload = {
+  name: string;
+  email: string;
+  phone?: string;
+  password: string;
+};
+
+export type SignupStartData = {
+  ok: boolean;
+  email: string;
+  expiresInSeconds: number;
+  resendCooldownSeconds: number;
+};
+
+export type SignupStartResult =
+  | { ok: true; data: SignupStartData }
+  | { ok: false; status: number; message?: string };
+
+export const signupStart = async (
+  payload: SignupStartPayload,
+): Promise<SignupStartResult> => {
+  const response = await fetch("/api/signup/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({
+      ...payload,
+      email: payload.email.trim().toLowerCase(),
+      phone: payload.phone?.trim() || undefined,
+    }),
+  });
+
+  if (!response.ok) {
+    let message: string | undefined;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      message = data.detail;
+    } catch {
+      message = undefined;
+    }
+    return { ok: false, status: response.status, message };
+  }
+
+  const data = (await response.json()) as SignupStartData;
+  return { ok: true, data };
+};

--- a/frontend/src/features/auth/transport/signupVerify.ts
+++ b/frontend/src/features/auth/transport/signupVerify.ts
@@ -1,0 +1,42 @@
+type AuthUser = {
+  id: string;
+  name: string;
+  email: string;
+  phone?: string | null;
+};
+
+export type SignupVerifyData = {
+  user: AuthUser;
+};
+
+export type SignupVerifyResult =
+  | { ok: true; data: SignupVerifyData }
+  | { ok: false; status: number; message?: string };
+
+export const signupVerify = async (
+  email: string,
+  code: string,
+): Promise<SignupVerifyResult> => {
+  const response = await fetch("/api/signup/verify", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify({ email: email.trim().toLowerCase(), code: code.trim() }),
+  });
+
+  if (!response.ok) {
+    let message: string | undefined;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      message = data.detail;
+    } catch {
+      message = undefined;
+    }
+    return { ok: false, status: response.status, message };
+  }
+
+  const data = (await response.json()) as SignupVerifyData;
+  return { ok: true, data };
+};

--- a/frontend/src/pages/VerifyEmailPage.tsx
+++ b/frontend/src/pages/VerifyEmailPage.tsx
@@ -1,0 +1,1 @@
+export { default } from "../features/auth/VerifyEmailPage";


### PR DESCRIPTION
### Motivation

- Provide a subtle decorative visual in the auth pages' right-hand panes to improve the login and create-account layouts.
- Ensure the decoration is non-interactive and accessible by marking it decorative so it doesn't affect keyboard focus or screen readers.

### Description

- Import `camsvg` and insert an `<img>` overlay into the `login-right-pane` and `create-account-right-pane` in `LoginPage.tsx` and `CreateAccountPage.tsx` respectively, with `alt=""`, `aria-hidden="true"`, and `focusable="false"` to keep it decorative.
- Add positioning and clipping styles to `LoginPage.css` and `CreateAccountPage.css` by setting the right panes to `position: relative` and `overflow: hidden` and by adding the shared `.auth-right-pane-overlay` rules for sizing, opacity, and pointer-event suppression.
- Replace empty aside placeholders with the overlay image so the visual appears consistently across both auth pages.

### Testing

- No automated tests were added or run as part of this change; existing automated test suites were not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a56f876f0c8332bfe8f7c7688d0f6b)