### PR TITLE
Add contact form with attachments and admin notification (frontend + backend)

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -10,7 +11,7 @@ import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
 
 from backend.app.auth import (
     clear_auth_cookie,
@@ -38,6 +39,7 @@ from backend.app.models import (
     EmailLoginRequest,
     LoginRequest,
     LoginResponse,
+    ContactResponse,
     RegisterInterestRequest,
     RegisterInterestResponse,
     SignupResendRequest,
@@ -49,6 +51,8 @@ from backend.app.services.auth_context import org_id_for_user_record
 from backend.app.services.postmark_email import (
     PostmarkConfigurationError,
     PostmarkDeliveryError,
+    PostmarkAttachment,
+    send_admin_contact_notification,
     send_admin_signup_notification,
     send_verification_email,
 )
@@ -62,6 +66,19 @@ SIGNUP_CODE_TTL_SECONDS = 15 * 60
 SIGNUP_MAX_VERIFY_ATTEMPTS = 5
 SIGNUP_RESEND_COOLDOWN_SECONDS = 30
 SIGNUP_MAX_RESENDS = 5
+
+CONTACT_MAX_FILES = 3
+CONTACT_MAX_FILE_BYTES = 10 * 1024 * 1024
+CONTACT_ALLOWED_EXTENSIONS = {".pdf", ".docx", ".xlsx", ".csv", ".png", ".jpg", ".jpeg"}
+CONTACT_ALLOWED_CONTENT_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "text/csv",
+    "application/csv",
+    "image/png",
+    "image/jpeg",
+}
 
 
 def _utc_now() -> datetime:
@@ -171,6 +188,114 @@ def _raise_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
         raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
     logger.exception("signup.email.unknown_error request_id=%s", request_id)
     raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
+
+
+def _raise_contact_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
+    if isinstance(exc, PostmarkConfigurationError):
+        logger.error(
+            "contact.email.config_error request_id=%s has_server_token=%s has_from_email=%s has_admin_notify_email=%s detail=%s",
+            request_id,
+            bool(os.getenv("POSTMARK_SERVER_TOKEN", "").strip()),
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            bool(os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()),
+            str(exc),
+        )
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if isinstance(exc, PostmarkDeliveryError):
+        logger.error(
+            "contact.email.delivery_error request_id=%s status_code=%s error_code=%s message=%s from_email=%s to_email=%s has_server_token=%s has_from_email=%s has_admin_notify_email=%s response_body=%s",
+            request_id,
+            exc.status_code,
+            exc.error_code,
+            exc.error_message,
+            exc.from_email,
+            exc.to_email_masked,
+            bool(os.getenv("POSTMARK_SERVER_TOKEN", "").strip()),
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            bool(os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()),
+            exc.response_body,
+        )
+        raise HTTPException(status_code=502, detail="Failed to send contact message.") from exc
+    logger.exception("contact.email.unknown_error request_id=%s", request_id)
+    raise HTTPException(status_code=502, detail="Failed to send contact message.") from exc
+
+
+def _validate_contact_fields(name: str, email: str, phone: str | None, message: str) -> tuple[str, str, str | None, str]:
+    safe_name = name.strip()
+    if not safe_name:
+        raise HTTPException(status_code=422, detail="Name is required")
+
+    safe_email = _validate_email(email)
+
+    safe_phone = phone.strip() if phone else None
+    if safe_phone and not PHONE_RE.match(safe_phone):
+        raise HTTPException(status_code=422, detail="Not a valid phone number")
+
+    safe_message = message.strip()
+    if not safe_message:
+        raise HTTPException(status_code=422, detail="Message is required")
+
+    return safe_name, safe_email, safe_phone, safe_message
+
+
+def _validate_contact_upload(content_type: str | None, filename: str, payload: bytes) -> None:
+    extension = os.path.splitext(filename)[1].lower()
+    normalized_type = (content_type or "").lower().strip()
+
+    if extension not in CONTACT_ALLOWED_EXTENSIONS:
+        raise HTTPException(status_code=422, detail=f"Unsupported file type: {filename}")
+
+    if normalized_type and normalized_type not in CONTACT_ALLOWED_CONTENT_TYPES:
+        raise HTTPException(status_code=422, detail=f"Unsupported file type: {filename}")
+
+    if len(payload) > CONTACT_MAX_FILE_BYTES:
+        raise HTTPException(status_code=422, detail=f"File exceeds 10MB limit: {filename}")
+
+
+@router.post("/api/contact", response_model=ContactResponse)
+async def submit_contact(
+    name: str = Form(...),
+    email: str = Form(...),
+    phone: str | None = Form(default=None),
+    message: str = Form(...),
+    attachments: list[UploadFile] = File(default=[]),
+):
+    request_id = str(uuid.uuid4())
+    safe_name, safe_email, safe_phone, safe_message = _validate_contact_fields(name, email, phone, message)
+
+    if len(attachments) > CONTACT_MAX_FILES:
+        raise HTTPException(status_code=422, detail="Upload up to 3 attachments.")
+
+    postmark_attachments: list[PostmarkAttachment] = []
+    attachment_names: list[str] = []
+
+    for attachment in attachments:
+        filename = (attachment.filename or "attachment").strip()
+        payload = await attachment.read()
+        _validate_contact_upload(attachment.content_type, filename, payload)
+
+        postmark_attachments.append(
+            PostmarkAttachment(
+                name=filename,
+                content_type=attachment.content_type or "application/octet-stream",
+                content_base64=base64.b64encode(payload).decode("ascii"),
+            )
+        )
+        attachment_names.append(filename)
+
+    try:
+        send_admin_contact_notification(
+            name=safe_name,
+            email=safe_email,
+            phone=safe_phone,
+            message=safe_message,
+            attachment_names=attachment_names,
+            attachments=postmark_attachments,
+        )
+    except Exception as exc:
+        _raise_contact_mail_delivery_error(exc, request_id=request_id)
+
+    return ContactResponse(message="Thanks for contacting us. We'll be in touch soon.")
 
 
 @router.post("/api/register-interest", response_model=RegisterInterestResponse)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -54,6 +54,7 @@ from backend.app.services.postmark_email import (
     PostmarkAttachment,
     send_admin_contact_notification,
     send_admin_signup_notification,
+    send_contact_confirmation_email,
     send_verification_email,
 )
 
@@ -294,6 +295,16 @@ async def submit_contact(
         )
     except Exception as exc:
         _raise_contact_mail_delivery_error(exc, request_id=request_id)
+
+    try:
+        send_contact_confirmation_email(to_email=safe_email, name=safe_name)
+    except Exception:
+        logger.exception(
+            "contact.email.sender_confirmation_failed request_id=%s from_email=%s to_email=%s",
+            request_id,
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            safe_email,
+        )
 
     return ContactResponse(message="Thanks for contacting us. We'll be in touch soon.")
 

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -26,9 +26,11 @@ from backend.app.data.json_store import (
     create_account_user,
     find_user_by_email,
     hash_password,
+    load_pending_settings_unlocks,
     load_pending_signups,
     load_users,
     normalize_email,
+    save_pending_settings_unlocks,
     save_pending_signups,
     save_users,
 )
@@ -40,6 +42,12 @@ from backend.app.models import (
     LoginRequest,
     LoginResponse,
     ContactResponse,
+    SettingsUnlockResendResponse,
+    SettingsUnlockStartRequest,
+    SettingsUnlockStartResponse,
+    SettingsUnlockVerifyRequest,
+    SettingsUnlockVerifyResponse,
+    UpdateMeRequest,
     RegisterInterestRequest,
     RegisterInterestResponse,
     SignupResendRequest,
@@ -55,6 +63,7 @@ from backend.app.services.postmark_email import (
     send_admin_contact_notification,
     send_admin_signup_notification,
     send_contact_confirmation_email,
+    send_settings_unlock_code_email,
     send_verification_email,
 )
 
@@ -67,6 +76,12 @@ SIGNUP_CODE_TTL_SECONDS = 15 * 60
 SIGNUP_MAX_VERIFY_ATTEMPTS = 5
 SIGNUP_RESEND_COOLDOWN_SECONDS = 30
 SIGNUP_MAX_RESENDS = 5
+
+SETTINGS_UNLOCK_CODE_TTL_SECONDS = 15 * 60
+SETTINGS_UNLOCK_MAX_VERIFY_ATTEMPTS = 5
+SETTINGS_UNLOCK_RESEND_COOLDOWN_SECONDS = 30
+SETTINGS_UNLOCK_MAX_RESENDS = 5
+SETTINGS_UNLOCK_SESSION_SECONDS = 10 * 60
 
 CONTACT_MAX_FILES = 3
 CONTACT_MAX_FILE_BYTES = 10 * 1024 * 1024
@@ -251,6 +266,287 @@ def _validate_contact_upload(content_type: str | None, filename: str, payload: b
 
     if len(payload) > CONTACT_MAX_FILE_BYTES:
         raise HTTPException(status_code=422, detail=f"File exceeds 10MB limit: {filename}")
+
+
+def _settings_unlock_challenge_key(user_id: str) -> str:
+    return user_id
+
+
+def _raise_settings_unlock_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
+    if isinstance(exc, PostmarkConfigurationError):
+        logger.error(
+            "settings.unlock.email.config_error request_id=%s has_server_token=%s has_from_email=%s has_admin_notify_email=%s detail=%s",
+            request_id,
+            bool(os.getenv("POSTMARK_SERVER_TOKEN", "").strip()),
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            bool(os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()),
+            str(exc),
+        )
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if isinstance(exc, PostmarkDeliveryError):
+        logger.error(
+            "settings.unlock.email.delivery_error request_id=%s status_code=%s error_code=%s message=%s",
+            request_id,
+            exc.status_code,
+            exc.error_code,
+            exc.error_message,
+        )
+        raise HTTPException(status_code=502, detail="Failed to send unlock code.") from exc
+    logger.exception("settings.unlock.email.unknown_error request_id=%s", request_id)
+    raise HTTPException(status_code=502, detail="Failed to send unlock code.") from exc
+
+
+def _prune_expired_settings_unlocks(challenges: dict, now: datetime) -> bool:
+    to_delete: list[str] = []
+    for key, record in challenges.items():
+        expires_at = _parse_iso(record.get("code_expires_at"))
+        unlock_expires_at = _parse_iso(record.get("unlock_expires_at"))
+        is_verified = bool(record.get("is_verified"))
+        if (not expires_at or expires_at <= now) and (not is_verified or not unlock_expires_at or unlock_expires_at <= now):
+            to_delete.append(key)
+        elif is_verified and (not unlock_expires_at or unlock_expires_at <= now):
+            to_delete.append(key)
+    for key in to_delete:
+        del challenges[key]
+    return bool(to_delete)
+
+
+def _load_settings_unlocks_pruned() -> tuple[dict, datetime, bool]:
+    challenges = load_pending_settings_unlocks()
+    now = _utc_now()
+    modified = _prune_expired_settings_unlocks(challenges, now)
+    return challenges, now, modified
+
+
+def _validate_update_me_payload(payload: UpdateMeRequest) -> tuple[str | None, str | None, str | None]:
+    name = payload.name.strip() if isinstance(payload.name, str) else None
+    if name is not None and not name:
+        raise HTTPException(status_code=422, detail="Name is required")
+
+    phone = payload.phone.strip() if isinstance(payload.phone, str) else None
+    if phone is not None and phone and not PHONE_RE.match(phone):
+        raise HTTPException(status_code=422, detail="Not a valid phone number")
+
+    password = payload.password.strip() if isinstance(payload.password, str) else None
+    confirm_password = payload.confirm_password.strip() if isinstance(payload.confirm_password, str) else None
+
+    if (password and not confirm_password) or (confirm_password and not password):
+        raise HTTPException(status_code=422, detail="Password and confirm password are required")
+
+    if password:
+        if len(password) < 8:
+            raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+        if password != confirm_password:
+            raise HTTPException(status_code=422, detail="Passwords do not match")
+
+    return name, phone, password
+
+
+@router.post("/api/settings/unlock/start", response_model=SettingsUnlockStartResponse)
+async def settings_unlock_start(
+    payload: SettingsUnlockStartRequest,
+    session_user: tuple[str, dict] = Depends(get_session_user),
+):
+    request_id = str(uuid.uuid4())
+    username, user_data = session_user
+    current_password = payload.current_password
+    if not current_password:
+        raise HTTPException(status_code=422, detail="Current password is required")
+
+    stored_hash = user_data.get("password_hash") or user_data.get("password", "")
+    if not verify_password(current_password, stored_hash):
+        raise HTTPException(status_code=401, detail="Incorrect password")
+
+    email = _validate_email(str(user_data.get("email", "")))
+    challenge_key = _settings_unlock_challenge_key(str(user_data.get("id", username)))
+    challenges, now, _ = _load_settings_unlocks_pruned()
+
+    code = _generate_verification_code()
+    now_iso = _to_iso(now)
+    code_expires_at_iso = _to_iso(now + timedelta(seconds=SETTINGS_UNLOCK_CODE_TTL_SECONDS))
+
+    challenges[challenge_key] = {
+        "user_id": str(user_data.get("id", username)),
+        "username": username,
+        "email": email,
+        "verification_code_hash": hash_password(code),
+        "code_expires_at": code_expires_at_iso,
+        "verify_attempts": 0,
+        "resend_count": 0,
+        "last_code_sent_at": now_iso,
+        "is_verified": False,
+        "unlock_token": None,
+        "unlock_expires_at": None,
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+
+    try:
+        send_settings_unlock_code_email(to_email=email, code=code)
+    except Exception as exc:
+        _raise_settings_unlock_mail_delivery_error(exc, request_id=request_id)
+
+    save_pending_settings_unlocks(challenges)
+    return SettingsUnlockStartResponse(
+        ok=True,
+        expiresInSeconds=SETTINGS_UNLOCK_CODE_TTL_SECONDS,
+        resendCooldownSeconds=SETTINGS_UNLOCK_RESEND_COOLDOWN_SECONDS,
+    )
+
+
+@router.post("/api/settings/unlock/resend", response_model=SettingsUnlockResendResponse)
+async def settings_unlock_resend(session_user: tuple[str, dict] = Depends(get_session_user)):
+    request_id = str(uuid.uuid4())
+    username, user_data = session_user
+    challenge_key = _settings_unlock_challenge_key(str(user_data.get("id", username)))
+
+    challenges, now, modified = _load_settings_unlocks_pruned()
+    record = challenges.get(challenge_key)
+    if not record:
+        if modified:
+            save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=404, detail="No unlock challenge found.")
+
+    expires_at = _parse_iso(record.get("code_expires_at"))
+    if not expires_at or expires_at <= now:
+        del challenges[challenge_key]
+        save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=410, detail="Unlock code expired. Restart unlock.")
+
+    last_sent_at = _parse_iso(record.get("last_code_sent_at"))
+    if last_sent_at and (now - last_sent_at).total_seconds() < SETTINGS_UNLOCK_RESEND_COOLDOWN_SECONDS:
+        raise HTTPException(status_code=429, detail="Please wait before requesting another code.")
+
+    resend_count = int(record.get("resend_count", 0))
+    if resend_count >= SETTINGS_UNLOCK_MAX_RESENDS:
+        raise HTTPException(status_code=429, detail="Maximum resend attempts reached.")
+
+    code = _generate_verification_code()
+    now_iso = _to_iso(now)
+    record["verification_code_hash"] = hash_password(code)
+    record["code_expires_at"] = _to_iso(now + timedelta(seconds=SETTINGS_UNLOCK_CODE_TTL_SECONDS))
+    record["resend_count"] = resend_count + 1
+    record["last_code_sent_at"] = now_iso
+    record["updated_at"] = now_iso
+
+    try:
+        send_settings_unlock_code_email(to_email=record["email"], code=code)
+    except Exception as exc:
+        _raise_settings_unlock_mail_delivery_error(exc, request_id=request_id)
+
+    save_pending_settings_unlocks(challenges)
+    return SettingsUnlockResendResponse(
+        ok=True,
+        expiresInSeconds=SETTINGS_UNLOCK_CODE_TTL_SECONDS,
+        resendCooldownSeconds=SETTINGS_UNLOCK_RESEND_COOLDOWN_SECONDS,
+        resendsRemaining=max(SETTINGS_UNLOCK_MAX_RESENDS - int(record["resend_count"]), 0),
+    )
+
+
+@router.post("/api/settings/unlock/verify", response_model=SettingsUnlockVerifyResponse)
+async def settings_unlock_verify(
+    payload: SettingsUnlockVerifyRequest,
+    session_user: tuple[str, dict] = Depends(get_session_user),
+):
+    username, user_data = session_user
+    challenge_key = _settings_unlock_challenge_key(str(user_data.get("id", username)))
+    code = payload.code.strip()
+    if not code:
+        raise HTTPException(status_code=422, detail="Verification code is required")
+
+    challenges, now, modified = _load_settings_unlocks_pruned()
+    record = challenges.get(challenge_key)
+    if not record:
+        if modified:
+            save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=404, detail="No unlock challenge found.")
+
+    expires_at = _parse_iso(record.get("code_expires_at"))
+    if not expires_at or expires_at <= now:
+        del challenges[challenge_key]
+        save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=410, detail="Unlock code expired. Restart unlock.")
+
+    current_attempts = int(record.get("verify_attempts", 0))
+    if current_attempts >= SETTINGS_UNLOCK_MAX_VERIFY_ATTEMPTS:
+        del challenges[challenge_key]
+        save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=429, detail="Too many verification attempts. Restart unlock.")
+
+    code_hash = str(record.get("verification_code_hash", ""))
+    if not verify_password(code, code_hash):
+        record["verify_attempts"] = current_attempts + 1
+        record["updated_at"] = _to_iso(now)
+        if int(record["verify_attempts"]) >= SETTINGS_UNLOCK_MAX_VERIFY_ATTEMPTS:
+            del challenges[challenge_key]
+            save_pending_settings_unlocks(challenges)
+            raise HTTPException(status_code=429, detail="Too many verification attempts. Restart unlock.")
+        save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=400, detail="Invalid verification code.")
+
+    unlock_token = secrets.token_urlsafe(24)
+    record["is_verified"] = True
+    record["unlock_token"] = hash_session_token(unlock_token)
+    record["unlock_expires_at"] = _to_iso(now + timedelta(seconds=SETTINGS_UNLOCK_SESSION_SECONDS))
+    record["updated_at"] = _to_iso(now)
+    save_pending_settings_unlocks(challenges)
+
+    return SettingsUnlockVerifyResponse(
+        ok=True,
+        unlockToken=unlock_token,
+        unlockExpiresInSeconds=SETTINGS_UNLOCK_SESSION_SECONDS,
+    )
+
+
+@router.put("/api/me", response_model=AuthUserResponse)
+async def update_me(
+    payload: UpdateMeRequest,
+    session_user: tuple[str, dict] = Depends(get_session_user),
+):
+    username, user_data = session_user
+    challenge_key = _settings_unlock_challenge_key(str(user_data.get("id", username)))
+    unlock_token = payload.unlock_token.strip()
+    if not unlock_token:
+        raise HTTPException(status_code=401, detail="Unlock required")
+
+    challenges, now, modified = _load_settings_unlocks_pruned()
+    record = challenges.get(challenge_key)
+    if not record:
+        if modified:
+            save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=401, detail="Unlock required")
+
+    unlock_expires_at = _parse_iso(record.get("unlock_expires_at"))
+    stored_unlock_token_hash = str(record.get("unlock_token", ""))
+    if not record.get("is_verified") or not unlock_expires_at or unlock_expires_at <= now or not secrets.compare_digest(hash_session_token(unlock_token), stored_unlock_token_hash):
+        del challenges[challenge_key]
+        save_pending_settings_unlocks(challenges)
+        raise HTTPException(status_code=401, detail="Unlock expired. Please unlock again.")
+
+    name, phone, password = _validate_update_me_payload(payload)
+
+    users = load_users()
+    existing = users.get(username)
+    if not existing:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if name is not None:
+        existing["name"] = name
+    if phone is not None:
+        existing["phone"] = phone or None
+    if password:
+        password_hash = hash_password(password)
+        existing["password_hash"] = password_hash
+        existing["password"] = password_hash
+
+    existing["updated_at"] = _to_iso(now)
+    users[username] = existing
+    save_users(users)
+
+    del challenges[challenge_key]
+    save_pending_settings_unlocks(challenges)
+
+    return AuthUserResponse(user=_safe_auth_user(existing))
 
 
 @router.post("/api/contact", response_model=ContactResponse)

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -32,6 +32,7 @@ from backend.app.data.json_store import (
     normalize_email,
     save_pending_settings_unlocks,
     save_pending_signups,
+    save_pending_password_resets,
     save_users,
 )
 from backend.app.models import (
@@ -50,6 +51,12 @@ from backend.app.models import (
     UpdateMeRequest,
     RegisterInterestRequest,
     RegisterInterestResponse,
+    PasswordResetStartRequest,
+    PasswordResetStartResponse,
+    PasswordResetResendRequest,
+    PasswordResetResendResponse,
+    PasswordResetVerifyRequest,
+    PasswordResetVerifyResponse,
     SignupResendRequest,
     SignupResendResponse,
     SignupStartResponse,
@@ -64,6 +71,7 @@ from backend.app.services.postmark_email import (
     send_admin_signup_notification,
     send_contact_confirmation_email,
     send_settings_unlock_code_email,
+    send_password_reset_code_email,
     send_verification_email,
 )
 
@@ -76,6 +84,10 @@ SIGNUP_CODE_TTL_SECONDS = 15 * 60
 SIGNUP_MAX_VERIFY_ATTEMPTS = 5
 SIGNUP_RESEND_COOLDOWN_SECONDS = 30
 SIGNUP_MAX_RESENDS = 5
+PASSWORD_RESET_CODE_TTL_SECONDS = 15 * 60
+PASSWORD_RESET_MAX_VERIFY_ATTEMPTS = 5
+PASSWORD_RESET_RESEND_COOLDOWN_SECONDS = 30
+PASSWORD_RESET_MAX_RESENDS = 5
 
 SETTINGS_UNLOCK_CODE_TTL_SECONDS = 15 * 60
 SETTINGS_UNLOCK_MAX_VERIFY_ATTEMPTS = 5
@@ -174,6 +186,24 @@ def _load_pending_signups_pruned() -> tuple[dict, datetime, bool]:
     now = _utc_now()
     modified = _prune_expired_pending_signups(pending_signups, now)
     return pending_signups, now, modified
+
+
+def _prune_expired_password_resets(password_resets: dict, now: datetime) -> bool:
+    to_delete: list[str] = []
+    for email, record in password_resets.items():
+        expires_at = _parse_iso(record.get("code_expires_at"))
+        if expires_at is None or expires_at <= now:
+            to_delete.append(email)
+    for email in to_delete:
+        del password_resets[email]
+    return bool(to_delete)
+
+
+def _load_password_resets_pruned() -> tuple[dict, datetime, bool]:
+    password_resets = load_pending_password_resets()
+    now = _utc_now()
+    modified = _prune_expired_password_resets(password_resets, now)
+    return password_resets, now, modified
 
 
 def _raise_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
@@ -817,6 +847,124 @@ async def signup_verify(payload: SignupVerifyRequest):
     return AuthUserResponse(user=_safe_auth_user(user_data))
 
 
+@router.post("/api/password-reset/start", response_model=PasswordResetStartResponse, status_code=202)
+async def password_reset_start(payload: PasswordResetStartRequest):
+    request_id = str(uuid.uuid4())
+    email = _validate_email(payload.email)
+    users = load_users()
+    username, _ = find_user_by_email(users, email)
+    if not username:
+        return PasswordResetStartResponse(ok=True, email=email, expiresInSeconds=PASSWORD_RESET_CODE_TTL_SECONDS, resendCooldownSeconds=PASSWORD_RESET_RESEND_COOLDOWN_SECONDS)
+
+    password_resets, now, _ = _load_password_resets_pruned()
+    now_iso = _to_iso(now)
+    code = _generate_verification_code()
+    password_resets[email] = {
+        "email": email,
+        "verification_code_hash": hash_password(code),
+        "code_expires_at": _to_iso(now + timedelta(seconds=PASSWORD_RESET_CODE_TTL_SECONDS)),
+        "verify_attempts": 0,
+        "resend_count": 0,
+        "last_code_sent_at": now_iso,
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+    try:
+        send_password_reset_code_email(to_email=email, code=code)
+    except Exception as exc:
+        _raise_mail_delivery_error(exc, request_id=request_id)
+    save_pending_password_resets(password_resets)
+    return PasswordResetStartResponse(ok=True, email=email, expiresInSeconds=PASSWORD_RESET_CODE_TTL_SECONDS, resendCooldownSeconds=PASSWORD_RESET_RESEND_COOLDOWN_SECONDS)
+
+
+@router.post("/api/password-reset/resend", response_model=PasswordResetResendResponse)
+async def password_reset_resend(payload: PasswordResetResendRequest):
+    request_id = str(uuid.uuid4())
+    email = _validate_email(payload.email)
+    password_resets, now, modified = _load_password_resets_pruned()
+    record = password_resets.get(email)
+    if not record:
+        if modified:
+            save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=404, detail="No pending password reset found for this email.")
+
+    last_sent_at = _parse_iso(record.get("last_code_sent_at"))
+    if last_sent_at and (now - last_sent_at).total_seconds() < PASSWORD_RESET_RESEND_COOLDOWN_SECONDS:
+        if modified:
+            save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=429, detail="Please wait before requesting another code.")
+
+    resend_count = int(record.get("resend_count", 0))
+    if resend_count >= PASSWORD_RESET_MAX_RESENDS:
+        if modified:
+            save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=429, detail="Resend limit reached. Please restart password reset.")
+
+    code = _generate_verification_code()
+    record["verification_code_hash"] = hash_password(code)
+    record["code_expires_at"] = _to_iso(now + timedelta(seconds=PASSWORD_RESET_CODE_TTL_SECONDS))
+    record["resend_count"] = resend_count + 1
+    record["last_code_sent_at"] = _to_iso(now)
+    record["verify_attempts"] = 0
+    record["updated_at"] = _to_iso(now)
+    try:
+        send_password_reset_code_email(to_email=email, code=code)
+    except Exception as exc:
+        _raise_mail_delivery_error(exc, request_id=request_id)
+    save_pending_password_resets(password_resets)
+    return PasswordResetResendResponse(ok=True, expiresInSeconds=PASSWORD_RESET_CODE_TTL_SECONDS, resendCooldownSeconds=PASSWORD_RESET_RESEND_COOLDOWN_SECONDS, resendsRemaining=max(PASSWORD_RESET_MAX_RESENDS - int(record["resend_count"]), 0))
+
+
+@router.post("/api/password-reset/verify", response_model=PasswordResetVerifyResponse)
+async def password_reset_verify(payload: PasswordResetVerifyRequest):
+    email = _validate_email(payload.email)
+    code = payload.code.strip()
+    if not code:
+        raise HTTPException(status_code=422, detail="Verification code is required")
+    if not payload.password:
+        raise HTTPException(status_code=422, detail="Password is required")
+    if len(payload.password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+    if payload.password != payload.confirm_password:
+        raise HTTPException(status_code=422, detail="Passwords do not match")
+
+    password_resets, now, modified = _load_password_resets_pruned()
+    record = password_resets.get(email)
+    if not record:
+        if modified:
+            save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=404, detail="No pending password reset found for this email.")
+
+    attempts = int(record.get("verify_attempts", 0))
+    if attempts >= PASSWORD_RESET_MAX_VERIFY_ATTEMPTS:
+        del password_resets[email]
+        save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=429, detail="Too many verification attempts. Please restart password reset.")
+
+    if not verify_password(code, str(record.get("verification_code_hash", ""))):
+        record["verify_attempts"] = attempts + 1
+        record["updated_at"] = _to_iso(now)
+        if int(record["verify_attempts"]) >= PASSWORD_RESET_MAX_VERIFY_ATTEMPTS:
+            del password_resets[email]
+            save_pending_password_resets(password_resets)
+            raise HTTPException(status_code=429, detail="Too many verification attempts. Please restart password reset.")
+        save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=400, detail="Invalid verification code.")
+
+    users = load_users()
+    username, user_data = find_user_by_email(users, email)
+    if username and user_data:
+        password_hash = hash_password(payload.password)
+        users[username]["password_hash"] = password_hash
+        users[username]["password"] = password_hash
+        users[username]["updated_at"] = _to_iso(now)
+        save_users(users)
+
+    del password_resets[email]
+    save_pending_password_resets(password_resets)
+    return PasswordResetVerifyResponse(ok=True)
+
+
 @router.post("/api/create-account", response_model=AuthUserResponse, status_code=201)
 async def create_account(payload: CreateAccountRequest):
     name, email, phone = _validate_signup_payload(payload)
@@ -895,3 +1043,4 @@ async def me(session_user: tuple[str, dict] = Depends(get_session_user)):
 @router.post("/api/logout", status_code=204)
 async def logout(response: Response):
     clear_auth_cookie(response)
+    load_pending_password_resets,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,7 @@ INTEREST_SUBMISSIONS_FILE = 'backend/data/interest_submissions.json'
 DOCUMENTS_FILE = 'backend/data/documents.json'
 DOCUMENT_BLOBS_DIR = 'backend/data/document_blobs'
 PENDING_SIGNUPS_FILE = 'backend/data/pending_signups.json'
+PENDING_SETTINGS_UNLOCKS_FILE = 'backend/data/pending_settings_unlocks.json'
 
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -13,6 +13,7 @@ DOCUMENTS_FILE = 'backend/data/documents.json'
 DOCUMENT_BLOBS_DIR = 'backend/data/document_blobs'
 PENDING_SIGNUPS_FILE = 'backend/data/pending_signups.json'
 PENDING_SETTINGS_UNLOCKS_FILE = 'backend/data/pending_settings_unlocks.json'
+PENDING_PASSWORD_RESETS_FILE = 'backend/data/pending_password_resets.json'
 
 
 

--- a/backend/app/data/json_store.py
+++ b/backend/app/data/json_store.py
@@ -19,6 +19,7 @@ from backend.app.config import (
     DEVICE_LISTS_FILE,
     PENDING_SIGNUPS_FILE,
     PENDING_SETTINGS_UNLOCKS_FILE,
+    PENDING_PASSWORD_RESETS_FILE,
 )
 
 
@@ -242,6 +243,30 @@ def save_pending_settings_unlocks(pending_data: dict):
         with os.fdopen(temp_fd, 'w') as f:
             json.dump(pending_data, f, indent=2)
         shutil.move(temp_path, PENDING_SETTINGS_UNLOCKS_FILE)
+    except Exception as e:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise e
+
+
+def load_pending_password_resets() -> dict:
+    """Load pending password reset records from JSON file."""
+    if not os.path.exists(PENDING_PASSWORD_RESETS_FILE):
+        return {}
+    with open(PENDING_PASSWORD_RESETS_FILE, 'r') as f:
+        return json.load(f)
+
+
+def save_pending_password_resets(pending_data: dict):
+    """Save pending password reset data to JSON file using atomic write."""
+    file_dir = os.path.dirname(PENDING_PASSWORD_RESETS_FILE) or '.'
+    os.makedirs(file_dir, exist_ok=True)
+
+    temp_fd, temp_path = tempfile.mkstemp(dir=file_dir, suffix='.tmp')
+    try:
+        with os.fdopen(temp_fd, 'w') as f:
+            json.dump(pending_data, f, indent=2)
+        shutil.move(temp_path, PENDING_PASSWORD_RESETS_FILE)
     except Exception as e:
         if os.path.exists(temp_path):
             os.unlink(temp_path)

--- a/backend/app/data/json_store.py
+++ b/backend/app/data/json_store.py
@@ -13,7 +13,13 @@ import secrets
 from datetime import datetime, timezone
 from uuid import uuid4
 
-from backend.app.config import USERS_FILE, ALARM_LOGS_FILE, DEVICE_LISTS_FILE, PENDING_SIGNUPS_FILE
+from backend.app.config import (
+    USERS_FILE,
+    ALARM_LOGS_FILE,
+    DEVICE_LISTS_FILE,
+    PENDING_SIGNUPS_FILE,
+    PENDING_SETTINGS_UNLOCKS_FILE,
+)
 
 
 def hash_password(password: str) -> str:
@@ -216,3 +222,27 @@ def save_device_lists(device_data: dict):
     os.makedirs(os.path.dirname(DEVICE_LISTS_FILE), exist_ok=True)
     with open(DEVICE_LISTS_FILE, 'w') as f:
         json.dump(device_data, f, indent=2)
+
+
+def load_pending_settings_unlocks() -> dict:
+    """Load pending settings unlock records from JSON file."""
+    if not os.path.exists(PENDING_SETTINGS_UNLOCKS_FILE):
+        return {}
+    with open(PENDING_SETTINGS_UNLOCKS_FILE, 'r') as f:
+        return json.load(f)
+
+
+def save_pending_settings_unlocks(pending_data: dict):
+    """Save pending settings unlock data to JSON file using atomic write."""
+    file_dir = os.path.dirname(PENDING_SETTINGS_UNLOCKS_FILE) or '.'
+    os.makedirs(file_dir, exist_ok=True)
+
+    temp_fd, temp_path = tempfile.mkstemp(dir=file_dir, suffix='.tmp')
+    try:
+        with os.fdopen(temp_fd, 'w') as f:
+            json.dump(pending_data, f, indent=2)
+        shutil.move(temp_path, PENDING_SETTINGS_UNLOCKS_FILE)
+    except Exception as e:
+        if os.path.exists(temp_path):
+            os.unlink(temp_path)
+        raise e

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -92,6 +92,39 @@ class SignupResendResponse(BaseModel):
     resendsRemaining: int
 
 
+class PasswordResetStartRequest(BaseModel):
+    email: str
+
+
+class PasswordResetStartResponse(BaseModel):
+    ok: bool
+    email: str
+    expiresInSeconds: int
+    resendCooldownSeconds: int
+
+
+class PasswordResetResendRequest(BaseModel):
+    email: str
+
+
+class PasswordResetResendResponse(BaseModel):
+    ok: bool
+    expiresInSeconds: int
+    resendCooldownSeconds: int
+    resendsRemaining: int
+
+
+class PasswordResetVerifyRequest(BaseModel):
+    email: str
+    code: str
+    password: str
+    confirm_password: str
+
+
+class PasswordResetVerifyResponse(BaseModel):
+    ok: bool
+
+
 
 
 class SettingsUnlockStartRequest(BaseModel):

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -106,6 +106,10 @@ class RegisterInterestResponse(BaseModel):
     submission_id: str
 
 
+class ContactResponse(BaseModel):
+    message: str
+
+
 class CreateAlarmRequest(BaseModel):
     instance: str
     device: str

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -92,6 +92,45 @@ class SignupResendResponse(BaseModel):
     resendsRemaining: int
 
 
+
+
+class SettingsUnlockStartRequest(BaseModel):
+    current_password: str
+
+
+class SettingsUnlockStartResponse(BaseModel):
+    ok: bool
+    expiresInSeconds: int
+    resendCooldownSeconds: int
+
+
+class SettingsUnlockVerifyRequest(BaseModel):
+    code: str
+
+
+class SettingsUnlockVerifyResponse(BaseModel):
+    ok: bool
+    unlockToken: str
+    unlockExpiresInSeconds: int
+
+
+class SettingsUnlockResendResponse(BaseModel):
+    ok: bool
+    expiresInSeconds: int
+    resendCooldownSeconds: int
+    resendsRemaining: int
+
+
+class UpdateMeRequest(BaseModel):
+    name: Optional[str] = None
+    phone: Optional[str] = None
+    password: Optional[str] = None
+    confirm_password: Optional[str] = None
+    unlock_token: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class RegisterInterestRequest(BaseModel):
     name: str
     email: str

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -255,3 +255,28 @@ def send_admin_contact_notification(
         from_email=config.from_email,
         to_email=config.admin_notify_email,
     )
+
+
+
+def send_contact_confirmation_email(*, to_email: str, name: str) -> None:
+    config = _load_config()
+    greeting = f"Hi {name}," if name.strip() else "Hello,"
+    payload = {
+        "From": config.from_email,
+        "To": to_email,
+        "Subject": "We received your message",
+        "TextBody": (
+            f"{greeting}\n\n"
+            "Thank you for contacting camOS.\n"
+            "We have received your message and our team will review it.\n"
+            "We will get back to you as appropriate.\n\n"
+            "Regards,\n"
+            "camOS Team\n"
+        ),
+    }
+    _postmark_send(
+        token=config.server_token,
+        payload=payload,
+        from_email=config.from_email,
+        to_email=to_email,
+    )

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -280,3 +280,22 @@ def send_contact_confirmation_email(*, to_email: str, name: str) -> None:
         from_email=config.from_email,
         to_email=to_email,
     )
+
+
+def send_settings_unlock_code_email(*, to_email: str, code: str) -> None:
+    config = _load_config()
+    payload = {
+        "From": config.from_email,
+        "To": to_email,
+        "Subject": "Your camOS account unlock code",
+        "TextBody": (
+            f"Your camOS account unlock code is {code}.\n\n"
+            "It expires in 15 minutes."
+        ),
+    }
+    _postmark_send(
+        token=config.server_token,
+        payload=payload,
+        from_email=config.from_email,
+        to_email=to_email,
+    )

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -48,6 +48,13 @@ class PostmarkConfig:
     admin_notify_email: str
 
 
+@dataclass(frozen=True)
+class PostmarkAttachment:
+    name: str
+    content_base64: str
+    content_type: str
+
+
 def _mask_email(email: str) -> str:
     if "@" not in email:
         return "***"
@@ -198,6 +205,50 @@ def send_admin_signup_notification(*, verified_email: str, name: str, username: 
             f"Timestamp (UTC): {timestamp}\n"
         ),
     }
+    _postmark_send(
+        token=config.server_token,
+        payload=payload,
+        from_email=config.from_email,
+        to_email=config.admin_notify_email,
+    )
+
+
+def send_admin_contact_notification(
+    *,
+    name: str,
+    email: str,
+    phone: str | None,
+    message: str,
+    attachment_names: list[str],
+    attachments: list[PostmarkAttachment] | None = None,
+) -> None:
+    config = _load_config()
+    attachments_line = ", ".join(attachment_names) if attachment_names else "None"
+    payload = {
+        "From": config.from_email,
+        "To": config.admin_notify_email,
+        "Subject": f"New contact submission: {name}",
+        "TextBody": (
+            "A new contact form submission has been received.\n\n"
+            f"Name: {name}\n"
+            f"Email: {email}\n"
+            f"Phone: {phone if phone else 'Not provided'}\n"
+            f"Attachments: {attachments_line}\n\n"
+            "Message:\n"
+            f"{message}\n"
+        ),
+    }
+
+    if attachments:
+        payload["Attachments"] = [
+            {
+                "Name": item.name,
+                "Content": item.content_base64,
+                "ContentType": item.content_type,
+            }
+            for item in attachments
+        ]
+
     _postmark_send(
         token=config.server_token,
         payload=payload,

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -299,3 +299,22 @@ def send_settings_unlock_code_email(*, to_email: str, code: str) -> None:
         from_email=config.from_email,
         to_email=to_email,
     )
+
+
+def send_password_reset_code_email(*, to_email: str, code: str) -> None:
+    config = _load_config()
+    payload = {
+        "From": config.from_email,
+        "To": to_email,
+        "Subject": "Your camOS password reset code",
+        "TextBody": (
+            f"Your camOS password reset code is {code}.\n\n"
+            "It expires in 15 minutes."
+        ),
+    }
+    _postmark_send(
+        token=config.server_token,
+        payload=payload,
+        from_email=config.from_email,
+        to_email=to_email,
+    )

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -30,6 +30,7 @@ const LandingPage = React.lazy(() => import("../pages/LandingPage"));
 const LoginPage = React.lazy(() => import("../pages/LoginPage"));
 const CreateAccountPage = React.lazy(() => import("../pages/CreateAccountPage"));
 const VerifyEmailPage = React.lazy(() => import("../pages/VerifyEmailPage"));
+const ResetPasswordPage = React.lazy(() => import("../pages/ResetPasswordPage"));
 const ContactPage = React.lazy(() => import("../pages/ContactPage"));
 const DemoPage = React.lazy(() => import("../pages/DemoPage"));
 
@@ -224,6 +225,16 @@ const AppRoutes: React.FC = () => {
         element={
           appMode === "public" ? (
             lazyRoute(<VerifyEmailPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/reset-password"
+        element={
+          appMode === "public" ? (
+            lazyRoute(<ResetPasswordPage />)
           ) : (
             <Navigate to="/home" replace />
           )

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -30,6 +30,7 @@ const LandingPage = React.lazy(() => import("../pages/LandingPage"));
 const LoginPage = React.lazy(() => import("../pages/LoginPage"));
 const CreateAccountPage = React.lazy(() => import("../pages/CreateAccountPage"));
 const VerifyEmailPage = React.lazy(() => import("../pages/VerifyEmailPage"));
+const ContactPage = React.lazy(() => import("../pages/ContactPage"));
 const DemoPage = React.lazy(() => import("../pages/DemoPage"));
 
 const AppRoutes: React.FC = () => {
@@ -223,6 +224,16 @@ const AppRoutes: React.FC = () => {
         element={
           appMode === "public" ? (
             lazyRoute(<VerifyEmailPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/contact"
+        element={
+          appMode === "public" ? (
+            lazyRoute(<ContactPage />)
           ) : (
             <Navigate to="/home" replace />
           )

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -1,0 +1,163 @@
+.contact-page {
+  min-height: 100vh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  background: #0f131a;
+  color: #fff;
+}
+
+.contact-shell {
+  min-height: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.contact-left-pane {
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+  padding: 34px 32px 40px;
+}
+
+.contact-content {
+  width: 100%;
+  max-width: 520px;
+  display: grid;
+  gap: 8px;
+}
+
+.contact-title {
+  color: #c9d2e1;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.contact-hero {
+  font-size: 41px;
+  line-height: 1.14;
+  letter-spacing: -0.02em;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.contact-field {
+  margin: 0;
+}
+
+.contact-error-slot {
+  min-height: 20px;
+  margin-top: 4px;
+}
+
+.contact-error {
+  color: #f4b63d;
+  font-size: 13px;
+}
+
+.contact-under-cta {
+  margin-top: 8px;
+  color: #aab6c9;
+  font-size: 13px;
+}
+
+.contact-inline-link {
+  color: #89b4ff;
+  text-decoration: none;
+  text-underline-offset: 2px;
+}
+
+.contact-inline-link:hover,
+.contact-inline-link:focus-visible {
+  text-decoration: underline;
+}
+
+.contact-right-pane {
+  position: relative;
+  overflow: hidden;
+  border-left: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    radial-gradient(circle at 22% 20%, rgba(105, 145, 215, 0.12), transparent 48%),
+    linear-gradient(145deg, #151a22 0%, #101722 60%, #0e1520 100%);
+  padding: 34px 32px 40px;
+}
+
+.contact-right-content {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  max-width: 520px;
+  margin: 0 auto;
+  display: grid;
+  gap: 8px;
+}
+
+.contact-message-input {
+  min-height: 170px;
+  resize: vertical;
+  padding-top: 10px;
+}
+
+.contact-attachment-hint {
+  margin-top: 6px;
+  color: #aab6c9;
+  font-size: 12px;
+}
+
+.contact-attachment-list {
+  margin: 8px 0 0;
+  padding-left: 16px;
+  color: #c9d2e1;
+  font-size: 13px;
+}
+
+.contact-request-error {
+  margin-top: 4px;
+}
+
+.contact-success {
+  margin-top: 4px;
+  color: #8ad9a2;
+  font-size: 13px;
+}
+
+.contact-actions {
+  margin-top: 6px;
+}
+
+.contact-submit {
+  width: 100%;
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+@media (max-width: 900px) {
+  .contact-page {
+    grid-template-rows: auto auto;
+  }
+
+  .contact-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-left-pane,
+  .contact-right-pane {
+    padding: 24px 20px 28px;
+  }
+
+  .contact-content,
+  .contact-right-content {
+    max-width: 560px;
+  }
+
+  .contact-hero {
+    font-size: 34px;
+  }
+
+  .contact-right-pane {
+    border-left: none;
+    border-top: 1px solid rgba(255, 255, 255, 0.12);
+  }
+}

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -75,10 +75,9 @@
   position: relative;
   overflow: hidden;
   border-left: 1px solid rgba(255, 255, 255, 0.12);
-  background:
-    radial-gradient(circle at 22% 20%, rgba(105, 145, 215, 0.12), transparent 48%),
-    linear-gradient(145deg, #151a22 0%, #101722 60%, #0e1520 100%);
+  background: #151a22;
   padding: 34px 32px 40px;
+  display: flex;
 }
 
 .contact-right-content {
@@ -87,12 +86,14 @@
   width: 100%;
   max-width: 520px;
   margin: 0 auto;
+  min-height: min(620px, calc(100vh - 180px));
   display: grid;
-  gap: 8px;
+  grid-template-rows: auto auto 1fr auto;
+  gap: 10px;
 }
 
 .contact-message-input {
-  min-height: 170px;
+  min-height: 300px;
   resize: vertical;
   padding-top: 10px;
 }
@@ -121,7 +122,8 @@
 }
 
 .contact-actions {
-  margin-top: 6px;
+  margin-top: 10px;
+  align-self: end;
 }
 
 .contact-submit {
@@ -150,6 +152,11 @@
   .contact-content,
   .contact-right-content {
     max-width: 560px;
+  }
+
+  .contact-right-content {
+    min-height: auto;
+    grid-template-rows: auto;
   }
 
   .contact-hero {

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -1,0 +1,282 @@
+import React, { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import AuthTopBar from "../../components/auth/AuthTopBar";
+import camsvg from "../../assets/camsvg.svg";
+import { submitContact } from "./transport/contact";
+import "./ContactPage.css";
+
+type FieldErrors = {
+  name?: string;
+  email?: string;
+  phone?: string;
+  message?: string;
+  attachments?: string;
+};
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PHONE_RE = /^\+?[0-9\s()-]{7,20}$/;
+const MAX_ATTACHMENTS = 3;
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const ACCEPTED_EXTENSIONS = [".pdf", ".docx", ".xlsx", ".csv", ".png", ".jpg", ".jpeg"];
+
+const ContactPage: React.FC = () => {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [message, setMessage] = useState("");
+  const [attachments, setAttachments] = useState<File[]>([]);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const attachmentSummary = useMemo(() => {
+    if (attachments.length === 0) {
+      return "No files selected";
+    }
+    return `${attachments.length} file${attachments.length > 1 ? "s" : ""} selected`;
+  }, [attachments.length]);
+
+  const validate = (): FieldErrors => {
+    const nextErrors: FieldErrors = {};
+
+    if (!name.trim()) {
+      nextErrors.name = "This field is required";
+    }
+
+    if (!email.trim()) {
+      nextErrors.email = "This field is required";
+    } else if (!EMAIL_RE.test(email.trim().toLowerCase())) {
+      nextErrors.email = "Not a valid email address";
+    }
+
+    if (phone.trim() && !PHONE_RE.test(phone.trim())) {
+      nextErrors.phone = "Not a valid phone number";
+    }
+
+    if (!message.trim()) {
+      nextErrors.message = "This field is required";
+    }
+
+    if (attachments.length > MAX_ATTACHMENTS) {
+      nextErrors.attachments = `Upload up to ${MAX_ATTACHMENTS} files only.`;
+    } else if (attachments.some((file) => file.size > MAX_FILE_BYTES)) {
+      nextErrors.attachments = "Each file must be 10MB or smaller.";
+    }
+
+    return nextErrors;
+  };
+
+  const onFilesChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(event.target.files ?? []);
+    setAttachments(selected);
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    if (selected.length > MAX_ATTACHMENTS) {
+      setErrors((prev) => ({ ...prev, attachments: `Upload up to ${MAX_ATTACHMENTS} files only.` }));
+      return;
+    }
+
+    if (selected.some((file) => file.size > MAX_FILE_BYTES)) {
+      setErrors((prev) => ({ ...prev, attachments: "Each file must be 10MB or smaller." }));
+      return;
+    }
+
+    setErrors((prev) => ({ ...prev, attachments: undefined }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setSubmitError(null);
+    setSubmitSuccess(null);
+
+    const validationErrors = validate();
+    setErrors(validationErrors);
+    if (Object.keys(validationErrors).length > 0) {
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const result = await submitContact({
+        name: name.trim(),
+        email: email.trim().toLowerCase(),
+        phone: phone.trim(),
+        message: message.trim(),
+        attachments,
+      });
+
+      if (!result.ok) {
+        setSubmitError(result.message);
+        return;
+      }
+
+      setSubmitSuccess("Message sent. We'll get back to you shortly.");
+      setName("");
+      setEmail("");
+      setPhone("");
+      setMessage("");
+      setAttachments([]);
+      setErrors({});
+    } catch {
+      setSubmitError("Unable to send your message. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="contact-page">
+      <AuthTopBar />
+
+      <form className="contact-shell" onSubmit={handleSubmit}>
+        <section className="contact-left-pane" aria-label="Contact details panel">
+          <div className="contact-content">
+            <p className="contact-title">Contact</p>
+            <h1 className="contact-hero">Get in Touch</h1>
+
+            <div className="vrm-field contact-field">
+              <label className="vrm-label" htmlFor="contact-name">Name</label>
+              <input
+                id="contact-name"
+                className="vrm-input"
+                value={name}
+                onChange={(event) => {
+                  setName(event.target.value);
+                  if (errors.name) setErrors((prev) => ({ ...prev, name: undefined }));
+                }}
+                autoComplete="name"
+                aria-invalid={Boolean(errors.name)}
+                aria-describedby={errors.name ? "contact-name-error" : undefined}
+              />
+              <div className="contact-error-slot" aria-live="polite">
+                {errors.name && <div id="contact-name-error" className="contact-error">{errors.name}</div>}
+              </div>
+            </div>
+
+            <div className="vrm-field contact-field">
+              <label className="vrm-label" htmlFor="contact-email">Email</label>
+              <input
+                id="contact-email"
+                className="vrm-input"
+                type="email"
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  if (errors.email) setErrors((prev) => ({ ...prev, email: undefined }));
+                }}
+                autoComplete="email"
+                aria-invalid={Boolean(errors.email)}
+                aria-describedby={errors.email ? "contact-email-error" : undefined}
+              />
+              <div className="contact-error-slot" aria-live="polite">
+                {errors.email && <div id="contact-email-error" className="contact-error">{errors.email}</div>}
+              </div>
+            </div>
+
+            <div className="vrm-field contact-field">
+              <label className="vrm-label" htmlFor="contact-phone">Phone (optional)</label>
+              <input
+                id="contact-phone"
+                className="vrm-input"
+                value={phone}
+                onChange={(event) => {
+                  setPhone(event.target.value);
+                  if (errors.phone) setErrors((prev) => ({ ...prev, phone: undefined }));
+                }}
+                autoComplete="tel"
+                aria-invalid={Boolean(errors.phone)}
+                aria-describedby={errors.phone ? "contact-phone-error" : undefined}
+              />
+              <div className="contact-error-slot" aria-live="polite">
+                {errors.phone && <div id="contact-phone-error" className="contact-error">{errors.phone}</div>}
+              </div>
+            </div>
+
+            <p className="contact-under-cta">
+              Why not create an account? <Link to="/create-account" className="contact-inline-link">Create Account</Link>
+            </p>
+          </div>
+        </section>
+
+        <section className="contact-right-pane" aria-label="Contact message panel">
+          <div className="contact-right-content">
+            <div className="vrm-field contact-field">
+              <label className="vrm-label" htmlFor="contact-message">Message</label>
+              <textarea
+                id="contact-message"
+                className="vrm-input contact-message-input"
+                value={message}
+                onChange={(event) => {
+                  setMessage(event.target.value);
+                  if (errors.message) setErrors((prev) => ({ ...prev, message: undefined }));
+                }}
+                placeholder="Tell us what you need help with"
+                aria-invalid={Boolean(errors.message)}
+                aria-describedby={errors.message ? "contact-message-error" : undefined}
+              />
+              <div className="contact-error-slot" aria-live="polite">
+                {errors.message && <div id="contact-message-error" className="contact-error">{errors.message}</div>}
+              </div>
+            </div>
+
+            <div className="vrm-field contact-field">
+              <label className="vrm-label" htmlFor="contact-attachments">Attachments (optional)</label>
+              <input
+                id="contact-attachments"
+                className="vrm-input"
+                type="file"
+                multiple
+                accept={ACCEPTED_EXTENSIONS.join(",")}
+                onChange={onFilesChange}
+                aria-invalid={Boolean(errors.attachments)}
+                aria-describedby={errors.attachments ? "contact-attachments-error" : undefined}
+              />
+              <p className="contact-attachment-hint">
+                {attachmentSummary}. Up to 3 files, 10MB each. Accepted: PDF, DOCX, XLSX, CSV, PNG, JPG.
+              </p>
+              {attachments.length > 0 && (
+                <ul className="contact-attachment-list" aria-label="Selected attachments">
+                  {attachments.map((file) => (
+                    <li key={`${file.name}-${file.lastModified}`}>{file.name}</li>
+                  ))}
+                </ul>
+              )}
+              <div className="contact-error-slot" aria-live="polite">
+                {errors.attachments && <div id="contact-attachments-error" className="contact-error">{errors.attachments}</div>}
+              </div>
+            </div>
+
+            {submitError && (
+              <div className="vrm-status vrm-status-warning contact-request-error" role="alert" aria-live="assertive">
+                {submitError}
+              </div>
+            )}
+
+            {submitSuccess && (
+              <div className="contact-success" role="status" aria-live="polite">
+                {submitSuccess}
+              </div>
+            )}
+
+            <div className="contact-actions">
+              <button type="submit" className="vrm-btn vrm-btn-primary contact-submit" disabled={submitting}>
+                {submitting ? "Sending…" : "Send"}
+              </button>
+            </div>
+          </div>
+          <img
+            src={camsvg}
+            alt=""
+            aria-hidden="true"
+            focusable="false"
+            className="auth-right-pane-overlay"
+          />
+        </section>
+      </form>
+    </div>
+  );
+};
+
+export default ContactPage;

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import AuthTopBar from "../../components/auth/AuthTopBar";
-import camsvg from "../../assets/camsvg.svg";
 import { submitContact } from "./transport/contact";
 import "./ContactPage.css";
 
@@ -266,13 +265,6 @@ const ContactPage: React.FC = () => {
               </button>
             </div>
           </div>
-          <img
-            src={camsvg}
-            alt=""
-            aria-hidden="true"
-            focusable="false"
-            className="auth-right-pane-overlay"
-          />
         </section>
       </form>
     </div>

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import AuthTopBar from "../../components/auth/AuthTopBar";
 import camsvg from "../../assets/camsvg.svg";
 import { useLoginForm } from "./hooks/useLoginForm";
@@ -13,11 +13,8 @@ type LoginStep = "email" | "password";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
-const stopNavigation: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
-  event.preventDefault();
-};
-
 const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
+  const navigate = useNavigate();
   const {
     email,
     password,
@@ -52,6 +49,25 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
     }
 
     await handleSubmit(event);
+  };
+
+  const handleResetPasswordClick: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
+    event.preventDefault();
+    if (!email.trim()) {
+      setEmailStepError("Enter your email before resetting your password");
+      if (step !== "email") {
+        setStep("email");
+      }
+      return;
+    }
+    if (!emailValid) {
+      setEmailStepError("Not a valid email address");
+      if (step !== "email") {
+        setStep("email");
+      }
+      return;
+    }
+    navigate(`/reset-password?email=${encodeURIComponent(email.trim().toLowerCase())}`);
   };
 
   return (
@@ -132,7 +148,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
 
                 {step === "password" && (
                   <p className="login-utility-row login-muted-row">
-                    Forgot your password? <a href="#" onClick={stopNavigation} className="login-inline-link">Reset password</a>
+                    Forgot your password? <a href="#" onClick={handleResetPasswordClick} className="login-inline-link">Reset password</a>
                   </p>
                 )}
               </div>

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+
+import AuthTopBar from "../../components/auth/AuthTopBar";
+import { passwordResetResend } from "./transport/passwordResetResend";
+import { passwordResetStart } from "./transport/passwordResetStart";
+import { passwordResetVerify } from "./transport/passwordResetVerify";
+import "./VerifyEmailPage.css";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const ResetPasswordPage: React.FC = () => {
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+  const email = (params.get("email") ?? "").trim().toLowerCase();
+  const validEmail = useMemo(() => EMAIL_RE.test(email), [email]);
+
+  const [code, setCode] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleVerify = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!validEmail) {
+      setError("Please start from the login page with a valid email.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await passwordResetVerify({ email, code, password, confirm_password: confirmPassword });
+      navigate("/login", { replace: true, state: { message: "Password reset successful. Please sign in." } });
+    } catch (verifyError) {
+      setError(verifyError instanceof Error ? verifyError.message : "Unable to reset password");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const sendCode = async (resend = false) => {
+    if (!validEmail) {
+      setError("Please start from the login page with a valid email.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      if (resend) {
+        await passwordResetResend(email);
+      } else {
+        await passwordResetStart(email);
+      }
+      setMessage("Verification code sent.");
+    } catch (requestError) {
+      setError(requestError instanceof Error ? requestError.message : "Unable to send code");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="verify-email-page">
+      <AuthTopBar />
+      <div className="verify-email-shell">
+        <section className="verify-email-left-pane" aria-label="Password reset panel">
+          <div className="verify-email-content">
+            <p className="verify-email-title">Reset Password</p>
+            <h1 className="verify-email-hero">Enter your reset code</h1>
+            <p className="verify-email-copy">{validEmail ? `Code will be sent to ${email}` : "Start from login to reset password."}</p>
+            <form className="verify-email-form" onSubmit={handleVerify}>
+              <div className="vrm-field verify-email-field">
+                <label className="vrm-label" htmlFor="reset-code">Code</label>
+                <input id="reset-code" className="vrm-input" value={code} onChange={(e) => setCode(e.target.value)} />
+              </div>
+              <div className="vrm-field verify-email-field">
+                <label className="vrm-label" htmlFor="reset-password">New password</label>
+                <input id="reset-password" className="vrm-input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+              </div>
+              <div className="vrm-field verify-email-field">
+                <label className="vrm-label" htmlFor="reset-confirm-password">Confirm password</label>
+                <input id="reset-confirm-password" className="vrm-input" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
+              </div>
+              {error ? <div className="verify-email-error">{error}</div> : null}
+              {message ? <div className="verify-email-message">{message}</div> : null}
+              <div className="verify-email-actions">
+                <button type="button" className="vrm-btn vrm-btn-secondary" onClick={() => sendCode(false)} disabled={loading}>Send code</button>
+                <button type="submit" className="vrm-btn vrm-btn-primary verify-email-submit" disabled={loading}>{loading ? "Submitting…" : "Reset password"}</button>
+              </div>
+            </form>
+            <div className="verify-email-resend-row">
+              <button type="button" className="verify-email-resend" onClick={() => sendCode(true)} disabled={loading}>Resend code</button>
+            </div>
+            <p className="verify-email-back-row"><Link to="/login" className="verify-email-link">Back to login</Link></p>
+          </div>
+        </section>
+        <aside className="verify-email-right-pane" aria-hidden="true" />
+      </div>
+    </div>
+  );
+};
+
+export default ResetPasswordPage;

--- a/frontend/src/features/auth/transport/contact.ts
+++ b/frontend/src/features/auth/transport/contact.ts
@@ -1,0 +1,45 @@
+export type ContactPayload = {
+  name: string;
+  email: string;
+  phone: string;
+  message: string;
+  attachments: File[];
+};
+
+export type ContactResult =
+  | { ok: true; message: string }
+  | { ok: false; status: number; message: string };
+
+export const submitContact = async (payload: ContactPayload): Promise<ContactResult> => {
+  const formData = new FormData();
+  formData.append("name", payload.name);
+  formData.append("email", payload.email);
+  formData.append("phone", payload.phone);
+  formData.append("message", payload.message);
+  payload.attachments.forEach((file) => formData.append("attachments", file));
+
+  const response = await fetch("/api/contact", {
+    method: "POST",
+    body: formData,
+  });
+
+  const data = await response.json().catch(() => ({}));
+  const message = typeof data?.message === "string"
+    ? data.message
+    : typeof data?.detail === "string"
+      ? data.detail
+      : "Unable to send your message. Please try again.";
+
+  if (!response.ok) {
+    return {
+      ok: false,
+      status: response.status,
+      message,
+    };
+  }
+
+  return {
+    ok: true,
+    message,
+  };
+};

--- a/frontend/src/features/auth/transport/passwordResetResend.ts
+++ b/frontend/src/features/auth/transport/passwordResetResend.ts
@@ -1,0 +1,22 @@
+export type PasswordResetResendResponse = {
+  ok: boolean;
+  expiresInSeconds: number;
+  resendCooldownSeconds: number;
+  resendsRemaining: number;
+};
+
+export const passwordResetResend = async (email: string): Promise<PasswordResetResendResponse> => {
+  const response = await fetch("/api/password-reset/resend", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ email: email.trim().toLowerCase() }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(errorBody?.detail ?? "Unable to resend reset code");
+  }
+
+  return response.json() as Promise<PasswordResetResendResponse>;
+};

--- a/frontend/src/features/auth/transport/passwordResetStart.ts
+++ b/frontend/src/features/auth/transport/passwordResetStart.ts
@@ -1,0 +1,22 @@
+export type PasswordResetStartResponse = {
+  ok: boolean;
+  email: string;
+  expiresInSeconds: number;
+  resendCooldownSeconds: number;
+};
+
+export const passwordResetStart = async (email: string): Promise<PasswordResetStartResponse> => {
+  const response = await fetch("/api/password-reset/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ email: email.trim().toLowerCase() }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(errorBody?.detail ?? "Unable to send reset code");
+  }
+
+  return response.json() as Promise<PasswordResetStartResponse>;
+};

--- a/frontend/src/features/auth/transport/passwordResetVerify.ts
+++ b/frontend/src/features/auth/transport/passwordResetVerify.ts
@@ -1,0 +1,22 @@
+export type PasswordResetVerifyResponse = { ok: boolean };
+
+export const passwordResetVerify = async (payload: {
+  email: string;
+  code: string;
+  password: string;
+  confirm_password: string;
+}): Promise<PasswordResetVerifyResponse> => {
+  const response = await fetch("/api/password-reset/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ ...payload, email: payload.email.trim().toLowerCase() }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(errorBody?.detail ?? "Unable to verify reset code");
+  }
+
+  return response.json() as Promise<PasswordResetVerifyResponse>;
+};

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -21,6 +21,10 @@ const LandingPage: React.FC = () => {
     navigate("/create-account");
   };
 
+  const goToContact = () => {
+    navigate("/contact");
+  };
+
   const capabilityAxisItems = landingCopy.capabilities.items
     .filter((item) => item !== "Dwell time")
     .slice(0, 3);
@@ -288,7 +292,7 @@ const LandingPage: React.FC = () => {
                   type="button"
                   className="btn landing-cta-btn landing-cta-node-secondary landing-assurance-cta"
                   data-testid="assurance-contact-us-cta"
-                  onClick={(e) => { e.preventDefault(); }}
+                  onClick={goToContact}
                 >
                   CONTACT US
                 </button>

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -117,6 +117,10 @@
   margin-top: 8px;
 }
 
+.settings-form-actions--spread {
+  justify-content: space-between;
+}
+
 @media (max-width: 900px) {
   .settings-field-row {
     grid-template-columns: 1fr;
@@ -130,5 +134,60 @@
   .settings-field-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+}
+
+
+.settings-form-message {
+  color: #8ad9a2;
+  font-size: 12px;
+}
+
+.settings-field-help {
+  color: var(--vrm-text-muted);
+  font-size: 12px;
+}
+
+.settings-password-group {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-account-header-actions {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.settings-unlock-chip {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(138, 217, 162, 0.4);
+  color: #8ad9a2;
+  font-size: 12px;
+}
+
+.settings-account-global-error,
+.settings-account-global-message {
+  padding: 0 20px 18px;
+}
+
+.settings-account-locked-layout .settings-field-row {
+  grid-template-columns: 160px minmax(0, 1fr);
+}
+
+@media (max-width: 900px) {
+  .settings-account-header-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .settings-account-locked-layout .settings-field-row {
+    grid-template-columns: 1fr;
   }
 }

--- a/frontend/src/features/settings/api/settingsApi.ts
+++ b/frontend/src/features/settings/api/settingsApi.ts
@@ -3,6 +3,9 @@ import type {
   AccessLevel,
   ManagedUser,
   PendingInvite,
+  SettingsUnlockStartResult,
+  SettingsUnlockVerifyResult,
+  SettingsUnlockResendResult,
   SettingsUser,
   UpdateMePayload,
 } from "../types";
@@ -17,24 +20,111 @@ export const getMe = async (): Promise<SettingsUser> => {
   return response.data.user;
 };
 
-export const verifyCurrentPassword = async (
-  email: string,
-  password: string,
-): Promise<void> => {
-  const response = await fetch("/api/login", {
+export const startSettingsUnlock = async (currentPassword: string): Promise<SettingsUnlockStartResult> => {
+  const response = await fetch("/api/settings/unlock/start", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",
-    body: JSON.stringify({ email: email.trim().toLowerCase(), password }),
+    body: JSON.stringify({ current_password: currentPassword }),
   });
 
   if (!response.ok) {
-    throw new Error("Incorrect password");
+    let message: string | undefined;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      message = data.detail;
+    } catch {
+      message = undefined;
+    }
+    return { ok: false, status: response.status, message };
   }
+
+  const data = await response.json() as {
+    ok: boolean;
+    expiresInSeconds: number;
+    resendCooldownSeconds: number;
+  };
+
+  return { ok: true, data };
 };
 
-export const updateMe = async (_payload: UpdateMePayload): Promise<void> => {
-  throw notImplementedError;
+export const resendSettingsUnlockCode = async (): Promise<SettingsUnlockResendResult> => {
+  const response = await fetch("/api/settings/unlock/resend", {
+    method: "POST",
+    credentials: "include",
+  });
+
+  if (!response.ok) {
+    let message: string | undefined;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      message = data.detail;
+    } catch {
+      message = undefined;
+    }
+    return { ok: false, status: response.status, message };
+  }
+
+  const data = await response.json() as {
+    ok: boolean;
+    expiresInSeconds: number;
+    resendCooldownSeconds: number;
+    resendsRemaining: number;
+  };
+  return { ok: true, data };
+};
+
+export const verifySettingsUnlockCode = async (code: string): Promise<SettingsUnlockVerifyResult> => {
+  const response = await fetch("/api/settings/unlock/verify", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ code: code.trim() }),
+  });
+
+  if (!response.ok) {
+    let message: string | undefined;
+    try {
+      const data = (await response.json()) as { detail?: string };
+      message = data.detail;
+    } catch {
+      message = undefined;
+    }
+    return { ok: false, status: response.status, message };
+  }
+
+  const data = await response.json() as {
+    ok: boolean;
+    unlockToken: string;
+    unlockExpiresInSeconds: number;
+  };
+
+  return { ok: true, data };
+};
+
+export const updateMe = async (payload: UpdateMePayload): Promise<SettingsUser> => {
+  const response = await fetch("/api/me", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = "Unable to save";
+    try {
+      const data = (await response.json()) as { detail?: string };
+      if (data.detail) {
+        message = data.detail;
+      }
+    } catch {
+      // noop
+    }
+    throw new Error(message);
+  }
+
+  const data = await response.json() as { user: SettingsUser };
+  return data.user;
 };
 
 export const updatePassword = async (_password: string): Promise<void> => {

--- a/frontend/src/features/settings/components/InviteUserModal.module.css
+++ b/frontend/src/features/settings/components/InviteUserModal.module.css
@@ -17,23 +17,9 @@
   background: var(--vrm-surface-secondary);
   color: var(--vrm-text-primary);
   border-color: var(--vrm-border-subtle);
-  color-scheme: dark;
 }
 
 .select:focus {
   outline: 1px solid var(--vrm-accent-blue);
   outline-offset: 0;
-}
-
-.select option {
-  background: var(--vrm-surface-secondary);
-  color: var(--vrm-text-primary);
-}
-
-.select option:checked {
-  background: var(--vrm-surface-tertiary, var(--vrm-hover));
-}
-
-.select option:hover {
-  background: var(--vrm-hover);
 }

--- a/frontend/src/features/settings/components/ReenterPasswordModal.tsx
+++ b/frontend/src/features/settings/components/ReenterPasswordModal.tsx
@@ -1,23 +1,33 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import styles from "./ReenterPasswordModal.module.css";
 
 type ReenterPasswordModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  onVerified: () => void;
-  onVerifyPassword: (password: string) => Promise<void>;
+  onVerified: (payload: { unlockToken: string; unlockExpiresInSeconds: number }) => void;
+  onStartUnlock: (password: string) => Promise<{ ok: true; resendCooldownSeconds: number } | { ok: false; message: string }>;
+  onVerifyCode: (code: string) => Promise<{ ok: true; unlockToken: string; unlockExpiresInSeconds: number } | { ok: false; message: string }>;
+  onResendCode: () => Promise<{ ok: true; resendCooldownSeconds: number } | { ok: false; message: string }>;
 };
+
+type UnlockStep = "password" | "code";
 
 const ReenterPasswordModal: React.FC<ReenterPasswordModalProps> = ({
   isOpen,
   onClose,
   onVerified,
-  onVerifyPassword,
+  onStartUnlock,
+  onVerifyCode,
+  onResendCode,
 }) => {
+  const [step, setStep] = useState<UnlockStep>("password");
   const [password, setPassword] = useState("");
+  const [code, setCode] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [cooldownRemaining, setCooldownRemaining] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
@@ -31,16 +41,32 @@ const ReenterPasswordModal: React.FC<ReenterPasswordModalProps> = ({
     return () => {
       document.body.style.overflow = previousOverflow;
     };
-  }, [isOpen]);
+  }, [isOpen, step]);
+
+  useEffect(() => {
+    if (cooldownRemaining <= 0) {
+      return;
+    }
+    const timer = window.setInterval(() => {
+      setCooldownRemaining((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [cooldownRemaining]);
+
+  const title = useMemo(() => (step === "password" ? "Unlock to edit" : "Enter verification code"), [step]);
 
   const handleClose = () => {
     setPassword("");
+    setCode("");
     setError(null);
+    setMessage(null);
+    setCooldownRemaining(0);
+    setStep("password");
     setIsSubmitting(false);
     onClose();
   };
 
-  const handleSubmit = async (event: React.FormEvent) => {
+  const handlePasswordSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!password || isSubmitting) {
       setError("Current password is required");
@@ -49,15 +75,59 @@ const ReenterPasswordModal: React.FC<ReenterPasswordModalProps> = ({
 
     setIsSubmitting(true);
     setError(null);
-    try {
-      await onVerifyPassword(password);
-      setPassword("");
-      onVerified();
-    } catch (verifyError) {
-      setError(verifyError instanceof Error ? verifyError.message : "Unable to verify password");
-    } finally {
+    setMessage(null);
+
+    const result = await onStartUnlock(password);
+    if (!result.ok) {
+      setError(result.message);
       setIsSubmitting(false);
+      return;
     }
+
+    setStep("code");
+    setPassword("");
+    setCooldownRemaining(result.resendCooldownSeconds);
+    setMessage("We sent a 6-digit code to your account email.");
+    setIsSubmitting(false);
+  };
+
+  const handleCodeSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!/^\d{6}$/.test(code.trim()) || isSubmitting) {
+      setError("Enter your 6-digit verification code.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setMessage(null);
+
+    const result = await onVerifyCode(code);
+    if (!result.ok) {
+      setError(result.message);
+      setIsSubmitting(false);
+      return;
+    }
+
+    setCode("");
+    onVerified({ unlockToken: result.unlockToken, unlockExpiresInSeconds: result.unlockExpiresInSeconds });
+  };
+
+  const handleResend = async () => {
+    if (cooldownRemaining > 0 || isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    const result = await onResendCode();
+    if (!result.ok) {
+      setError(result.message);
+      setIsSubmitting(false);
+      return;
+    }
+    setCooldownRemaining(result.resendCooldownSeconds);
+    setMessage("A new verification code was sent.");
+    setIsSubmitting(false);
   };
 
   if (!isOpen) {
@@ -66,33 +136,69 @@ const ReenterPasswordModal: React.FC<ReenterPasswordModalProps> = ({
 
   return (
     <div className={styles.backdrop}>
-      <div className={`vrm-card ${styles.modal}`} role="dialog" aria-modal="true" aria-label="Enter password">
+      <div className={`vrm-card ${styles.modal}`} role="dialog" aria-modal="true" aria-label={title}>
         <div className="vrm-card-header">
-          <h3 className="vrm-card-title">Enter password</h3>
+          <h3 className="vrm-card-title">{title}</h3>
         </div>
         <div className="vrm-card-body">
-          <form onSubmit={handleSubmit} className="settings-form-grid">
-            <div className="settings-form-field">
-              <label className="settings-form-label" htmlFor="current-password">Current password</label>
-              <input
-                id="current-password"
-                ref={inputRef}
-                className="settings-input"
-                type="password"
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-              />
-            </div>
-            {error ? <div className="settings-form-error">{error}</div> : null}
-            <div className="settings-form-actions">
-              <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleClose}>
-                Cancel
-              </button>
-              <button type="submit" className="vrm-btn vrm-btn-sm" disabled={isSubmitting}>
-                {isSubmitting ? "Verifying..." : "Continue"}
-              </button>
-            </div>
-          </form>
+          {step === "password" ? (
+            <form onSubmit={handlePasswordSubmit} className="settings-form-grid">
+              <div className="settings-form-field">
+                <label className="settings-form-label" htmlFor="current-password">Current password</label>
+                <input
+                  id="current-password"
+                  ref={inputRef}
+                  className="settings-input"
+                  type="password"
+                  value={password}
+                  onChange={(event) => setPassword(event.target.value)}
+                />
+              </div>
+              {error ? <div className="settings-form-error">{error}</div> : null}
+              <div className="settings-form-actions">
+                <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleClose}>
+                  Cancel
+                </button>
+                <button type="submit" className="vrm-btn vrm-btn-sm" disabled={isSubmitting}>
+                  {isSubmitting ? "Verifying..." : "Continue"}
+                </button>
+              </div>
+            </form>
+          ) : (
+            <form onSubmit={handleCodeSubmit} className="settings-form-grid">
+              <div className="settings-form-field">
+                <label className="settings-form-label" htmlFor="unlock-code">Verification code</label>
+                <input
+                  id="unlock-code"
+                  ref={inputRef}
+                  className="settings-input"
+                  type="text"
+                  inputMode="numeric"
+                  value={code}
+                  onChange={(event) => setCode(event.target.value.replace(/\D/g, "").slice(0, 6))}
+                  placeholder="123456"
+                />
+              </div>
+              {message ? <div className="settings-form-message">{message}</div> : null}
+              {error ? <div className="settings-form-error">{error}</div> : null}
+              <div className="settings-form-actions settings-form-actions--spread">
+                <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleClose}>
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="vrm-btn vrm-btn-secondary vrm-btn-sm"
+                  onClick={handleResend}
+                  disabled={cooldownRemaining > 0 || isSubmitting}
+                >
+                  {cooldownRemaining > 0 ? `Resend in ${cooldownRemaining}s` : "Resend code"}
+                </button>
+                <button type="submit" className="vrm-btn vrm-btn-sm" disabled={isSubmitting}>
+                  {isSubmitting ? "Unlocking..." : "Unlock"}
+                </button>
+              </div>
+            </form>
+          )}
         </div>
       </div>
     </div>

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import {
   getMe,
@@ -7,11 +7,14 @@ import {
   updateMe,
   verifySettingsUnlockCode,
 } from "../api/settingsApi";
+import EditableFieldRow from "../components/EditableFieldRow";
 import ReenterPasswordModal from "../components/ReenterPasswordModal";
 import SettingsFrame from "../components/SettingsFrame";
 import SettingsPageHeader from "../components/SettingsPageHeader";
 import type { SettingsUser } from "../types";
 import "../SettingsPages.css";
+
+type RowId = "name" | "phone" | "password" | null;
 
 type DraftState = {
   name: string;
@@ -56,6 +59,7 @@ const MyAccountPage: React.FC = () => {
   const [unlockExpiresAt, setUnlockExpiresAt] = useState<number | null>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [activeEditingRowId, setActiveEditingRowId] = useState<RowId>(null);
   const [errors, setErrors] = useState<FormErrorState>({});
   const [drafts, setDrafts] = useState<DraftState>({
     name: "",
@@ -69,17 +73,11 @@ const MyAccountPage: React.FC = () => {
       try {
         const me = await getMe();
         setUser(me);
-        setDrafts({
-          name: me.name,
-          phone: me.phone ?? "",
-          password: "",
-          confirmPassword: "",
-        });
+        setDrafts({ name: me.name, phone: me.phone ?? "", password: "", confirmPassword: "" });
       } catch (error) {
         setLoadingError(error instanceof Error ? error.message : "Unable to load account");
       }
     };
-
     load();
   }, []);
 
@@ -92,41 +90,22 @@ const MyAccountPage: React.FC = () => {
         setIsUnlocked(false);
         setUnlockToken(null);
         setUnlockExpiresAt(null);
+        setActiveEditingRowId(null);
         setErrors((prev) => ({ ...prev, form: "Editing lock expired. Unlock again to continue." }));
       }
     }, 1000);
     return () => window.clearInterval(timer);
   }, [isUnlocked, unlockExpiresAt]);
 
-  useEffect(() => {
-    return () => {
-      setIsUnlocked(false);
-      setUnlockToken(null);
-      setUnlockExpiresAt(null);
-    };
-  }, []);
-
-  const unlockTimeLeftLabel = useMemo(() => {
-    if (!isUnlocked || !unlockExpiresAt) {
-      return null;
-    }
-    const seconds = Math.max(0, Math.floor((unlockExpiresAt - Date.now()) / 1000));
-    return `${seconds}s`;
-  }, [isUnlocked, unlockExpiresAt]);
-
   const resetDrafts = (nextUser: SettingsUser) => {
-    setDrafts({
-      name: nextUser.name,
-      phone: nextUser.phone ?? "",
-      password: "",
-      confirmPassword: "",
-    });
+    setDrafts({ name: nextUser.name, phone: nextUser.phone ?? "", password: "", confirmPassword: "" });
   };
 
   const relock = (nextUser?: SettingsUser) => {
     setIsUnlocked(false);
     setUnlockToken(null);
     setUnlockExpiresAt(null);
+    setActiveEditingRowId(null);
     setErrors({});
     if (nextUser) {
       resetDrafts(nextUser);
@@ -135,25 +114,47 @@ const MyAccountPage: React.FC = () => {
     }
   };
 
-  const handleSave = async () => {
-    if (!user) {
+  const requestEdit = (rowId: Exclude<RowId, null>) => {
+    if (!isUnlocked) {
+      setIsUnlockOpen(true);
+      return;
+    }
+    setSaveMessage(null);
+    setErrors({});
+    setActiveEditingRowId(rowId);
+    if (rowId === "password") {
+      setDrafts((prev) => ({ ...prev, password: "", confirmPassword: "" }));
+    }
+  };
+
+  const handleSave = async (rowId: Exclude<RowId, null>) => {
+    if (!user || !unlockToken) {
+      setErrors({ form: "Unlock required before saving" });
       return;
     }
 
     const nextErrors: FormErrorState = {};
-    const trimmedName = drafts.name.trim();
-    const trimmedPhone = drafts.phone.trim();
+    const payload: Record<string, string> = { unlock_token: unlockToken };
 
-    if (!trimmedName) {
-      nextErrors.name = "This field is required";
+    if (rowId === "name") {
+      const trimmedName = drafts.name.trim();
+      if (!trimmedName) {
+        nextErrors.name = "This field is required";
+      } else {
+        payload.name = trimmedName;
+      }
     }
 
-    if (trimmedPhone && !PHONE_RE.test(trimmedPhone)) {
-      nextErrors.phone = "Phone must be in international format (e.g. +447700900123)";
+    if (rowId === "phone") {
+      const trimmedPhone = drafts.phone.trim();
+      if (trimmedPhone && !PHONE_RE.test(trimmedPhone)) {
+        nextErrors.phone = "Phone must be in international format (e.g. +447700900123)";
+      } else {
+        payload.phone = trimmedPhone;
+      }
     }
 
-    const isPasswordProvided = drafts.password.length > 0 || drafts.confirmPassword.length > 0;
-    if (isPasswordProvided) {
+    if (rowId === "password") {
       if (!drafts.password || !drafts.confirmPassword) {
         nextErrors.password = "Password and confirm password are required";
       } else {
@@ -164,27 +165,19 @@ const MyAccountPage: React.FC = () => {
           nextErrors.confirmPassword = "Passwords do not match";
         }
       }
-    }
-
-    if (!unlockToken) {
-      nextErrors.form = "Unlock required before saving";
+      payload.password = drafts.password;
+      payload.confirm_password = drafts.confirmPassword;
     }
 
     setErrors(nextErrors);
-    setSaveMessage(null);
     if (Object.keys(nextErrors).length > 0) {
       return;
     }
 
     setSaving(true);
+    setSaveMessage(null);
     try {
-      const updatedUser = await updateMe({
-        name: trimmedName,
-        phone: trimmedPhone,
-        password: drafts.password || undefined,
-        confirm_password: drafts.confirmPassword || undefined,
-        unlock_token: unlockToken,
-      });
+      const updatedUser = await updateMe(payload);
       setUser(updatedUser);
       setSaveMessage("Account updated successfully.");
       relock(updatedUser);
@@ -200,25 +193,11 @@ const MyAccountPage: React.FC = () => {
   };
 
   if (loadingError) {
-    return (
-      <SettingsFrame>
-        <SettingsPageHeader title="My Account" />
-        <div className="vrm-card">
-          <div className="vrm-card-body">{loadingError}</div>
-        </div>
-      </SettingsFrame>
-    );
+    return <SettingsFrame><SettingsPageHeader title="My Account" /><div className="vrm-card"><div className="vrm-card-body">{loadingError}</div></div></SettingsFrame>;
   }
 
   if (!user) {
-    return (
-      <SettingsFrame>
-        <SettingsPageHeader title="My Account" />
-        <div className="vrm-card">
-          <div className="vrm-card-body">Loading account…</div>
-        </div>
-      </SettingsFrame>
-    );
+    return <SettingsFrame><SettingsPageHeader title="My Account" /><div className="vrm-card"><div className="vrm-card-body">Loading account…</div></div></SettingsFrame>;
   }
 
   return (
@@ -228,42 +207,31 @@ const MyAccountPage: React.FC = () => {
         action={(
           <div className="settings-account-header-actions">
             {!isUnlocked ? (
-              <button className="vrm-btn vrm-btn-sm" onClick={() => setIsUnlockOpen(true)}>
-                Unlock to edit
-              </button>
+              <button className="vrm-btn vrm-btn-sm" onClick={() => setIsUnlockOpen(true)}>Unlock to edit</button>
             ) : (
-              <>
-                <span className="settings-unlock-chip" aria-live="polite">Unlocked {unlockTimeLeftLabel ? `(${unlockTimeLeftLabel})` : ""}</span>
-                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => relock()}>
-                  Cancel / Lock
-                </button>
-                <button className="vrm-btn vrm-btn-sm" onClick={handleSave} disabled={saving}>
-                  {saving ? "Saving..." : "Save"}
-                </button>
-              </>
+              <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => relock()}>Cancel / Lock</button>
             )}
           </div>
         )}
       />
       <div className="vrm-card">
         <div className="vrm-card-body settings-account-card-body settings-account-locked-layout">
-          <div className="settings-field-row">
-            <div className="settings-field-label">Username</div>
-            <div className="settings-field-main">
-              {!isUnlocked ? (
-                <div className="settings-field-value">{user.name}</div>
-              ) : (
-                <>
-                  <input
-                    className="settings-input"
-                    value={drafts.name}
-                    onChange={(event) => setDrafts((prev) => ({ ...prev, name: event.target.value }))}
-                  />
-                  {errors.name ? <div className="settings-inline-error">{errors.name}</div> : null}
-                </>
-              )}
-            </div>
-          </div>
+          <EditableFieldRow
+            label="Username"
+            displayValue={user.name}
+            value={drafts.name}
+            isEditing={activeEditingRowId === "name"}
+            isSaving={saving}
+            error={errors.name}
+            onEdit={() => requestEdit("name")}
+            onCancel={() => {
+              setDrafts((prev) => ({ ...prev, name: user.name }));
+              setActiveEditingRowId(null);
+              setErrors({});
+            }}
+            onSave={() => handleSave("name")}
+            onChange={(value) => setDrafts((prev) => ({ ...prev, name: value }))}
+          />
 
           <div className="settings-field-row">
             <div className="settings-field-label">Email</div>
@@ -273,49 +241,45 @@ const MyAccountPage: React.FC = () => {
             </div>
           </div>
 
-          <div className="settings-field-row">
-            <div className="settings-field-label">Phone</div>
-            <div className="settings-field-main">
-              {!isUnlocked ? (
-                <div className="settings-field-value">{maskPhone(user.phone)}</div>
-              ) : (
-                <>
-                  <input
-                    className="settings-input"
-                    value={drafts.phone}
-                    onChange={(event) => setDrafts((prev) => ({ ...prev, phone: event.target.value }))}
-                    placeholder="+447700900123"
-                  />
-                  {errors.phone ? <div className="settings-inline-error">{errors.phone}</div> : null}
-                </>
-              )}
-            </div>
-          </div>
+          <EditableFieldRow
+            label="Phone"
+            displayValue={maskPhone(user.phone)}
+            value={drafts.phone}
+            isEditing={activeEditingRowId === "phone"}
+            isSaving={saving}
+            error={errors.phone}
+            onEdit={() => requestEdit("phone")}
+            onCancel={() => {
+              setDrafts((prev) => ({ ...prev, phone: user.phone ?? "" }));
+              setActiveEditingRowId(null);
+              setErrors({});
+            }}
+            onSave={() => handleSave("phone")}
+            onChange={(value) => setDrafts((prev) => ({ ...prev, phone: value }))}
+          />
 
           <div className="settings-field-row">
             <div className="settings-field-label">Password</div>
             <div className="settings-field-main">
-              {!isUnlocked ? (
+              {activeEditingRowId !== "password" ? (
                 <div className="settings-field-value">••••••••</div>
               ) : (
                 <div className="settings-password-group">
-                  <input
-                    className="settings-input"
-                    type="password"
-                    value={drafts.password}
-                    onChange={(event) => setDrafts((prev) => ({ ...prev, password: event.target.value }))}
-                    placeholder="New password"
-                  />
-                  <input
-                    className="settings-input"
-                    type="password"
-                    value={drafts.confirmPassword}
-                    onChange={(event) => setDrafts((prev) => ({ ...prev, confirmPassword: event.target.value }))}
-                    placeholder="Confirm new password"
-                  />
+                  <input className="settings-input" type="password" value={drafts.password} onChange={(e) => setDrafts((prev) => ({ ...prev, password: e.target.value }))} placeholder="New password" />
+                  <input className="settings-input" type="password" value={drafts.confirmPassword} onChange={(e) => setDrafts((prev) => ({ ...prev, confirmPassword: e.target.value }))} placeholder="Confirm new password" />
                   {errors.password ? <div className="settings-inline-error">{errors.password}</div> : null}
                   {errors.confirmPassword ? <div className="settings-inline-error">{errors.confirmPassword}</div> : null}
                 </div>
+              )}
+            </div>
+            <div className="settings-field-actions">
+              {activeEditingRowId !== "password" ? (
+                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => requestEdit("password")}>Edit</button>
+              ) : (
+                <>
+                  <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => { setActiveEditingRowId(null); setDrafts((prev) => ({ ...prev, password: "", confirmPassword: "" })); setErrors({}); }} disabled={saving}>Cancel</button>
+                  <button className="vrm-btn vrm-btn-sm" onClick={() => handleSave("password")} disabled={saving}>{saving ? "Saving..." : "Save"}</button>
+                </>
               )}
             </div>
           </div>
@@ -348,11 +312,7 @@ const MyAccountPage: React.FC = () => {
           if (!result.ok) {
             return { ok: false as const, message: result.message ?? "Unable to verify code" };
           }
-          return {
-            ok: true as const,
-            unlockToken: result.data.unlockToken,
-            unlockExpiresInSeconds: result.data.unlockExpiresInSeconds,
-          };
+          return { ok: true as const, unlockToken: result.data.unlockToken, unlockExpiresInSeconds: result.data.unlockExpiresInSeconds };
         }}
         onResendCode={async () => {
           const result = await resendSettingsUnlockCode();

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -2,23 +2,33 @@ import React, { useEffect, useMemo, useState } from "react";
 
 import {
   getMe,
-  isNotImplementedError,
+  resendSettingsUnlockCode,
+  startSettingsUnlock,
   updateMe,
-  updatePassword,
-  verifyCurrentPassword,
+  verifySettingsUnlockCode,
 } from "../api/settingsApi";
-import EditableFieldRow from "../components/EditableFieldRow";
 import ReenterPasswordModal from "../components/ReenterPasswordModal";
 import SettingsFrame from "../components/SettingsFrame";
 import SettingsPageHeader from "../components/SettingsPageHeader";
 import type { SettingsUser } from "../types";
 import "../SettingsPages.css";
 
-type EditableRowKey = "username" | "email" | "phone" | "password";
+type DraftState = {
+  name: string;
+  phone: string;
+  password: string;
+  confirmPassword: string;
+};
 
-type RowDraftState = Record<EditableRowKey, string>;
-type RowSavingState = Record<EditableRowKey, boolean>;
-type RowErrorState = Record<EditableRowKey, string | null>;
+type FormErrorState = {
+  name?: string;
+  phone?: string;
+  password?: string;
+  confirmPassword?: string;
+  form?: string;
+};
+
+const PHONE_RE = /^\+[1-9]\d{6,14}$/;
 
 const maskEmail = (email: string) => {
   const [localPart, domain] = email.split("@");
@@ -37,34 +47,22 @@ const maskPhone = (phone: string | null | undefined) => {
   return `${"•".repeat(Math.max(phone.length - 2, 4))}${visible}`;
 };
 
-const defaultSavingState: RowSavingState = {
-  username: false,
-  email: false,
-  phone: false,
-  password: false,
-};
-
-const defaultErrorState: RowErrorState = {
-  username: null,
-  email: null,
-  phone: null,
-  password: null,
-};
-
 const MyAccountPage: React.FC = () => {
   const [user, setUser] = useState<SettingsUser | null>(null);
   const [loadingError, setLoadingError] = useState<string | null>(null);
-  const [activeEditingRowId, setActiveEditingRowId] = useState<EditableRowKey | null>(null);
-  const [pendingRowToEdit, setPendingRowToEdit] = useState<EditableRowKey | null>(null);
-  const [isPasswordGateOpen, setIsPasswordGateOpen] = useState(false);
-  const [drafts, setDrafts] = useState<RowDraftState>({
-    username: "",
-    email: "",
+  const [isUnlockOpen, setIsUnlockOpen] = useState(false);
+  const [isUnlocked, setIsUnlocked] = useState(false);
+  const [unlockToken, setUnlockToken] = useState<string | null>(null);
+  const [unlockExpiresAt, setUnlockExpiresAt] = useState<number | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<FormErrorState>({});
+  const [drafts, setDrafts] = useState<DraftState>({
+    name: "",
     phone: "",
     password: "",
+    confirmPassword: "",
   });
-  const [saving, setSaving] = useState<RowSavingState>(defaultSavingState);
-  const [errors, setErrors] = useState<RowErrorState>(defaultErrorState);
 
   useEffect(() => {
     const load = async () => {
@@ -72,10 +70,10 @@ const MyAccountPage: React.FC = () => {
         const me = await getMe();
         setUser(me);
         setDrafts({
-          username: me.name,
-          email: me.email,
+          name: me.name,
           phone: me.phone ?? "",
           password: "",
+          confirmPassword: "",
         });
       } catch (error) {
         setLoadingError(error instanceof Error ? error.message : "Unable to load account");
@@ -85,119 +83,121 @@ const MyAccountPage: React.FC = () => {
     load();
   }, []);
 
-  const requestEdit = (rowId: EditableRowKey) => {
-    if (!user) {
+  useEffect(() => {
+    if (!isUnlocked || !unlockExpiresAt) {
       return;
     }
-    setErrors((prev) => ({ ...prev, [rowId]: null }));
-    setPendingRowToEdit(rowId);
-    setIsPasswordGateOpen(true);
-  };
+    const timer = window.setInterval(() => {
+      if (Date.now() >= unlockExpiresAt) {
+        setIsUnlocked(false);
+        setUnlockToken(null);
+        setUnlockExpiresAt(null);
+        setErrors((prev) => ({ ...prev, form: "Editing lock expired. Unlock again to continue." }));
+      }
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [isUnlocked, unlockExpiresAt]);
 
-  const beginEditingApprovedRow = () => {
-    if (!user || !pendingRowToEdit) {
-      return;
+  useEffect(() => {
+    return () => {
+      setIsUnlocked(false);
+      setUnlockToken(null);
+      setUnlockExpiresAt(null);
+    };
+  }, []);
+
+  const unlockTimeLeftLabel = useMemo(() => {
+    if (!isUnlocked || !unlockExpiresAt) {
+      return null;
     }
+    const seconds = Math.max(0, Math.floor((unlockExpiresAt - Date.now()) / 1000));
+    return `${seconds}s`;
+  }, [isUnlocked, unlockExpiresAt]);
 
-    const rowId = pendingRowToEdit;
-    setDrafts((prev) => ({
-      ...prev,
-      username: user.name,
-      email: user.email,
-      phone: user.phone ?? "",
-      password: rowId === "password" ? "" : prev.password,
-    }));
-    setActiveEditingRowId(rowId);
-    setPendingRowToEdit(null);
-    setIsPasswordGateOpen(false);
-  };
-
-  const cancelEditing = (rowId: EditableRowKey) => {
-    if (!user) {
-      return;
-    }
-
-    setErrors((prev) => ({ ...prev, [rowId]: null }));
-    setDrafts((prev) => ({
-      ...prev,
-      username: user.name,
-      email: user.email,
-      phone: user.phone ?? "",
+  const resetDrafts = (nextUser: SettingsUser) => {
+    setDrafts({
+      name: nextUser.name,
+      phone: nextUser.phone ?? "",
       password: "",
-    }));
-    setActiveEditingRowId((prev) => (prev === rowId ? null : prev));
+      confirmPassword: "",
+    });
   };
 
-  const handleSave = async (rowId: EditableRowKey) => {
+  const relock = (nextUser?: SettingsUser) => {
+    setIsUnlocked(false);
+    setUnlockToken(null);
+    setUnlockExpiresAt(null);
+    setErrors({});
+    if (nextUser) {
+      resetDrafts(nextUser);
+    } else if (user) {
+      resetDrafts(user);
+    }
+  };
+
+  const handleSave = async () => {
     if (!user) {
       return;
     }
 
-    const nextValue = drafts[rowId].trim();
-    if (rowId !== "phone" && !nextValue) {
-      setErrors((prev) => ({ ...prev, [rowId]: "This field is required" }));
+    const nextErrors: FormErrorState = {};
+    const trimmedName = drafts.name.trim();
+    const trimmedPhone = drafts.phone.trim();
+
+    if (!trimmedName) {
+      nextErrors.name = "This field is required";
+    }
+
+    if (trimmedPhone && !PHONE_RE.test(trimmedPhone)) {
+      nextErrors.phone = "Phone must be in international format (e.g. +447700900123)";
+    }
+
+    const isPasswordProvided = drafts.password.length > 0 || drafts.confirmPassword.length > 0;
+    if (isPasswordProvided) {
+      if (!drafts.password || !drafts.confirmPassword) {
+        nextErrors.password = "Password and confirm password are required";
+      } else {
+        if (drafts.password.length < 8) {
+          nextErrors.password = "Password must be at least 8 characters";
+        }
+        if (drafts.password !== drafts.confirmPassword) {
+          nextErrors.confirmPassword = "Passwords do not match";
+        }
+      }
+    }
+
+    if (!unlockToken) {
+      nextErrors.form = "Unlock required before saving";
+    }
+
+    setErrors(nextErrors);
+    setSaveMessage(null);
+    if (Object.keys(nextErrors).length > 0) {
       return;
     }
 
-    setSaving((prev) => ({ ...prev, [rowId]: true }));
-    setErrors((prev) => ({ ...prev, [rowId]: null }));
-
+    setSaving(true);
     try {
-      if (rowId === "password") {
-        await updatePassword(nextValue);
-      } else if (rowId === "username") {
-        await updateMe({ name: nextValue });
-      } else if (rowId === "email") {
-        await updateMe({ email: nextValue });
-      } else {
-        await updateMe({ phone: nextValue });
-      }
-
-      setUser((prev) => {
-        if (!prev || rowId === "password") {
-          return prev;
-        }
-        if (rowId === "username") {
-          return { ...prev, name: nextValue };
-        }
-        if (rowId === "email") {
-          return { ...prev, email: nextValue };
-        }
-        return { ...prev, phone: nextValue };
+      const updatedUser = await updateMe({
+        name: trimmedName,
+        phone: trimmedPhone,
+        password: drafts.password || undefined,
+        confirm_password: drafts.confirmPassword || undefined,
+        unlock_token: unlockToken,
       });
-      setActiveEditingRowId(null);
-      setDrafts((prev) => ({ ...prev, password: "" }));
+      setUser(updatedUser);
+      setSaveMessage("Account updated successfully.");
+      relock(updatedUser);
     } catch (error) {
-      if (isNotImplementedError(error)) {
-        setErrors((prev) => ({ ...prev, [rowId]: "Not implemented yet" }));
-      } else {
-        setErrors((prev) => ({
-          ...prev,
-          [rowId]: error instanceof Error ? error.message : "Unable to save",
-        }));
+      const message = error instanceof Error ? error.message : "Unable to save";
+      if (message.toLowerCase().includes("unlock")) {
+        relock();
       }
+      setErrors((prev) => ({ ...prev, form: message }));
     } finally {
-      setSaving((prev) => ({ ...prev, [rowId]: false }));
+      setSaving(false);
     }
   };
-
-  const rows = useMemo(() => {
-    if (!user) {
-      return [] as Array<{
-        key: EditableRowKey;
-        label: string;
-        displayValue: string;
-        type?: "text" | "email" | "tel" | "password";
-      }>;
-    }
-
-    return [
-      { key: "username", label: "Username", displayValue: user.name, type: "text" as const },
-      { key: "email", label: "Email", displayValue: maskEmail(user.email), type: "email" as const },
-      { key: "phone", label: "Phone", displayValue: maskPhone(user.phone), type: "tel" as const },
-      { key: "password", label: "Password", displayValue: "••••••••", type: "password" as const },
-    ];
-  }, [user]);
 
   if (loadingError) {
     return (
@@ -223,35 +223,144 @@ const MyAccountPage: React.FC = () => {
 
   return (
     <SettingsFrame>
-      <SettingsPageHeader title="My Account" />
+      <SettingsPageHeader
+        title="My Account"
+        action={(
+          <div className="settings-account-header-actions">
+            {!isUnlocked ? (
+              <button className="vrm-btn vrm-btn-sm" onClick={() => setIsUnlockOpen(true)}>
+                Unlock to edit
+              </button>
+            ) : (
+              <>
+                <span className="settings-unlock-chip" aria-live="polite">Unlocked {unlockTimeLeftLabel ? `(${unlockTimeLeftLabel})` : ""}</span>
+                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => relock()}>
+                  Cancel / Lock
+                </button>
+                <button className="vrm-btn vrm-btn-sm" onClick={handleSave} disabled={saving}>
+                  {saving ? "Saving..." : "Save"}
+                </button>
+              </>
+            )}
+          </div>
+        )}
+      />
       <div className="vrm-card">
-        <div className="vrm-card-body settings-account-card-body">
-          {rows.map((row) => (
-            <EditableFieldRow
-              key={row.key}
-              label={row.label}
-              displayValue={row.displayValue}
-              value={drafts[row.key]}
-              type={row.type}
-              isEditing={activeEditingRowId === row.key}
-              isSaving={saving[row.key]}
-              error={errors[row.key]}
-              onEdit={() => requestEdit(row.key)}
-              onCancel={() => cancelEditing(row.key)}
-              onSave={() => handleSave(row.key)}
-              onChange={(value) => setDrafts((prev) => ({ ...prev, [row.key]: value }))}
-            />
-          ))}
+        <div className="vrm-card-body settings-account-card-body settings-account-locked-layout">
+          <div className="settings-field-row">
+            <div className="settings-field-label">Username</div>
+            <div className="settings-field-main">
+              {!isUnlocked ? (
+                <div className="settings-field-value">{user.name}</div>
+              ) : (
+                <>
+                  <input
+                    className="settings-input"
+                    value={drafts.name}
+                    onChange={(event) => setDrafts((prev) => ({ ...prev, name: event.target.value }))}
+                  />
+                  {errors.name ? <div className="settings-inline-error">{errors.name}</div> : null}
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="settings-field-row">
+            <div className="settings-field-label">Email</div>
+            <div className="settings-field-main">
+              <div className="settings-field-value">{maskEmail(user.email)}</div>
+              <div className="settings-field-help">Email cannot be changed from My Account.</div>
+            </div>
+          </div>
+
+          <div className="settings-field-row">
+            <div className="settings-field-label">Phone</div>
+            <div className="settings-field-main">
+              {!isUnlocked ? (
+                <div className="settings-field-value">{maskPhone(user.phone)}</div>
+              ) : (
+                <>
+                  <input
+                    className="settings-input"
+                    value={drafts.phone}
+                    onChange={(event) => setDrafts((prev) => ({ ...prev, phone: event.target.value }))}
+                    placeholder="+447700900123"
+                  />
+                  {errors.phone ? <div className="settings-inline-error">{errors.phone}</div> : null}
+                </>
+              )}
+            </div>
+          </div>
+
+          <div className="settings-field-row">
+            <div className="settings-field-label">Password</div>
+            <div className="settings-field-main">
+              {!isUnlocked ? (
+                <div className="settings-field-value">••••••••</div>
+              ) : (
+                <div className="settings-password-group">
+                  <input
+                    className="settings-input"
+                    type="password"
+                    value={drafts.password}
+                    onChange={(event) => setDrafts((prev) => ({ ...prev, password: event.target.value }))}
+                    placeholder="New password"
+                  />
+                  <input
+                    className="settings-input"
+                    type="password"
+                    value={drafts.confirmPassword}
+                    onChange={(event) => setDrafts((prev) => ({ ...prev, confirmPassword: event.target.value }))}
+                    placeholder="Confirm new password"
+                  />
+                  {errors.password ? <div className="settings-inline-error">{errors.password}</div> : null}
+                  {errors.confirmPassword ? <div className="settings-inline-error">{errors.confirmPassword}</div> : null}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {errors.form ? <div className="settings-form-error settings-account-global-error">{errors.form}</div> : null}
+          {saveMessage ? <div className="settings-form-message settings-account-global-message">{saveMessage}</div> : null}
         </div>
       </div>
+
       <ReenterPasswordModal
-        isOpen={isPasswordGateOpen}
-        onClose={() => {
-          setIsPasswordGateOpen(false);
-          setPendingRowToEdit(null);
+        isOpen={isUnlockOpen}
+        onClose={() => setIsUnlockOpen(false)}
+        onVerified={({ unlockToken: verifiedUnlockToken, unlockExpiresInSeconds }) => {
+          setUnlockToken(verifiedUnlockToken);
+          setUnlockExpiresAt(Date.now() + (unlockExpiresInSeconds * 1000));
+          setIsUnlocked(true);
+          setIsUnlockOpen(false);
+          setErrors({});
+          setSaveMessage(null);
         }}
-        onVerified={beginEditingApprovedRow}
-        onVerifyPassword={(password) => verifyCurrentPassword(user.email, password)}
+        onStartUnlock={async (password) => {
+          const result = await startSettingsUnlock(password);
+          if (!result.ok) {
+            return { ok: false as const, message: result.message ?? "Unable to verify password" };
+          }
+          return { ok: true as const, resendCooldownSeconds: result.data.resendCooldownSeconds };
+        }}
+        onVerifyCode={async (code) => {
+          const result = await verifySettingsUnlockCode(code);
+          if (!result.ok) {
+            return { ok: false as const, message: result.message ?? "Unable to verify code" };
+          }
+          return {
+            ok: true as const,
+            unlockToken: result.data.unlockToken,
+            unlockExpiresInSeconds: result.data.unlockExpiresInSeconds,
+          };
+        }}
+        onResendCode={async () => {
+          const result = await resendSettingsUnlockCode();
+          if (!result.ok) {
+            return { ok: false as const, message: result.message ?? "Unable to resend code" };
+          }
+          return { ok: true as const, resendCooldownSeconds: result.data.resendCooldownSeconds };
+        }}
       />
     </SettingsFrame>
   );

--- a/frontend/src/features/settings/types.ts
+++ b/frontend/src/features/settings/types.ts
@@ -23,6 +23,42 @@ export type PendingInvite = {
 
 export type UpdateMePayload = {
   name?: string;
-  email?: string;
   phone?: string;
+  password?: string;
+  confirm_password?: string;
+  unlock_token: string;
 };
+
+export type SettingsUnlockStartResult =
+  | {
+      ok: true;
+      data: {
+        ok: boolean;
+        expiresInSeconds: number;
+        resendCooldownSeconds: number;
+      };
+    }
+  | { ok: false; status: number; message?: string };
+
+export type SettingsUnlockResendResult =
+  | {
+      ok: true;
+      data: {
+        ok: boolean;
+        expiresInSeconds: number;
+        resendCooldownSeconds: number;
+        resendsRemaining: number;
+      };
+    }
+  | { ok: false; status: number; message?: string };
+
+export type SettingsUnlockVerifyResult =
+  | {
+      ok: true;
+      data: {
+        ok: boolean;
+        unlockToken: string;
+        unlockExpiresInSeconds: number;
+      };
+    }
+  | { ok: false; status: number; message?: string };

--- a/frontend/src/pages/ContactPage.tsx
+++ b/frontend/src/pages/ContactPage.tsx
@@ -1,0 +1,1 @@
+export { default } from "../features/auth/ContactPage";

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,1 @@
+export { default } from "../features/auth/ResetPasswordPage";


### PR DESCRIPTION
### Motivation

- Provide a public contact form so visitors can send messages and optional attachments to the admin.
- Allow the marketing/landing CTA to navigate to a dedicated contact page.

### Description

- Added a new frontend contact UI under `frontend/src/features/auth/ContactPage.tsx` with styles in `ContactPage.css`, a page export `frontend/src/pages/ContactPage.tsx`, and client transport `frontend/src/features/auth/transport/contact.ts` that submits a `FormData` POST to `/api/contact` and supports file attachments.
- Registered the route and lazy-loaded page by updating `frontend/src/app/routes.tsx` and wired the Landing CTA to `navigate('/contact')` in `frontend/src/features/landing/LandingPage.tsx`.
- Implemented a backend API endpoint `POST /api/contact` in `backend/app/api/auth.py` that validates inputs, enforces limits (up to 3 attachments, 10MB each), checks allowed extensions/content-types, and base64-encodes attachments for outbound delivery.
- Added `ContactResponse` to `backend/app/models.py`, introduced `PostmarkAttachment` dataclass and `send_admin_contact_notification` helper in `backend/app/services/postmark_email.py`, and added dedicated error logging/handling for contact mail delivery.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69aad8fb6438833288800d4b1faef016)