### PR TITLE
Add multi-step password reset, Postmark admin handling, and UI/UX improvements

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -33,6 +33,7 @@ from backend.app.data.json_store import (
     save_pending_settings_unlocks,
     save_pending_signups,
     save_pending_password_resets,
+    load_pending_password_resets,
     save_users,
 )
 from backend.app.models import (
@@ -57,6 +58,8 @@ from backend.app.models import (
     PasswordResetResendResponse,
     PasswordResetVerifyRequest,
     PasswordResetVerifyResponse,
+    PasswordResetSetPasswordRequest,
+    PasswordResetSetPasswordResponse,
     SignupResendRequest,
     SignupResendResponse,
     SignupStartResponse,
@@ -88,6 +91,7 @@ PASSWORD_RESET_CODE_TTL_SECONDS = 15 * 60
 PASSWORD_RESET_MAX_VERIFY_ATTEMPTS = 5
 PASSWORD_RESET_RESEND_COOLDOWN_SECONDS = 30
 PASSWORD_RESET_MAX_RESENDS = 5
+PASSWORD_RESET_SESSION_TTL_SECONDS = 10 * 60
 
 SETTINGS_UNLOCK_CODE_TTL_SECONDS = 15 * 60
 SETTINGS_UNLOCK_MAX_VERIFY_ATTEMPTS = 5
@@ -234,6 +238,29 @@ def _raise_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
         raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
     logger.exception("signup.email.unknown_error request_id=%s", request_id)
     raise HTTPException(status_code=502, detail="Failed to send verification email.") from exc
+
+
+def _raise_password_reset_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
+    if isinstance(exc, PostmarkConfigurationError):
+        logger.error(
+            "password_reset.email.config_error request_id=%s has_server_token=%s has_from_email=%s detail=%s",
+            request_id,
+            bool(os.getenv("POSTMARK_SERVER_TOKEN", "").strip()),
+            bool(os.getenv("POSTMARK_FROM_EMAIL", "").strip()),
+            str(exc),
+        )
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if isinstance(exc, PostmarkDeliveryError):
+        logger.error(
+            "password_reset.email.delivery_error request_id=%s status_code=%s error_code=%s message=%s",
+            request_id,
+            exc.status_code,
+            exc.error_code,
+            exc.error_message,
+        )
+        raise HTTPException(status_code=502, detail="Failed to send reset code email.") from exc
+    logger.exception("password_reset.email.unknown_error request_id=%s", request_id)
+    raise HTTPException(status_code=502, detail="Failed to send reset code email.") from exc
 
 
 def _raise_contact_mail_delivery_error(exc: Exception, *, request_id: str) -> None:
@@ -872,7 +899,7 @@ async def password_reset_start(payload: PasswordResetStartRequest):
     try:
         send_password_reset_code_email(to_email=email, code=code)
     except Exception as exc:
-        _raise_mail_delivery_error(exc, request_id=request_id)
+        _raise_password_reset_mail_delivery_error(exc, request_id=request_id)
     save_pending_password_resets(password_resets)
     return PasswordResetStartResponse(ok=True, email=email, expiresInSeconds=PASSWORD_RESET_CODE_TTL_SECONDS, resendCooldownSeconds=PASSWORD_RESET_RESEND_COOLDOWN_SECONDS)
 
@@ -910,24 +937,17 @@ async def password_reset_resend(payload: PasswordResetResendRequest):
     try:
         send_password_reset_code_email(to_email=email, code=code)
     except Exception as exc:
-        _raise_mail_delivery_error(exc, request_id=request_id)
+        _raise_password_reset_mail_delivery_error(exc, request_id=request_id)
     save_pending_password_resets(password_resets)
     return PasswordResetResendResponse(ok=True, expiresInSeconds=PASSWORD_RESET_CODE_TTL_SECONDS, resendCooldownSeconds=PASSWORD_RESET_RESEND_COOLDOWN_SECONDS, resendsRemaining=max(PASSWORD_RESET_MAX_RESENDS - int(record["resend_count"]), 0))
 
 
-@router.post("/api/password-reset/verify", response_model=PasswordResetVerifyResponse)
+@router.post("/api/password-reset/verify-code", response_model=PasswordResetVerifyResponse)
 async def password_reset_verify(payload: PasswordResetVerifyRequest):
     email = _validate_email(payload.email)
     code = payload.code.strip()
     if not code:
         raise HTTPException(status_code=422, detail="Verification code is required")
-    if not payload.password:
-        raise HTTPException(status_code=422, detail="Password is required")
-    if len(payload.password) < 8:
-        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
-    if payload.password != payload.confirm_password:
-        raise HTTPException(status_code=422, detail="Passwords do not match")
-
     password_resets, now, modified = _load_password_resets_pruned()
     record = password_resets.get(email)
     if not record:
@@ -951,6 +971,43 @@ async def password_reset_verify(payload: PasswordResetVerifyRequest):
         save_pending_password_resets(password_resets)
         raise HTTPException(status_code=400, detail="Invalid verification code.")
 
+    reset_token = secrets.token_urlsafe(24)
+    record["reset_token_hash"] = hash_session_token(reset_token)
+    record["reset_expires_at"] = _to_iso(now + timedelta(seconds=PASSWORD_RESET_SESSION_TTL_SECONDS))
+    record["updated_at"] = _to_iso(now)
+    save_pending_password_resets(password_resets)
+    return PasswordResetVerifyResponse(ok=True, resetToken=reset_token, resetExpiresInSeconds=PASSWORD_RESET_SESSION_TTL_SECONDS)
+
+
+@router.post("/api/password-reset/set-password", response_model=PasswordResetSetPasswordResponse)
+async def password_reset_set_password(payload: PasswordResetSetPasswordRequest):
+    email = _validate_email(payload.email)
+    reset_token = payload.reset_token.strip()
+    if not reset_token:
+        raise HTTPException(status_code=422, detail="Reset token is required")
+    if not payload.password:
+        raise HTTPException(status_code=422, detail="Password is required")
+    if len(payload.password) < 8:
+        raise HTTPException(status_code=422, detail="Password must be at least 8 characters")
+    if payload.password != payload.confirm_password:
+        raise HTTPException(status_code=422, detail="Passwords do not match")
+
+    password_resets, now, modified = _load_password_resets_pruned()
+    record = password_resets.get(email)
+    if not record:
+        if modified:
+            save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=404, detail="No pending password reset found for this email.")
+
+    reset_expires_at = _parse_iso(record.get("reset_expires_at"))
+    if not reset_expires_at or reset_expires_at <= now:
+        del password_resets[email]
+        save_pending_password_resets(password_resets)
+        raise HTTPException(status_code=410, detail="Reset session expired. Restart password reset.")
+
+    if hash_session_token(reset_token) != str(record.get("reset_token_hash", "")):
+        raise HTTPException(status_code=401, detail="Invalid reset session. Restart password reset.")
+
     users = load_users()
     username, user_data = find_user_by_email(users, email)
     if username and user_data:
@@ -962,7 +1019,13 @@ async def password_reset_verify(payload: PasswordResetVerifyRequest):
 
     del password_resets[email]
     save_pending_password_resets(password_resets)
-    return PasswordResetVerifyResponse(ok=True)
+    return PasswordResetSetPasswordResponse(ok=True)
+
+
+@router.post("/api/password-reset/verify", response_model=PasswordResetSetPasswordResponse)
+async def password_reset_verify_legacy(payload: PasswordResetSetPasswordRequest):
+    """Backward compatible endpoint for older clients."""
+    return await password_reset_set_password(payload)
 
 
 @router.post("/api/create-account", response_model=AuthUserResponse, status_code=201)
@@ -1043,4 +1106,3 @@ async def me(session_user: tuple[str, dict] = Depends(get_session_user)):
 @router.post("/api/logout", status_code=204)
 async def logout(response: Response):
     clear_auth_cookie(response)
-    load_pending_password_resets,

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -97,7 +97,7 @@ SETTINGS_UNLOCK_CODE_TTL_SECONDS = 15 * 60
 SETTINGS_UNLOCK_MAX_VERIFY_ATTEMPTS = 5
 SETTINGS_UNLOCK_RESEND_COOLDOWN_SECONDS = 30
 SETTINGS_UNLOCK_MAX_RESENDS = 5
-SETTINGS_UNLOCK_SESSION_SECONDS = 10 * 60
+SETTINGS_UNLOCK_SESSION_SECONDS = 5 * 60
 
 CONTACT_MAX_FILES = 3
 CONTACT_MAX_FILE_BYTES = 10 * 1024 * 1024
@@ -600,7 +600,8 @@ async def update_me(
     users[username] = existing
     save_users(users)
 
-    del challenges[challenge_key]
+    record["updated_at"] = _to_iso(now)
+    challenges[challenge_key] = record
     save_pending_settings_unlocks(challenges)
 
     return AuthUserResponse(user=_safe_auth_user(existing))

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -117,11 +117,22 @@ class PasswordResetResendResponse(BaseModel):
 class PasswordResetVerifyRequest(BaseModel):
     email: str
     code: str
+
+
+class PasswordResetVerifyResponse(BaseModel):
+    ok: bool
+    resetToken: str
+    resetExpiresInSeconds: int
+
+
+class PasswordResetSetPasswordRequest(BaseModel):
+    email: str
+    reset_token: str
     password: str
     confirm_password: str
 
 
-class PasswordResetVerifyResponse(BaseModel):
+class PasswordResetSetPasswordResponse(BaseModel):
     ok: bool
 
 

--- a/backend/app/services/postmark_email.py
+++ b/backend/app/services/postmark_email.py
@@ -45,7 +45,6 @@ class PostmarkDeliveryError(RuntimeError):
 class PostmarkConfig:
     server_token: str
     from_email: str
-    admin_notify_email: str
 
 
 @dataclass(frozen=True)
@@ -79,13 +78,11 @@ def _parse_postmark_error(body: str) -> tuple[int | None, str | None]:
 def _load_config() -> PostmarkConfig:
     server_token = os.getenv("POSTMARK_SERVER_TOKEN", "").strip()
     from_email = os.getenv("POSTMARK_FROM_EMAIL", "").strip()
-    admin_notify_email = os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()
     missing = [
         name
         for name, value in (
             ("POSTMARK_SERVER_TOKEN", server_token),
             ("POSTMARK_FROM_EMAIL", from_email),
-            ("ADMIN_NOTIFY_EMAIL", admin_notify_email),
         )
         if not value
     ]
@@ -97,8 +94,14 @@ def _load_config() -> PostmarkConfig:
     return PostmarkConfig(
         server_token=server_token,
         from_email=from_email,
-        admin_notify_email=admin_notify_email,
     )
+
+
+def _require_admin_notify_email() -> str:
+    admin_notify_email = os.getenv("ADMIN_NOTIFY_EMAIL", "").strip()
+    if not admin_notify_email:
+        raise PostmarkConfigurationError("Email service is not configured. Missing ADMIN_NOTIFY_EMAIL.")
+    return admin_notify_email
 
 
 def _postmark_send(*, token: str, payload: dict, from_email: str, to_email: str) -> None:
@@ -193,9 +196,10 @@ def send_verification_email(*, to_email: str, code: str) -> None:
 
 def send_admin_signup_notification(*, verified_email: str, name: str, username: str, timestamp: str) -> None:
     config = _load_config()
+    admin_notify_email = _require_admin_notify_email()
     payload = {
         "From": config.from_email,
-        "To": config.admin_notify_email,
+        "To": admin_notify_email,
         "Subject": f"New verified signup: {verified_email}",
         "TextBody": (
             "A new user has verified their email and completed signup.\n\n"
@@ -209,7 +213,7 @@ def send_admin_signup_notification(*, verified_email: str, name: str, username: 
         token=config.server_token,
         payload=payload,
         from_email=config.from_email,
-        to_email=config.admin_notify_email,
+        to_email=admin_notify_email,
     )
 
 
@@ -223,10 +227,11 @@ def send_admin_contact_notification(
     attachments: list[PostmarkAttachment] | None = None,
 ) -> None:
     config = _load_config()
+    admin_notify_email = _require_admin_notify_email()
     attachments_line = ", ".join(attachment_names) if attachment_names else "None"
     payload = {
         "From": config.from_email,
-        "To": config.admin_notify_email,
+        "To": admin_notify_email,
         "Subject": f"New contact submission: {name}",
         "TextBody": (
             "A new contact form submission has been received.\n\n"
@@ -253,7 +258,7 @@ def send_admin_contact_notification(
         token=config.server_token,
         payload=payload,
         from_email=config.from_email,
-        to_email=config.admin_notify_email,
+        to_email=admin_notify_email,
     )
 
 

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -44,6 +44,7 @@ const AppRoutes: React.FC = () => {
   const location = useLocation();
   const viewToken = getViewTokenFromLocation(location.search);
   const hasViewToken = Boolean(viewToken);
+  const isDemoRoute = location.pathname === "/demo" || location.pathname.startsWith("/demo/");
   const [isSessionChecked, setIsSessionChecked] = useState(hasViewToken);
 
   useEffect(() => {
@@ -81,13 +82,13 @@ const AppRoutes: React.FC = () => {
   };
 
   const isDemoSession = isDemoSessionActive();
-  const appMode: "public" | "authenticated" | "view_token" | "demo" = isLoggedIn
-    ? "authenticated"
-    : hasViewToken
+  const appMode: "public" | "authenticated" | "view_token" | "demo" = hasViewToken
       ? "view_token"
-      : isDemoSession
+      : (isDemoSession || isDemoRoute)
         ? "demo"
-        : "public";
+        : isLoggedIn
+          ? "authenticated"
+          : "public";
   const isAuthenticatedMode = appMode === "authenticated";
   const dashboardDataMode: DashboardDataMode = appMode === "authenticated"
     ? "authenticated"
@@ -190,7 +191,7 @@ const AppRoutes: React.FC = () => {
       <Route
         path="/"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
             lazyRoute(<LandingPage />)
           ) : appMode === "view_token" || appMode === "demo" ? (
             <Navigate to={appMode === "demo" ? appendParams("/demo/site-a/dashboard") : appendViewToken("/sites/all/dashboard")} replace />
@@ -203,7 +204,7 @@ const AppRoutes: React.FC = () => {
       <Route
         path="/create-account"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
             lazyRoute(<CreateAccountPage />)
           ) : (
             <Navigate to="/home" replace />
@@ -213,7 +214,7 @@ const AppRoutes: React.FC = () => {
       <Route
         path="/login"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
             lazyRoute(<LoginPage onLogin={handleLogin} />)
           ) : (
             <Navigate to="/home" replace />
@@ -223,7 +224,7 @@ const AppRoutes: React.FC = () => {
       <Route
         path="/verify-email"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
             lazyRoute(<VerifyEmailPage />)
           ) : (
             <Navigate to="/home" replace />
@@ -233,7 +234,27 @@ const AppRoutes: React.FC = () => {
       <Route
         path="/reset-password"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
+            lazyRoute(<ResetPasswordPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/reset-password/code"
+        element={
+          !isAuthenticatedMode ? (
+            lazyRoute(<ResetPasswordPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/reset-password/new"
+        element={
+          !isAuthenticatedMode ? (
             lazyRoute(<ResetPasswordPage />)
           ) : (
             <Navigate to="/home" replace />
@@ -243,7 +264,7 @@ const AppRoutes: React.FC = () => {
       <Route
         path="/contact"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
             lazyRoute(<ContactPage />)
           ) : (
             <Navigate to="/home" replace />
@@ -460,7 +481,7 @@ const AppRoutes: React.FC = () => {
       <Route
         path="*"
         element={
-          appMode === "public" ? (
+          !isAuthenticatedMode ? (
             <Navigate to="/" replace />
           ) : appMode === "view_token" || appMode === "demo" ? (
             <Navigate to={appMode === "demo" ? appendParams("/demo/site-a/dashboard") : appendViewToken("/sites/all/dashboard")} replace />

--- a/frontend/src/components/HeaderStatusStrip.tsx
+++ b/frontend/src/components/HeaderStatusStrip.tsx
@@ -57,16 +57,15 @@ const HeaderStatusStrip: React.FC<HeaderStatusStripProps> = ({ className, isAuth
         <span className="vrm-header-chip" title="Last updated timestamp">
           Last updated:{" "}
           <span className="vrm-header-chip-highlight">
-            {isAuthenticatedView ? <span aria-hidden="true">✕</span> : <RealtimeWaveIcon />} {" "}
-            {isAuthenticatedView ? <span style={{ color: "#ff6b6b" }}>NA</span> : "Realtime"}
+            {isAuthenticatedView ? <span style={{ color: "var(--vrm-text-muted)" }}>-</span> : <><RealtimeWaveIcon /> Realtime</>}
           </span>
         </span>
       </div>
       <span className="vrm-header-meta-divider" aria-hidden="true" />
       <div className="vrm-header-meta-group">
-        <span className="vrm-header-chip" title={isAuthenticatedView ? "No connected sites" : statusCopy[systemStatus]}>
+        <span className="vrm-header-chip" title={isAuthenticatedView ? "System status unavailable" : statusCopy[systemStatus]}>
           {isAuthenticatedView ? (
-            <span style={{ color: "var(--vrm-text-muted)" }}>0 Sites Connected</span>
+            <span style={{ color: "var(--vrm-text-muted)" }}>NA</span>
           ) : (
             <>
               <span

--- a/frontend/src/components/HeaderStatusStrip.tsx
+++ b/frontend/src/components/HeaderStatusStrip.tsx
@@ -3,15 +3,19 @@ import {
   useGlobalControls,
   SystemStatus,
 } from "../context/GlobalControlsContext";
+
 const statusCopy: Record<SystemStatus, string> = {
   ok: "System status: OK",
   warning: "System status: Warning",
   critical: "System status: Attention required",
 };
+
 interface HeaderStatusStripProps {
   className?: string;
+  isAuthenticatedView?: boolean;
 }
-const HeaderStatusStrip: React.FC<HeaderStatusStripProps> = ({ className }) => {
+
+const HeaderStatusStrip: React.FC<HeaderStatusStripProps> = ({ className, isAuthenticatedView = false }) => {
   const { systemStatus, localTime } = useGlobalControls();
   const RealtimeWaveIcon = () => (
     <svg
@@ -42,6 +46,7 @@ const HeaderStatusStrip: React.FC<HeaderStatusStripProps> = ({ className }) => {
       </g>
     </svg>
   );
+
   return (
     <div
       className={`vrm-header-meta ${className ?? ""}`.trim()}
@@ -50,31 +55,37 @@ const HeaderStatusStrip: React.FC<HeaderStatusStripProps> = ({ className }) => {
     >
       <div className="vrm-header-meta-group">
         <span className="vrm-header-chip" title="Last updated timestamp">
-          {" "}
           Last updated:{" "}
           <span className="vrm-header-chip-highlight">
-            <RealtimeWaveIcon /> Realtime{" "}
+            {isAuthenticatedView ? <span aria-hidden="true">✕</span> : <RealtimeWaveIcon />} {" "}
+            {isAuthenticatedView ? <span style={{ color: "#ff6b6b" }}>NA</span> : "Realtime"}
           </span>
         </span>
       </div>
       <span className="vrm-header-meta-divider" aria-hidden="true" />
       <div className="vrm-header-meta-group">
-        <span className="vrm-header-chip" title={statusCopy[systemStatus]}>
-          <span
-            className={`vrm-status-indicator ${systemStatus}`}
-            aria-hidden
-          />{" "}
-          {statusCopy[systemStatus]}{" "}
+        <span className="vrm-header-chip" title={isAuthenticatedView ? "No connected sites" : statusCopy[systemStatus]}>
+          {isAuthenticatedView ? (
+            <span style={{ color: "var(--vrm-text-muted)" }}>0 Sites Connected</span>
+          ) : (
+            <>
+              <span
+                className={`vrm-status-indicator ${systemStatus}`}
+                aria-hidden
+              />{" "}
+              {statusCopy[systemStatus]}
+            </>
+          )}
         </span>
       </div>
       <span className="vrm-header-meta-divider" aria-hidden="true" />
       <div className="vrm-header-meta-group">
         <span className="vrm-header-chip" title="Local site time">
-          {" "}
-          Local time: {localTime}{" "}
+          Local time: {localTime}
         </span>
       </div>
     </div>
   );
 };
+
 export default HeaderStatusStrip;

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -23,7 +23,7 @@
   width: 100%;
   max-width: 520px;
   display: grid;
-  gap: 4px;
+  gap: 2px;
 }
 
 .contact-title {
@@ -93,7 +93,7 @@
   min-height: min(620px, calc(100vh - 180px));
   display: grid;
   grid-template-rows: auto auto 1fr auto;
-  gap: 6px;
+  gap: 4px;
 }
 
 .contact-message-input {
@@ -143,6 +143,7 @@
   padding: 20px;
   display: grid;
   gap: 12px;
+  position: relative;
 }
 
 .contact-success-modal h2 {
@@ -162,11 +163,21 @@
 }
 
 .contact-success-close {
-  justify-self: end;
-  border: none;
-  background: transparent;
-  color: #89b4ff;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 28px;
+  height: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 999px;
+  background: #0f131a;
+  color: #dbe6ff;
   cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .contact-actions {
@@ -215,4 +226,10 @@
     border-left: none;
     border-top: 1px solid rgba(255, 255, 255, 0.12);
   }
+}
+
+.contact-success-close:hover,
+.contact-success-close:focus-visible {
+  border-color: #89b4ff;
+  color: #89b4ff;
 }

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -23,7 +23,7 @@
   width: 100%;
   max-width: 520px;
   display: grid;
-  gap: 8px;
+  gap: 4px;
 }
 
 .contact-title {
@@ -45,8 +45,12 @@
 }
 
 .contact-error-slot {
-  min-height: 20px;
+  min-height: 0;
   margin-top: 4px;
+}
+
+.contact-error-slot:empty {
+  margin-top: 0;
 }
 
 .contact-error {
@@ -89,7 +93,7 @@
   min-height: min(620px, calc(100vh - 180px));
   display: grid;
   grid-template-rows: auto auto 1fr auto;
-  gap: 10px;
+  gap: 6px;
 }
 
 .contact-message-input {
@@ -119,6 +123,50 @@
   margin-top: 4px;
   color: #8ad9a2;
   font-size: 13px;
+}
+
+.contact-success-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 15, 22, 0.72);
+  z-index: 1000;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+
+.contact-success-modal {
+  width: min(520px, 100%);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: #151a22;
+  border-radius: 12px;
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+}
+
+.contact-success-modal h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.contact-success-modal p {
+  margin: 0;
+  color: #c9d2e1;
+}
+
+.contact-success-modal-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.contact-success-close {
+  justify-self: end;
+  border: none;
+  background: transparent;
+  color: #89b4ff;
+  cursor: pointer;
 }
 
 .contact-actions {

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -2,7 +2,9 @@ import React, { useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import AuthTopBar from "../../components/auth/AuthTopBar";
 import { submitContact } from "./transport/contact";
+import AuthPhoneField from "./components/AuthPhoneField";
 import "./ContactPage.css";
+import "./components/AuthPhoneField.css";
 
 type FieldErrors = {
   name?: string;
@@ -13,7 +15,7 @@ type FieldErrors = {
 };
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const PHONE_RE = /^\+?[0-9\s()-]{7,20}$/;
+const PHONE_RE = /^\+[1-9]\d{6,14}$/;
 const MAX_ATTACHMENTS = 3;
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const ACCEPTED_EXTENSIONS = [".pdf", ".docx", ".xlsx", ".csv", ".png", ".jpg", ".jpeg"];
@@ -21,7 +23,8 @@ const ACCEPTED_EXTENSIONS = [".pdf", ".docx", ".xlsx", ".csv", ".png", ".jpg", "
 const ContactPage: React.FC = () => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
-  const [phone, setPhone] = useState("");
+  const [phoneCountryCode, setPhoneCountryCode] = useState("+44");
+  const [phoneLocal, setPhoneLocal] = useState("");
   const [message, setMessage] = useState("");
   const [attachments, setAttachments] = useState<File[]>([]);
   const [errors, setErrors] = useState<FieldErrors>({});
@@ -51,7 +54,8 @@ const ContactPage: React.FC = () => {
       nextErrors.email = "Not a valid email address";
     }
 
-    if (phone.trim() && !PHONE_RE.test(phone.trim())) {
+    const phoneValue = phoneLocal.trim() ? `${phoneCountryCode}${phoneLocal.trim().replace(/^0+/, "")}` : "";
+    if (phoneValue && !PHONE_RE.test(phoneValue)) {
       nextErrors.phone = "Not a valid phone number";
     }
 
@@ -103,7 +107,7 @@ const ContactPage: React.FC = () => {
       const result = await submitContact({
         name: name.trim(),
         email: email.trim().toLowerCase(),
-        phone: phone.trim(),
+        phone: phoneLocal.trim() ? `${phoneCountryCode}${phoneLocal.trim().replace(/^0+/, "")}` : "",
         message: message.trim(),
         attachments,
       });
@@ -116,7 +120,8 @@ const ContactPage: React.FC = () => {
       setSubmitSuccess("Message sent");
       setName("");
       setEmail("");
-      setPhone("");
+      setPhoneCountryCode("+44");
+      setPhoneLocal("");
       setMessage("");
       setAttachments([]);
       setErrors({});
@@ -182,18 +187,20 @@ const ContactPage: React.FC = () => {
             </div>
 
             <div className="vrm-field contact-field">
-              <label className="vrm-label" htmlFor="contact-phone">Phone (optional)</label>
-              <input
-                id="contact-phone"
-                className="vrm-input"
-                value={phone}
-                onChange={(event) => {
-                  setPhone(event.target.value);
+              <label className="vrm-label" htmlFor="contact-country">Phone (optional)</label>
+              <AuthPhoneField
+                idPrefix="contact"
+                countryCode={phoneCountryCode}
+                localNumber={phoneLocal}
+                onCountryCodeChange={(value) => {
+                  setPhoneCountryCode(value);
                   if (errors.phone) setErrors((prev) => ({ ...prev, phone: undefined }));
                 }}
-                autoComplete="tel"
-                aria-invalid={Boolean(errors.phone)}
-                aria-describedby={errors.phone ? "contact-phone-error" : undefined}
+                onLocalNumberChange={(value) => {
+                  setPhoneLocal(value);
+                  if (errors.phone) setErrors((prev) => ({ ...prev, phone: undefined }));
+                }}
+                inputClassName="vrm-input"
               />
               <div className="contact-error-slot" aria-live="polite">
                 {errors.phone && <div id="contact-phone-error" className="contact-error">{errors.phone}</div>}

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -113,7 +113,7 @@ const ContactPage: React.FC = () => {
         return;
       }
 
-      setSubmitSuccess("Message sent. We'll get back to you shortly.");
+      setSubmitSuccess("Message sent");
       setName("");
       setEmail("");
       setPhone("");
@@ -277,15 +277,15 @@ const ContactPage: React.FC = () => {
       </form>
       </div>
       {showSuccessModal ? (
-        <div className="contact-success-modal-backdrop" role="presentation" onClick={() => setShowSuccessModal(false)}>
-          <div className="contact-success-modal" role="dialog" aria-modal="true" aria-labelledby="contact-success-title" onClick={(event) => event.stopPropagation()}>
+        <div className="contact-success-modal-backdrop" role="presentation">
+          <div className="contact-success-modal" role="dialog" aria-modal="true" aria-labelledby="contact-success-title">
+            <button type="button" className="contact-success-close" onClick={() => setShowSuccessModal(false)} aria-label="Close success modal">×</button>
             <h2 id="contact-success-title">Message sent</h2>
-            <p>Thanks for contacting camOS. Our team will get back to you shortly.</p>
+            <p>Thanks for contacting camOS. Our team will get back to you within 24 Hours.</p>
             <div className="contact-success-modal-actions">
               <Link className="vrm-btn vrm-btn-secondary" to="/" onClick={() => setShowSuccessModal(false)}>Learn more about camOS</Link>
               <Link className="vrm-btn vrm-btn-primary" to="/create-account" onClick={() => setShowSuccessModal(false)}>Create Account</Link>
             </div>
-            <button type="button" className="contact-success-close" onClick={() => setShowSuccessModal(false)}>Close</button>
           </div>
         </div>
       ) : null}

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import AuthTopBar from "../../components/auth/AuthTopBar";
 import { submitContact } from "./transport/contact";
@@ -27,7 +27,9 @@ const ContactPage: React.FC = () => {
   const [errors, setErrors] = useState<FieldErrors>({});
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState<string | null>(null);
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const attachmentSummary = useMemo(() => {
     if (attachments.length === 0) {
@@ -118,6 +120,10 @@ const ContactPage: React.FC = () => {
       setMessage("");
       setAttachments([]);
       setErrors({});
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      setShowSuccessModal(true);
     } catch {
       setSubmitError("Unable to send your message. Please try again.");
     } finally {
@@ -126,7 +132,8 @@ const ContactPage: React.FC = () => {
   };
 
   return (
-    <div className="contact-page">
+    <>
+      <div className="contact-page">
       <AuthTopBar />
 
       <form className="contact-shell" onSubmit={handleSubmit}>
@@ -226,6 +233,7 @@ const ContactPage: React.FC = () => {
                 id="contact-attachments"
                 className="vrm-input"
                 type="file"
+                ref={fileInputRef}
                 multiple
                 accept={ACCEPTED_EXTENSIONS.join(",")}
                 onChange={onFilesChange}
@@ -267,7 +275,21 @@ const ContactPage: React.FC = () => {
           </div>
         </section>
       </form>
-    </div>
+      </div>
+      {showSuccessModal ? (
+        <div className="contact-success-modal-backdrop" role="presentation" onClick={() => setShowSuccessModal(false)}>
+          <div className="contact-success-modal" role="dialog" aria-modal="true" aria-labelledby="contact-success-title" onClick={(event) => event.stopPropagation()}>
+            <h2 id="contact-success-title">Message sent</h2>
+            <p>Thanks for contacting camOS. Our team will get back to you shortly.</p>
+            <div className="contact-success-modal-actions">
+              <Link className="vrm-btn vrm-btn-secondary" to="/" onClick={() => setShowSuccessModal(false)}>Learn more about camOS</Link>
+              <Link className="vrm-btn vrm-btn-primary" to="/create-account" onClick={() => setShowSuccessModal(false)}>Create Account</Link>
+            </div>
+            <button type="button" className="contact-success-close" onClick={() => setShowSuccessModal(false)}>Close</button>
+          </div>
+        </div>
+      ) : null}
+    </>
   );
 };
 

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -67,18 +67,6 @@
   margin: 0;
 }
 
-.create-account-phone-row {
-  display: grid;
-  grid-template-columns: max-content minmax(0, 1fr);
-  gap: 8px;
-}
-
-.create-account-country-select {
-  width: auto;
-  min-width: 116px;
-  padding-right: 28px;
-}
-
 .create-account-password-wrap {
   position: relative;
 }

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -23,7 +23,7 @@
   width: 100%;
   max-width: 520px;
   display: grid;
-  gap: 8px;
+  gap: 4px;
 }
 
 .create-account-back-link {
@@ -60,7 +60,7 @@
 
 .create-account-form {
   display: grid;
-  gap: 8px;
+  gap: 4px;
 }
 
 .create-account-field {
@@ -109,13 +109,18 @@
 }
 
 .create-account-password-hint-slot {
-  min-height: 18px;
+  min-height: 0;
   margin-top: 4px;
 }
 
 .create-account-error-slot {
-  min-height: 20px;
+  min-height: 0;
   margin-top: 4px;
+}
+
+.create-account-error-slot:empty,
+.create-account-password-hint-slot:empty {
+  margin-top: 0;
 }
 
 .create-account-error {

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -69,8 +69,14 @@
 
 .create-account-phone-row {
   display: grid;
-  grid-template-columns: 170px 1fr;
+  grid-template-columns: max-content minmax(0, 1fr);
   gap: 8px;
+}
+
+.create-account-country-select {
+  width: auto;
+  min-width: 116px;
+  padding-right: 28px;
 }
 
 .create-account-password-wrap {

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -4,15 +4,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import AuthTopBar from '../../components/auth/AuthTopBar';
 import camsvg from '../../assets/camsvg.svg';
 import { useCreateAccountForm } from './hooks/useCreateAccountForm';
+import { COUNTRY_PHONE_OPTIONS } from './countryPhoneData';
 import './CreateAccountPage.css';
-
-const COUNTRY_CODES = [
-  { label: 'United Kingdom (+44)', value: '+44' },
-  { label: 'United States (+1)', value: '+1' },
-  { label: 'Germany (+49)', value: '+49' },
-  { label: 'France (+33)', value: '+33' },
-  { label: 'India (+91)', value: '+91' },
-];
 
 const stopNavigation: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
   event.preventDefault();
@@ -104,8 +97,8 @@ const CreateAccountPage: React.FC = () => {
                     value={form.countryCode}
                     onChange={(e) => form.setCountryCode(e.target.value)}
                   >
-                    {COUNTRY_CODES.map((option) => (
-                      <option key={option.value} value={option.value}>{option.label}</option>
+                    {COUNTRY_PHONE_OPTIONS.map((option) => (
+                      <option key={`${option.iso2}-${option.dialCode}`} value={option.dialCode}>{option.iso2} ({option.dialCode})</option>
                     ))}
                   </select>
                   <input
@@ -220,6 +213,9 @@ const CreateAccountPage: React.FC = () => {
                   <a href="#" onClick={stopNavigation}>privacy policy</a>.{' '}
                   You can find the policy{' '}
                   <a href="#" onClick={stopNavigation}>here</a>
+                </p>
+                <p>
+                  Already have an Account? <Link to="/login">Login here</Link>
                 </p>
               </div>
             </form>

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -93,7 +93,7 @@ const CreateAccountPage: React.FC = () => {
                 <div className="create-account-phone-row">
                   <select
                     id="create-country"
-                    className="vrm-input"
+                    className="vrm-input create-account-country-select"
                     value={form.countryCode}
                     onChange={(e) => form.setCountryCode(e.target.value)}
                   >

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -4,8 +4,9 @@ import { Link, useNavigate } from 'react-router-dom';
 import AuthTopBar from '../../components/auth/AuthTopBar';
 import camsvg from '../../assets/camsvg.svg';
 import { useCreateAccountForm } from './hooks/useCreateAccountForm';
-import { COUNTRY_PHONE_OPTIONS } from './countryPhoneData';
+import AuthPhoneField from './components/AuthPhoneField';
 import './CreateAccountPage.css';
+import './components/AuthPhoneField.css';
 
 const stopNavigation: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
   event.preventDefault();
@@ -90,27 +91,14 @@ const CreateAccountPage: React.FC = () => {
 
               <div className="vrm-field create-account-field">
                 <label className="vrm-label" htmlFor="create-country">Phone (optional)</label>
-                <div className="create-account-phone-row">
-                  <select
-                    id="create-country"
-                    className="vrm-input create-account-country-select"
-                    value={form.countryCode}
-                    onChange={(e) => form.setCountryCode(e.target.value)}
-                  >
-                    {COUNTRY_PHONE_OPTIONS.map((option) => (
-                      <option key={`${option.iso2}-${option.dialCode}`} value={option.dialCode}>{option.iso2} ({option.dialCode})</option>
-                    ))}
-                  </select>
-                  <input
-                    className="vrm-input"
-                    autoComplete="tel"
-                    inputMode="tel"
-                    placeholder="Phone number"
-                    value={form.phoneLocal}
-                    onChange={(e) => form.setPhoneLocal(e.target.value.replace(/[^\d]/g, ''))}
-                    onBlur={() => form.markTouched('phone')}
-                    aria-invalid={Boolean(form.visibleErrors.phone)}
-                    aria-describedby={form.visibleErrors.phone ? 'create-phone-error' : undefined}
+                <div onBlur={() => form.markTouched('phone')}>
+                  <AuthPhoneField
+                    idPrefix="create"
+                    countryCode={form.countryCode}
+                    localNumber={form.phoneLocal}
+                    onCountryCodeChange={form.setCountryCode}
+                    onLocalNumberChange={form.setPhoneLocal}
+                    inputClassName="vrm-input"
                   />
                 </div>
                 <div className="create-account-error-slot" aria-live="polite">

--- a/frontend/src/features/auth/LoginPage.css
+++ b/frontend/src/features/auth/LoginPage.css
@@ -23,14 +23,9 @@
   width: 100%;
   max-width: 520px;
   display: grid;
-  gap: 8px;
+  gap: 4px;
 }
 
-.login-title {
-  color: #c9d2e1;
-  font-size: 16px;
-  font-weight: 500;
-}
 
 .login-hero {
   font-size: 41px;
@@ -42,7 +37,7 @@
 
 .login-form {
   display: grid;
-  gap: 8px;
+  gap: 4px;
 }
 
 .login-field {
@@ -50,8 +45,12 @@
 }
 
 .login-error-slot {
-  min-height: 20px;
+  min-height: 0;
   margin-top: 4px;
+}
+
+.login-error-slot:empty {
+  margin-top: 0;
 }
 
 .login-error {

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "react-router-dom";
 import AuthTopBar from "../../components/auth/AuthTopBar";
 import camsvg from "../../assets/camsvg.svg";
 import { useLoginForm } from "./hooks/useLoginForm";
+import { passwordResetStart } from "./transport/passwordResetStart";
 import "./LoginPage.css";
 
 interface LoginPageProps {
@@ -51,7 +52,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
     await handleSubmit(event);
   };
 
-  const handleResetPasswordClick: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
+  const handleResetPasswordClick: React.MouseEventHandler<HTMLAnchorElement> = async (event) => {
     event.preventDefault();
     if (!email.trim()) {
       setEmailStepError("Enter your email before resetting your password");
@@ -67,7 +68,12 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
       }
       return;
     }
-    navigate(`/reset-password?email=${encodeURIComponent(email.trim().toLowerCase())}`);
+    try {
+      await passwordResetStart(email.trim().toLowerCase());
+      navigate(`/reset-password/code?email=${encodeURIComponent(email.trim().toLowerCase())}`);
+    } catch (resetError) {
+      setEmailStepError(resetError instanceof Error ? resetError.message : "Unable to start password reset.");
+    }
   };
 
   return (

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -83,7 +83,6 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
       <div className="login-shell">
         <section className="login-left-pane" aria-label="Login form panel">
           <div className="login-content">
-            <p className="login-title">Login</p>
             <h1 className="login-hero">Welcome Back</h1>
 
             <form className="login-form" onSubmit={onPrimaryAction}>

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -1,10 +1,10 @@
-import React, { useMemo, useState } from "react";
-import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 import AuthTopBar from "../../components/auth/AuthTopBar";
 import { passwordResetResend } from "./transport/passwordResetResend";
-import { passwordResetStart } from "./transport/passwordResetStart";
-import { passwordResetVerify } from "./transport/passwordResetVerify";
+import { passwordResetSetPassword } from "./transport/passwordResetSetPassword";
+import { passwordResetVerifyCode } from "./transport/passwordResetVerifyCode";
 import "./VerifyEmailPage.css";
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -12,8 +12,11 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const ResetPasswordPage: React.FC = () => {
   const [params] = useSearchParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const email = (params.get("email") ?? "").trim().toLowerCase();
+  const resetToken = (params.get("resetToken") ?? "").trim();
   const validEmail = useMemo(() => EMAIL_RE.test(email), [email]);
+  const isCodeStep = location.pathname === "/reset-password" || location.pathname === "/reset-password/code";
 
   const [code, setCode] = useState("");
   const [password, setPassword] = useState("");
@@ -21,8 +24,25 @@ const ResetPasswordPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [cooldownRemaining, setCooldownRemaining] = useState(30);
 
-  const handleVerify = async (event: React.FormEvent) => {
+  useEffect(() => {
+    if (!isCodeStep || cooldownRemaining <= 0) {
+      return;
+    }
+    const timer = window.setInterval(() => {
+      setCooldownRemaining((current) => {
+        if (current <= 1) {
+          window.clearInterval(timer);
+          return 0;
+        }
+        return current - 1;
+      });
+    }, 1000);
+    return () => window.clearInterval(timer);
+  }, [cooldownRemaining, isCodeStep]);
+
+  const handleVerifyCode = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!validEmail) {
       setError("Please start from the login page with a valid email.");
@@ -32,16 +52,40 @@ const ResetPasswordPage: React.FC = () => {
     setError(null);
     setMessage(null);
     try {
-      await passwordResetVerify({ email, code, password, confirm_password: confirmPassword });
-      navigate("/login", { replace: true, state: { message: "Password reset successful. Please sign in." } });
+      const result = await passwordResetVerifyCode({ email, code });
+      navigate(`/reset-password/new?email=${encodeURIComponent(email)}&resetToken=${encodeURIComponent(result.resetToken)}`);
     } catch (verifyError) {
-      setError(verifyError instanceof Error ? verifyError.message : "Unable to reset password");
+      setError(verifyError instanceof Error ? verifyError.message : "Unable to verify reset code");
     } finally {
       setLoading(false);
     }
   };
 
-  const sendCode = async (resend = false) => {
+  const handleSetPassword = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!validEmail || !resetToken) {
+      setError("Invalid or expired reset session. Please restart from login.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setMessage(null);
+    try {
+      await passwordResetSetPassword({
+        email,
+        reset_token: resetToken,
+        password,
+        confirm_password: confirmPassword,
+      });
+      navigate("/login", { replace: true, state: { message: "Password reset successful. Please sign in." } });
+    } catch (setPasswordError) {
+      setError(setPasswordError instanceof Error ? setPasswordError.message : "Unable to reset password");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resendCode = async () => {
     if (!validEmail) {
       setError("Please start from the login page with a valid email.");
       return;
@@ -50,14 +94,11 @@ const ResetPasswordPage: React.FC = () => {
     setError(null);
     setMessage(null);
     try {
-      if (resend) {
-        await passwordResetResend(email);
-      } else {
-        await passwordResetStart(email);
-      }
-      setMessage("Verification code sent.");
+      await passwordResetResend(email);
+      setMessage("A new verification code was sent.");
+      setCooldownRemaining(30);
     } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : "Unable to send code");
+      setError(requestError instanceof Error ? requestError.message : "Unable to resend code");
     } finally {
       setLoading(false);
     }
@@ -70,31 +111,57 @@ const ResetPasswordPage: React.FC = () => {
         <section className="verify-email-left-pane" aria-label="Password reset panel">
           <div className="verify-email-content">
             <p className="verify-email-title">Reset Password</p>
-            <h1 className="verify-email-hero">Enter your reset code</h1>
-            <p className="verify-email-copy">{validEmail ? `Code will be sent to ${email}` : "Start from login to reset password."}</p>
-            <form className="verify-email-form" onSubmit={handleVerify}>
-              <div className="vrm-field verify-email-field">
-                <label className="vrm-label" htmlFor="reset-code">Code</label>
-                <input id="reset-code" className="vrm-input" value={code} onChange={(e) => setCode(e.target.value)} />
-              </div>
-              <div className="vrm-field verify-email-field">
-                <label className="vrm-label" htmlFor="reset-password">New password</label>
-                <input id="reset-password" className="vrm-input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
-              </div>
-              <div className="vrm-field verify-email-field">
-                <label className="vrm-label" htmlFor="reset-confirm-password">Confirm password</label>
-                <input id="reset-confirm-password" className="vrm-input" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
-              </div>
+            <h1 className="verify-email-hero">{isCodeStep ? "Enter verification code" : "Set new password"}</h1>
+            <p className="verify-email-copy">
+              {isCodeStep
+                ? validEmail
+                  ? <>We sent a reset code to <strong>{email}</strong>.</>
+                  : "Start from login to reset password."
+                : "Choose your new password."}
+            </p>
+
+            <form className="verify-email-form" onSubmit={isCodeStep ? handleVerifyCode : handleSetPassword}>
+              {isCodeStep ? (
+                <div className="vrm-field verify-email-field">
+                  <label className="vrm-label" htmlFor="reset-code">Verification code</label>
+                  <input id="reset-code" className="vrm-input" value={code} onChange={(e) => setCode(e.target.value)} />
+                </div>
+              ) : (
+                <>
+                  <div className="vrm-field verify-email-field">
+                    <label className="vrm-label" htmlFor="reset-password">New password</label>
+                    <input id="reset-password" className="vrm-input" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+                  </div>
+                  <div className="vrm-field verify-email-field">
+                    <label className="vrm-label" htmlFor="reset-confirm-password">Confirm password</label>
+                    <input id="reset-confirm-password" className="vrm-input" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} />
+                  </div>
+                </>
+              )}
+
               {error ? <div className="verify-email-error">{error}</div> : null}
               {message ? <div className="verify-email-message">{message}</div> : null}
+
               <div className="verify-email-actions">
-                <button type="button" className="vrm-btn vrm-btn-secondary" onClick={() => sendCode(false)} disabled={loading}>Send code</button>
-                <button type="submit" className="vrm-btn vrm-btn-primary verify-email-submit" disabled={loading}>{loading ? "Submitting…" : "Reset password"}</button>
+                <button type="submit" className="vrm-btn vrm-btn-primary verify-email-submit" disabled={loading}>
+                  {loading ? "Submitting…" : isCodeStep ? "Verify code" : "Set new password"}
+                </button>
               </div>
             </form>
-            <div className="verify-email-resend-row">
-              <button type="button" className="verify-email-resend" onClick={() => sendCode(true)} disabled={loading}>Resend code</button>
-            </div>
+
+            {isCodeStep ? (
+              <div className="verify-email-resend-row">
+                <button
+                  type="button"
+                  className="verify-email-resend"
+                  onClick={resendCode}
+                  disabled={loading || cooldownRemaining > 0}
+                >
+                  {cooldownRemaining > 0 ? `Resend in ${cooldownRemaining}s` : "Resend code"}
+                </button>
+              </div>
+            ) : null}
+
             <p className="verify-email-back-row"><Link to="/login" className="verify-email-link">Back to login</Link></p>
           </div>
         </section>

--- a/frontend/src/features/auth/components/AuthPhoneField.css
+++ b/frontend/src/features/auth/components/AuthPhoneField.css
@@ -1,0 +1,12 @@
+.auth-phone-row {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 8px;
+}
+
+.auth-phone-country-select {
+  width: fit-content;
+  min-width: 0;
+  max-width: 9ch;
+  padding-right: 24px;
+}

--- a/frontend/src/features/auth/components/AuthPhoneField.tsx
+++ b/frontend/src/features/auth/components/AuthPhoneField.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+import { COUNTRY_PHONE_OPTIONS } from "../countryPhoneData";
+
+type AuthPhoneFieldProps = {
+  idPrefix: string;
+  countryCode: string;
+  localNumber: string;
+  onCountryCodeChange: (value: string) => void;
+  onLocalNumberChange: (value: string) => void;
+  inputClassName?: string;
+};
+
+const AuthPhoneField: React.FC<AuthPhoneFieldProps> = ({
+  idPrefix,
+  countryCode,
+  localNumber,
+  onCountryCodeChange,
+  onLocalNumberChange,
+  inputClassName = "vrm-input",
+}) => (
+  <div className="auth-phone-row">
+    <select
+      id={`${idPrefix}-country`}
+      className={`vrm-input auth-phone-country-select`}
+      value={countryCode}
+      onChange={(event) => onCountryCodeChange(event.target.value)}
+    >
+      {COUNTRY_PHONE_OPTIONS.map((option) => (
+        <option key={`${option.iso2}-${option.dialCode}`} value={option.dialCode}>{option.iso2} ({option.dialCode})</option>
+      ))}
+    </select>
+    <input
+      id={`${idPrefix}-local`}
+      className={inputClassName}
+      autoComplete="tel"
+      inputMode="tel"
+      placeholder="Phone number"
+      value={localNumber}
+      onChange={(event) => onLocalNumberChange(event.target.value.replace(/[^\d]/g, ""))}
+    />
+  </div>
+);
+
+export default AuthPhoneField;

--- a/frontend/src/features/auth/countryPhoneData.ts
+++ b/frontend/src/features/auth/countryPhoneData.ts
@@ -1,0 +1,984 @@
+export type CountryPhoneOption = { iso2: string; dialCode: string };
+
+export const COUNTRY_PHONE_OPTIONS: CountryPhoneOption[] = [
+  {
+    "iso2": "AC",
+    "dialCode": "+247"
+  },
+  {
+    "iso2": "AD",
+    "dialCode": "+376"
+  },
+  {
+    "iso2": "AE",
+    "dialCode": "+971"
+  },
+  {
+    "iso2": "AF",
+    "dialCode": "+93"
+  },
+  {
+    "iso2": "AG",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "AI",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "AL",
+    "dialCode": "+355"
+  },
+  {
+    "iso2": "AM",
+    "dialCode": "+374"
+  },
+  {
+    "iso2": "AO",
+    "dialCode": "+244"
+  },
+  {
+    "iso2": "AR",
+    "dialCode": "+54"
+  },
+  {
+    "iso2": "AS",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "AT",
+    "dialCode": "+43"
+  },
+  {
+    "iso2": "AU",
+    "dialCode": "+61"
+  },
+  {
+    "iso2": "AW",
+    "dialCode": "+297"
+  },
+  {
+    "iso2": "AX",
+    "dialCode": "+358"
+  },
+  {
+    "iso2": "AZ",
+    "dialCode": "+994"
+  },
+  {
+    "iso2": "BA",
+    "dialCode": "+387"
+  },
+  {
+    "iso2": "BB",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "BD",
+    "dialCode": "+880"
+  },
+  {
+    "iso2": "BE",
+    "dialCode": "+32"
+  },
+  {
+    "iso2": "BF",
+    "dialCode": "+226"
+  },
+  {
+    "iso2": "BG",
+    "dialCode": "+359"
+  },
+  {
+    "iso2": "BH",
+    "dialCode": "+973"
+  },
+  {
+    "iso2": "BI",
+    "dialCode": "+257"
+  },
+  {
+    "iso2": "BJ",
+    "dialCode": "+229"
+  },
+  {
+    "iso2": "BL",
+    "dialCode": "+590"
+  },
+  {
+    "iso2": "BM",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "BN",
+    "dialCode": "+673"
+  },
+  {
+    "iso2": "BO",
+    "dialCode": "+591"
+  },
+  {
+    "iso2": "BQ",
+    "dialCode": "+599"
+  },
+  {
+    "iso2": "BR",
+    "dialCode": "+55"
+  },
+  {
+    "iso2": "BS",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "BT",
+    "dialCode": "+975"
+  },
+  {
+    "iso2": "BW",
+    "dialCode": "+267"
+  },
+  {
+    "iso2": "BY",
+    "dialCode": "+375"
+  },
+  {
+    "iso2": "BZ",
+    "dialCode": "+501"
+  },
+  {
+    "iso2": "CA",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "CC",
+    "dialCode": "+61"
+  },
+  {
+    "iso2": "CD",
+    "dialCode": "+243"
+  },
+  {
+    "iso2": "CF",
+    "dialCode": "+236"
+  },
+  {
+    "iso2": "CG",
+    "dialCode": "+242"
+  },
+  {
+    "iso2": "CH",
+    "dialCode": "+41"
+  },
+  {
+    "iso2": "CI",
+    "dialCode": "+225"
+  },
+  {
+    "iso2": "CK",
+    "dialCode": "+682"
+  },
+  {
+    "iso2": "CL",
+    "dialCode": "+56"
+  },
+  {
+    "iso2": "CM",
+    "dialCode": "+237"
+  },
+  {
+    "iso2": "CN",
+    "dialCode": "+86"
+  },
+  {
+    "iso2": "CO",
+    "dialCode": "+57"
+  },
+  {
+    "iso2": "CR",
+    "dialCode": "+506"
+  },
+  {
+    "iso2": "CU",
+    "dialCode": "+53"
+  },
+  {
+    "iso2": "CV",
+    "dialCode": "+238"
+  },
+  {
+    "iso2": "CW",
+    "dialCode": "+599"
+  },
+  {
+    "iso2": "CX",
+    "dialCode": "+61"
+  },
+  {
+    "iso2": "CY",
+    "dialCode": "+357"
+  },
+  {
+    "iso2": "CZ",
+    "dialCode": "+420"
+  },
+  {
+    "iso2": "DE",
+    "dialCode": "+49"
+  },
+  {
+    "iso2": "DJ",
+    "dialCode": "+253"
+  },
+  {
+    "iso2": "DK",
+    "dialCode": "+45"
+  },
+  {
+    "iso2": "DM",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "DO",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "DZ",
+    "dialCode": "+213"
+  },
+  {
+    "iso2": "EC",
+    "dialCode": "+593"
+  },
+  {
+    "iso2": "EE",
+    "dialCode": "+372"
+  },
+  {
+    "iso2": "EG",
+    "dialCode": "+20"
+  },
+  {
+    "iso2": "EH",
+    "dialCode": "+212"
+  },
+  {
+    "iso2": "ER",
+    "dialCode": "+291"
+  },
+  {
+    "iso2": "ES",
+    "dialCode": "+34"
+  },
+  {
+    "iso2": "ET",
+    "dialCode": "+251"
+  },
+  {
+    "iso2": "FI",
+    "dialCode": "+358"
+  },
+  {
+    "iso2": "FJ",
+    "dialCode": "+679"
+  },
+  {
+    "iso2": "FK",
+    "dialCode": "+500"
+  },
+  {
+    "iso2": "FM",
+    "dialCode": "+691"
+  },
+  {
+    "iso2": "FO",
+    "dialCode": "+298"
+  },
+  {
+    "iso2": "FR",
+    "dialCode": "+33"
+  },
+  {
+    "iso2": "GA",
+    "dialCode": "+241"
+  },
+  {
+    "iso2": "GB",
+    "dialCode": "+44"
+  },
+  {
+    "iso2": "GD",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "GE",
+    "dialCode": "+995"
+  },
+  {
+    "iso2": "GF",
+    "dialCode": "+594"
+  },
+  {
+    "iso2": "GG",
+    "dialCode": "+44"
+  },
+  {
+    "iso2": "GH",
+    "dialCode": "+233"
+  },
+  {
+    "iso2": "GI",
+    "dialCode": "+350"
+  },
+  {
+    "iso2": "GL",
+    "dialCode": "+299"
+  },
+  {
+    "iso2": "GM",
+    "dialCode": "+220"
+  },
+  {
+    "iso2": "GN",
+    "dialCode": "+224"
+  },
+  {
+    "iso2": "GP",
+    "dialCode": "+590"
+  },
+  {
+    "iso2": "GQ",
+    "dialCode": "+240"
+  },
+  {
+    "iso2": "GR",
+    "dialCode": "+30"
+  },
+  {
+    "iso2": "GT",
+    "dialCode": "+502"
+  },
+  {
+    "iso2": "GU",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "GW",
+    "dialCode": "+245"
+  },
+  {
+    "iso2": "GY",
+    "dialCode": "+592"
+  },
+  {
+    "iso2": "HK",
+    "dialCode": "+852"
+  },
+  {
+    "iso2": "HN",
+    "dialCode": "+504"
+  },
+  {
+    "iso2": "HR",
+    "dialCode": "+385"
+  },
+  {
+    "iso2": "HT",
+    "dialCode": "+509"
+  },
+  {
+    "iso2": "HU",
+    "dialCode": "+36"
+  },
+  {
+    "iso2": "ID",
+    "dialCode": "+62"
+  },
+  {
+    "iso2": "IE",
+    "dialCode": "+353"
+  },
+  {
+    "iso2": "IL",
+    "dialCode": "+972"
+  },
+  {
+    "iso2": "IM",
+    "dialCode": "+44"
+  },
+  {
+    "iso2": "IN",
+    "dialCode": "+91"
+  },
+  {
+    "iso2": "IO",
+    "dialCode": "+246"
+  },
+  {
+    "iso2": "IQ",
+    "dialCode": "+964"
+  },
+  {
+    "iso2": "IR",
+    "dialCode": "+98"
+  },
+  {
+    "iso2": "IS",
+    "dialCode": "+354"
+  },
+  {
+    "iso2": "IT",
+    "dialCode": "+39"
+  },
+  {
+    "iso2": "JE",
+    "dialCode": "+44"
+  },
+  {
+    "iso2": "JM",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "JO",
+    "dialCode": "+962"
+  },
+  {
+    "iso2": "JP",
+    "dialCode": "+81"
+  },
+  {
+    "iso2": "KE",
+    "dialCode": "+254"
+  },
+  {
+    "iso2": "KG",
+    "dialCode": "+996"
+  },
+  {
+    "iso2": "KH",
+    "dialCode": "+855"
+  },
+  {
+    "iso2": "KI",
+    "dialCode": "+686"
+  },
+  {
+    "iso2": "KM",
+    "dialCode": "+269"
+  },
+  {
+    "iso2": "KN",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "KP",
+    "dialCode": "+850"
+  },
+  {
+    "iso2": "KR",
+    "dialCode": "+82"
+  },
+  {
+    "iso2": "KW",
+    "dialCode": "+965"
+  },
+  {
+    "iso2": "KY",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "KZ",
+    "dialCode": "+7"
+  },
+  {
+    "iso2": "LA",
+    "dialCode": "+856"
+  },
+  {
+    "iso2": "LB",
+    "dialCode": "+961"
+  },
+  {
+    "iso2": "LC",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "LI",
+    "dialCode": "+423"
+  },
+  {
+    "iso2": "LK",
+    "dialCode": "+94"
+  },
+  {
+    "iso2": "LR",
+    "dialCode": "+231"
+  },
+  {
+    "iso2": "LS",
+    "dialCode": "+266"
+  },
+  {
+    "iso2": "LT",
+    "dialCode": "+370"
+  },
+  {
+    "iso2": "LU",
+    "dialCode": "+352"
+  },
+  {
+    "iso2": "LV",
+    "dialCode": "+371"
+  },
+  {
+    "iso2": "LY",
+    "dialCode": "+218"
+  },
+  {
+    "iso2": "MA",
+    "dialCode": "+212"
+  },
+  {
+    "iso2": "MC",
+    "dialCode": "+377"
+  },
+  {
+    "iso2": "MD",
+    "dialCode": "+373"
+  },
+  {
+    "iso2": "ME",
+    "dialCode": "+382"
+  },
+  {
+    "iso2": "MF",
+    "dialCode": "+590"
+  },
+  {
+    "iso2": "MG",
+    "dialCode": "+261"
+  },
+  {
+    "iso2": "MH",
+    "dialCode": "+692"
+  },
+  {
+    "iso2": "MK",
+    "dialCode": "+389"
+  },
+  {
+    "iso2": "ML",
+    "dialCode": "+223"
+  },
+  {
+    "iso2": "MM",
+    "dialCode": "+95"
+  },
+  {
+    "iso2": "MN",
+    "dialCode": "+976"
+  },
+  {
+    "iso2": "MO",
+    "dialCode": "+853"
+  },
+  {
+    "iso2": "MP",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "MQ",
+    "dialCode": "+596"
+  },
+  {
+    "iso2": "MR",
+    "dialCode": "+222"
+  },
+  {
+    "iso2": "MS",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "MT",
+    "dialCode": "+356"
+  },
+  {
+    "iso2": "MU",
+    "dialCode": "+230"
+  },
+  {
+    "iso2": "MV",
+    "dialCode": "+960"
+  },
+  {
+    "iso2": "MW",
+    "dialCode": "+265"
+  },
+  {
+    "iso2": "MX",
+    "dialCode": "+52"
+  },
+  {
+    "iso2": "MY",
+    "dialCode": "+60"
+  },
+  {
+    "iso2": "MZ",
+    "dialCode": "+258"
+  },
+  {
+    "iso2": "NA",
+    "dialCode": "+264"
+  },
+  {
+    "iso2": "NC",
+    "dialCode": "+687"
+  },
+  {
+    "iso2": "NE",
+    "dialCode": "+227"
+  },
+  {
+    "iso2": "NF",
+    "dialCode": "+672"
+  },
+  {
+    "iso2": "NG",
+    "dialCode": "+234"
+  },
+  {
+    "iso2": "NI",
+    "dialCode": "+505"
+  },
+  {
+    "iso2": "NL",
+    "dialCode": "+31"
+  },
+  {
+    "iso2": "NO",
+    "dialCode": "+47"
+  },
+  {
+    "iso2": "NP",
+    "dialCode": "+977"
+  },
+  {
+    "iso2": "NR",
+    "dialCode": "+674"
+  },
+  {
+    "iso2": "NU",
+    "dialCode": "+683"
+  },
+  {
+    "iso2": "NZ",
+    "dialCode": "+64"
+  },
+  {
+    "iso2": "OM",
+    "dialCode": "+968"
+  },
+  {
+    "iso2": "PA",
+    "dialCode": "+507"
+  },
+  {
+    "iso2": "PE",
+    "dialCode": "+51"
+  },
+  {
+    "iso2": "PF",
+    "dialCode": "+689"
+  },
+  {
+    "iso2": "PG",
+    "dialCode": "+675"
+  },
+  {
+    "iso2": "PH",
+    "dialCode": "+63"
+  },
+  {
+    "iso2": "PK",
+    "dialCode": "+92"
+  },
+  {
+    "iso2": "PL",
+    "dialCode": "+48"
+  },
+  {
+    "iso2": "PM",
+    "dialCode": "+508"
+  },
+  {
+    "iso2": "PR",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "PS",
+    "dialCode": "+970"
+  },
+  {
+    "iso2": "PT",
+    "dialCode": "+351"
+  },
+  {
+    "iso2": "PW",
+    "dialCode": "+680"
+  },
+  {
+    "iso2": "PY",
+    "dialCode": "+595"
+  },
+  {
+    "iso2": "QA",
+    "dialCode": "+974"
+  },
+  {
+    "iso2": "RE",
+    "dialCode": "+262"
+  },
+  {
+    "iso2": "RO",
+    "dialCode": "+40"
+  },
+  {
+    "iso2": "RS",
+    "dialCode": "+381"
+  },
+  {
+    "iso2": "RU",
+    "dialCode": "+7"
+  },
+  {
+    "iso2": "RW",
+    "dialCode": "+250"
+  },
+  {
+    "iso2": "SA",
+    "dialCode": "+966"
+  },
+  {
+    "iso2": "SB",
+    "dialCode": "+677"
+  },
+  {
+    "iso2": "SC",
+    "dialCode": "+248"
+  },
+  {
+    "iso2": "SD",
+    "dialCode": "+249"
+  },
+  {
+    "iso2": "SE",
+    "dialCode": "+46"
+  },
+  {
+    "iso2": "SG",
+    "dialCode": "+65"
+  },
+  {
+    "iso2": "SH",
+    "dialCode": "+290"
+  },
+  {
+    "iso2": "SI",
+    "dialCode": "+386"
+  },
+  {
+    "iso2": "SJ",
+    "dialCode": "+47"
+  },
+  {
+    "iso2": "SK",
+    "dialCode": "+421"
+  },
+  {
+    "iso2": "SL",
+    "dialCode": "+232"
+  },
+  {
+    "iso2": "SM",
+    "dialCode": "+378"
+  },
+  {
+    "iso2": "SN",
+    "dialCode": "+221"
+  },
+  {
+    "iso2": "SO",
+    "dialCode": "+252"
+  },
+  {
+    "iso2": "SR",
+    "dialCode": "+597"
+  },
+  {
+    "iso2": "SS",
+    "dialCode": "+211"
+  },
+  {
+    "iso2": "ST",
+    "dialCode": "+239"
+  },
+  {
+    "iso2": "SV",
+    "dialCode": "+503"
+  },
+  {
+    "iso2": "SX",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "SY",
+    "dialCode": "+963"
+  },
+  {
+    "iso2": "SZ",
+    "dialCode": "+268"
+  },
+  {
+    "iso2": "TA",
+    "dialCode": "+290"
+  },
+  {
+    "iso2": "TC",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "TD",
+    "dialCode": "+235"
+  },
+  {
+    "iso2": "TG",
+    "dialCode": "+228"
+  },
+  {
+    "iso2": "TH",
+    "dialCode": "+66"
+  },
+  {
+    "iso2": "TJ",
+    "dialCode": "+992"
+  },
+  {
+    "iso2": "TK",
+    "dialCode": "+690"
+  },
+  {
+    "iso2": "TL",
+    "dialCode": "+670"
+  },
+  {
+    "iso2": "TM",
+    "dialCode": "+993"
+  },
+  {
+    "iso2": "TN",
+    "dialCode": "+216"
+  },
+  {
+    "iso2": "TO",
+    "dialCode": "+676"
+  },
+  {
+    "iso2": "TR",
+    "dialCode": "+90"
+  },
+  {
+    "iso2": "TT",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "TV",
+    "dialCode": "+688"
+  },
+  {
+    "iso2": "TW",
+    "dialCode": "+886"
+  },
+  {
+    "iso2": "TZ",
+    "dialCode": "+255"
+  },
+  {
+    "iso2": "UA",
+    "dialCode": "+380"
+  },
+  {
+    "iso2": "UG",
+    "dialCode": "+256"
+  },
+  {
+    "iso2": "US",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "UY",
+    "dialCode": "+598"
+  },
+  {
+    "iso2": "UZ",
+    "dialCode": "+998"
+  },
+  {
+    "iso2": "VA",
+    "dialCode": "+39"
+  },
+  {
+    "iso2": "VC",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "VE",
+    "dialCode": "+58"
+  },
+  {
+    "iso2": "VG",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "VI",
+    "dialCode": "+1"
+  },
+  {
+    "iso2": "VN",
+    "dialCode": "+84"
+  },
+  {
+    "iso2": "VU",
+    "dialCode": "+678"
+  },
+  {
+    "iso2": "WF",
+    "dialCode": "+681"
+  },
+  {
+    "iso2": "WS",
+    "dialCode": "+685"
+  },
+  {
+    "iso2": "XK",
+    "dialCode": "+383"
+  },
+  {
+    "iso2": "YE",
+    "dialCode": "+967"
+  },
+  {
+    "iso2": "YT",
+    "dialCode": "+262"
+  },
+  {
+    "iso2": "ZA",
+    "dialCode": "+27"
+  },
+  {
+    "iso2": "ZM",
+    "dialCode": "+260"
+  },
+  {
+    "iso2": "ZW",
+    "dialCode": "+263"
+  }
+] as CountryPhoneOption[];

--- a/frontend/src/features/auth/transport/passwordResetSetPassword.ts
+++ b/frontend/src/features/auth/transport/passwordResetSetPassword.ts
@@ -1,0 +1,22 @@
+export type PasswordResetSetPasswordResponse = { ok: boolean };
+
+export const passwordResetSetPassword = async (payload: {
+  email: string;
+  reset_token: string;
+  password: string;
+  confirm_password: string;
+}): Promise<PasswordResetSetPasswordResponse> => {
+  const response = await fetch('/api/password-reset/set-password', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ ...payload, email: payload.email.trim().toLowerCase() }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(errorBody?.detail ?? 'Unable to set a new password');
+  }
+
+  return response.json() as Promise<PasswordResetSetPasswordResponse>;
+};

--- a/frontend/src/features/auth/transport/passwordResetVerifyCode.ts
+++ b/frontend/src/features/auth/transport/passwordResetVerifyCode.ts
@@ -1,0 +1,24 @@
+export type PasswordResetVerifyCodeResponse = {
+  ok: boolean;
+  resetToken: string;
+  resetExpiresInSeconds: number;
+};
+
+export const passwordResetVerifyCode = async (payload: {
+  email: string;
+  code: string;
+}): Promise<PasswordResetVerifyCodeResponse> => {
+  const response = await fetch('/api/password-reset/verify-code', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ ...payload, email: payload.email.trim().toLowerCase() }),
+  });
+
+  if (!response.ok) {
+    const errorBody = (await response.json().catch(() => null)) as { detail?: string } | null;
+    throw new Error(errorBody?.detail ?? 'Unable to verify reset code');
+  }
+
+  return response.json() as Promise<PasswordResetVerifyCodeResponse>;
+};

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -85,6 +85,7 @@ const DashboardPage = ({
     <DashboardView
       mode="full"
       clientId={resolvedUiClient}
+      isAuthenticatedView={dataMode === "authenticated"}
       status={status}
       error={error}
       kpiWidgets={kpiWidgets}

--- a/frontend/src/features/dashboard/components/DashboardHeader.tsx
+++ b/frontend/src/features/dashboard/components/DashboardHeader.tsx
@@ -7,11 +7,13 @@ type DashboardHeaderProps = {
   clientId?: string;
   siteLabelOverride?: string;
   mode?: "full" | "preview";
+  isAuthenticatedView?: boolean;
 };
 
 const DashboardHeader: React.FC<DashboardHeaderProps> = ({
   siteLabelOverride,
   mode = "full",
+  isAuthenticatedView = false,
 }) => {
   const { siteId } = useParams();
   const siteLabel = useMemo(() => {
@@ -32,7 +34,7 @@ const DashboardHeader: React.FC<DashboardHeaderProps> = ({
         </div>
         {mode === "full" ? (
           <div className="vrm-dashboard-header-right">
-            <HeaderStatusStrip className="vrm-dashboard-header-meta" />
+            <HeaderStatusStrip className="vrm-dashboard-header-meta" isAuthenticatedView={isAuthenticatedView} />
           </div>
         ) : null}
       </div>

--- a/frontend/src/features/dashboard/components/DashboardView.tsx
+++ b/frontend/src/features/dashboard/components/DashboardView.tsx
@@ -16,6 +16,7 @@ interface DashboardViewProps {
   mode?: "full" | "preview";
   clientId?: string;
   siteLabel?: string;
+  isAuthenticatedView?: boolean;
   status: "idle" | "loading" | "ready" | "error";
   error: string | null;
   kpiWidgets: DashboardWidgetState[];
@@ -42,6 +43,7 @@ const DashboardView: React.FC<DashboardViewProps> = ({
   mode = "full",
   clientId,
   siteLabel,
+  isAuthenticatedView = false,
   status,
   error,
   kpiWidgets,
@@ -63,7 +65,7 @@ const DashboardView: React.FC<DashboardViewProps> = ({
       aria-busy={status === "loading"}
     >
       <div className="dashboard-v2__content vrm-dashboard-shell">
-        <DashboardHeader clientId={clientId} siteLabelOverride={siteLabel} mode={mode} />
+        <DashboardHeader clientId={clientId} siteLabelOverride={siteLabel} mode={mode} isAuthenticatedView={isAuthenticatedView} />
         {status === "error" && error ? (
           <div
             className={`dashboard-v2__error-banner ${

--- a/frontend/src/features/dashboard/hooks/useDashboardManifest.ts
+++ b/frontend/src/features/dashboard/hooks/useDashboardManifest.ts
@@ -25,6 +25,7 @@ type UseDashboardManifestParams = {
   credentials: Credentials;
   manifestLoader?: ManifestLoader;
   dashboardId?: string;
+  orgIdOverride?: string;
 };
 
 type UseDashboardManifestResult = {
@@ -48,12 +49,13 @@ export const useDashboardManifest = ({
   credentials,
   manifestLoader,
   dashboardId,
+  orgIdOverride,
 }: UseDashboardManifestParams): UseDashboardManifestResult => {
   const viewToken = useMemo(() => getViewTokenFromLocation(), []);
   const isDemoSession = useMemo(() => isDemoSessionActive(), []);
   const demoTimeRangeOverrideRef = useRef(consumeDemoTimeRangeOverride());
-  const orgId =
-    viewToken || isDemoSession ? undefined : determineOrgId(credentials);
+  const orgId = orgIdOverride
+    ?? (viewToken || isDemoSession ? undefined : determineOrgId(credentials));
   const resolvedDashboardId = dashboardId ?? "dashboard-default";
   const manifestLoaderImpl = manifestLoader ?? fetchDashboardManifest;
   const [manifest, setManifest] = useState<DashboardManifest | null>(null);

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -98,7 +98,7 @@ const initialWireLayout: WireLayout = {
 };
 
 
-const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDemo: () => void }> = ({ forceMockTopology, onAccessDemo }) => {
+const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDemo: () => void; previewOrgId?: string }> = ({ forceMockTopology, onAccessDemo, previewOrgId }) => {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const topClusterRef = useRef<HTMLDivElement | null>(null);
   const bottomClusterRef = useRef<HTMLDivElement | null>(null);
@@ -135,7 +135,7 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDem
     resolvedDashboardId,
     resolvedUiClient,
     setManifest,
-  } = useDashboardManifest({ credentials: PREVIEW_CREDENTIALS });
+  } = useDashboardManifest({ credentials: PREVIEW_CREDENTIALS, orgIdOverride: previewOrgId });
 
   const {
     status: widgetStatus,
@@ -688,13 +688,13 @@ const SystemOverviewPreview: React.FC<{ onAccessDemo: () => void }> = ({ onAcces
     return new URLSearchParams(location.search).get(TOPOLOGY_MOCK_PARAM) === "1";
   }, [location.search]);
   const hasViewToken = Boolean(getViewTokenFromLocation(location.search));
-  const isLoggedIn = typeof window !== "undefined" && Boolean(window.sessionStorage.getItem("camOS_credentials"));
+  const shouldUsePublicPreviewOrg = !hasViewToken && !isDemoSessionActive();
   const [bootstrapState, setBootstrapState] = useState<"idle" | "loading" | "ready" | "error">("idle");
   const [bootstrapDegraded, setBootstrapDegraded] = useState(false);
   const bootstrapStartedRef = useRef(false);
 
   const runBootstrap = async () => {
-    if (forceMockTopology || isLoggedIn || hasViewToken || isDemoSessionActive()) {
+    if (forceMockTopology || hasViewToken || isDemoSessionActive() || shouldUsePublicPreviewOrg) {
       setBootstrapState("ready");
       return;
     }
@@ -709,7 +709,7 @@ const SystemOverviewPreview: React.FC<{ onAccessDemo: () => void }> = ({ onAcces
     }
     bootstrapStartedRef.current = true;
     void runBootstrap();
-  }, [hasViewToken, isLoggedIn, forceMockTopology]);
+  }, [hasViewToken, forceMockTopology, shouldUsePublicPreviewOrg]);
 
   const handleRetry = () => {
     bootstrapStartedRef.current = false;
@@ -741,7 +741,11 @@ const SystemOverviewPreview: React.FC<{ onAccessDemo: () => void }> = ({ onAcces
 
   return (
     <>
-      <SystemOverviewLiveKpis forceMockTopology={forceMockTopology} onAccessDemo={onAccessDemo} />
+      <SystemOverviewLiveKpis
+        forceMockTopology={forceMockTopology}
+        onAccessDemo={onAccessDemo}
+        previewOrgId={shouldUsePublicPreviewOrg ? "client1" : undefined}
+      />
       {bootstrapDegraded ? <p className={styles.errorNote}>Demo bootstrap unavailable; preview is using direct live data flow.</p> : null}
     </>
   );

--- a/frontend/src/features/reports/ReportsPage.tsx
+++ b/frontend/src/features/reports/ReportsPage.tsx
@@ -629,7 +629,7 @@ const ReportsPage: React.FC<ReportsPageProps> = ({
   };
   const handleGenerateReport = () => {
     if (!isDemoMode) {
-      setDownloadBlockedMessage("Report download is unavailable in authenticated mode.");
+      setDownloadBlockedMessage("No Sites Connected");
       return;
     }
     setDownloadBlockedMessage(null);

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -56,6 +56,11 @@
   gap: 8px;
 }
 
+.settings-select option {
+  background: #161d28;
+  color: var(--vrm-text-primary);
+}
+
 .settings-edit-icon-btn {
   width: 32px;
   height: 32px;
@@ -127,6 +132,16 @@
 
 .settings-multiselect-option input {
   accent-color: var(--vrm-accent-blue);
+}
+
+.settings-multiselect-error {
+  margin-top: 6px;
+}
+
+.settings-current-user-site-cell {
+  display: grid;
+  gap: 8px;
+  min-width: 220px;
 }
 
 .settings-inline-error,

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -211,7 +211,7 @@
 
 @media (max-width: 900px) {
   .settings-field-row {
-    grid-template-columns: 1fr;
+    grid-template-columns: 120px minmax(0, 1fr) auto;
     gap: 10px;
   }
 
@@ -220,8 +220,8 @@
   }
 
   .settings-field-actions {
-    width: 100%;
-    justify-content: flex-start;
+    width: auto;
+    justify-content: flex-end;
   }
 }
 
@@ -263,10 +263,6 @@
   padding: 0 20px 18px;
 }
 
-.settings-account-locked-layout .settings-field-row {
-  grid-template-columns: 160px minmax(0, 1fr);
-}
-
 @media (max-width: 900px) {
   .settings-account-header-actions {
     width: 100%;
@@ -274,8 +270,22 @@
     grid-template-columns: 1fr;
     align-items: stretch;
   }
+}
 
-  .settings-account-locked-layout .settings-field-row {
-    grid-template-columns: 1fr;
-  }
+.settings-users-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.settings-save-cta--active {
+  box-shadow: 0 0 0 2px rgba(137, 180, 255, 0.28);
+}
+
+.settings-save-cta--inactive {
+  opacity: 0.7;
+}
+
+.settings-manage-access-save-message {
+  padding: 0 16px 14px;
 }

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -56,6 +56,24 @@
   gap: 8px;
 }
 
+.settings-edit-icon-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid var(--vrm-border-subtle);
+  background: var(--vrm-surface-secondary);
+  color: var(--vrm-text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.settings-edit-icon-btn:hover,
+.settings-edit-icon-btn:focus-visible {
+  border-color: rgba(137, 180, 255, 0.55);
+}
+
 .settings-inline-error,
 .settings-form-error {
   color: #ff8b8b;

--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -74,6 +74,61 @@
   border-color: rgba(137, 180, 255, 0.55);
 }
 
+
+
+.settings-field-row--readonly {
+  align-items: center;
+}
+
+.settings-multiselect {
+  position: relative;
+}
+
+.settings-multiselect-trigger {
+  width: 100%;
+  min-height: 40px;
+  border: 1px solid var(--vrm-border-subtle);
+  border-radius: 8px;
+  background: var(--vrm-surface-secondary);
+  color: var(--vrm-text-primary);
+  padding: 8px 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.settings-multiselect-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  background: #161d28;
+  border: 1px solid var(--vrm-border-subtle);
+  border-radius: 8px;
+  padding: 6px;
+  display: grid;
+  gap: 2px;
+  box-shadow: 0 12px 24px rgba(0,0,0,0.35);
+}
+
+.settings-multiselect-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  color: var(--vrm-text-primary);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.settings-multiselect-option:hover {
+  background: rgba(255,255,255,0.06);
+}
+
+.settings-multiselect-option input {
+  accent-color: var(--vrm-accent-blue);
+}
+
 .settings-inline-error,
 .settings-form-error {
   color: #ff8b8b;

--- a/frontend/src/features/settings/components/EditableFieldRow.tsx
+++ b/frontend/src/features/settings/components/EditableFieldRow.tsx
@@ -46,7 +46,7 @@ const EditableFieldRow: React.FC<EditableFieldRowProps> = ({
   };
 
   return (
-    <div className={`settings-field-row ${isEditing ? "settings-field-row--editing" : ""}`}>
+    <div className={`settings-field-row ${isEditing ? "settings-field-row--editing" : "settings-field-row--readonly"}`}>
       <div className="settings-field-label">{label}</div>
       <div className="settings-field-main">
         {!isEditing ? (

--- a/frontend/src/features/settings/components/EditableFieldRow.tsx
+++ b/frontend/src/features/settings/components/EditableFieldRow.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { PenLine } from "lucide-react";
 
 type EditableFieldRowProps = {
   label: string;
@@ -65,8 +66,8 @@ const EditableFieldRow: React.FC<EditableFieldRowProps> = ({
       </div>
       <div className="settings-field-actions">
         {!isEditing ? (
-          <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={onEdit}>
-            Edit
+          <button className="settings-edit-icon-btn" onClick={onEdit} aria-label={`Edit ${label}`}>
+            <PenLine size={14} aria-hidden="true" />
           </button>
         ) : (
           <>

--- a/frontend/src/features/settings/components/InviteUserModal.tsx
+++ b/frontend/src/features/settings/components/InviteUserModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 
 import type { AccessLevel } from "../types";
+import SiteMultiSelect from "./SiteMultiSelect";
 import styles from "./InviteUserModal.module.css";
 
 type InviteUserModalProps = {
@@ -15,13 +16,13 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSubmitted }) => {
   const [email, setEmail] = useState("");
-  const [site, setSite] = useState("all-sites");
+  const [sites, setSites] = useState<string[]>(["all-sites"]);
   const [accessLevel, setAccessLevel] = useState<AccessLevel>("Viewer");
   const [state, setState] = useState<InviteState>("closed");
   const [error, setError] = useState<string | null>(null);
   const emailInputRef = useRef<HTMLInputElement | null>(null);
 
-  const isValid = EMAIL_RE.test(email.trim()) && Boolean(site.trim()) && Boolean(accessLevel);
+  const isValid = EMAIL_RE.test(email.trim()) && sites.length > 0 && Boolean(accessLevel);
 
   useEffect(() => {
     if (!isOpen) {
@@ -57,7 +58,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
 
   const resetState = () => {
     setEmail("");
-    setSite("all-sites");
+    setSites(["all-sites"]);
     setAccessLevel("Viewer");
     setState("closed");
     setError(null);
@@ -72,6 +73,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
     event.preventDefault();
     if (!isValid || state === "submitting") {
       setState("invalid");
+      setError(sites.length === 0 ? "Sites required" : null);
       return;
     }
 
@@ -81,7 +83,7 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
     try {
       await onSubmitted({
         email: email.trim(),
-        site,
+        site: sites[0],
         accessLevel,
       });
       handleClose();
@@ -116,14 +118,18 @@ const InviteUserModal: React.FC<InviteUserModalProps> = ({ isOpen, onClose, onSu
             </div>
             <div className="settings-form-field">
               <label className="settings-form-label" htmlFor="invite-site">Site</label>
-              <select
-                id="invite-site"
-                className={`settings-select ${styles.select}`}
-                value={site}
-                onChange={(event) => setSite(event.target.value)}
-              >
-                <option value="all-sites">All Sites</option>
-              </select>
+              <SiteMultiSelect
+                options={[{ id: "all-sites", label: "All Sites" }]}
+                selectedSites={sites}
+                onChange={(next) => {
+                  setSites(next);
+                  if (next.length > 0) {
+                    setError(null);
+                  }
+                }}
+                placeholder="Select sites"
+                error={state === "invalid" && sites.length === 0 ? "Sites required" : null}
+              />
             </div>
             <div className="settings-form-field">
               <label className="settings-form-label" htmlFor="invite-level">Access level</label>

--- a/frontend/src/features/settings/components/SiteMultiSelect.tsx
+++ b/frontend/src/features/settings/components/SiteMultiSelect.tsx
@@ -1,0 +1,90 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+type SiteOption = { id: string; label: string };
+
+type SiteMultiSelectProps = {
+  options: SiteOption[];
+  selectedSites: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+};
+
+const ALL_SITE_ID = "all-sites";
+
+const SiteMultiSelect: React.FC<SiteMultiSelectProps> = ({
+  options,
+  selectedSites,
+  onChange,
+  placeholder = "Select sites",
+}) => {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleDocClick = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleDocClick);
+    return () => document.removeEventListener("mousedown", handleDocClick);
+  }, [open]);
+
+  const selectedLabel = useMemo(() => {
+    if (selectedSites.length === 0) {
+      return placeholder;
+    }
+    const labels = options
+      .filter((option) => selectedSites.includes(option.id))
+      .map((option) => option.label);
+    return labels.join(", ");
+  }, [options, placeholder, selectedSites]);
+
+  const toggleOption = (siteId: string) => {
+    if (siteId === ALL_SITE_ID) {
+      onChange([ALL_SITE_ID]);
+      return;
+    }
+
+    const withoutAll = selectedSites.filter((item) => item !== ALL_SITE_ID);
+    if (withoutAll.includes(siteId)) {
+      onChange(withoutAll.filter((item) => item !== siteId));
+      return;
+    }
+    onChange([...withoutAll, siteId]);
+  };
+
+  return (
+    <div className="settings-multiselect" ref={containerRef}>
+      <button
+        type="button"
+        className="settings-multiselect-trigger"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        {selectedLabel}
+      </button>
+
+      {open ? (
+        <div className="settings-multiselect-menu" role="listbox" aria-multiselectable="true">
+          {options.map((option) => {
+            const checked = selectedSites.includes(option.id);
+            return (
+              <label className="settings-multiselect-option" key={option.id}>
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  onChange={() => toggleOption(option.id)}
+                />
+                <span>{option.label}</span>
+              </label>
+            );
+          })}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+export default SiteMultiSelect;

--- a/frontend/src/features/settings/components/SiteMultiSelect.tsx
+++ b/frontend/src/features/settings/components/SiteMultiSelect.tsx
@@ -7,6 +7,7 @@ type SiteMultiSelectProps = {
   selectedSites: string[];
   onChange: (next: string[]) => void;
   placeholder?: string;
+  error?: string | null;
 };
 
 const ALL_SITE_ID = "all-sites";
@@ -16,6 +17,7 @@ const SiteMultiSelect: React.FC<SiteMultiSelectProps> = ({
   selectedSites,
   onChange,
   placeholder = "Select sites",
+  error,
 }) => {
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -43,6 +45,10 @@ const SiteMultiSelect: React.FC<SiteMultiSelectProps> = ({
 
   const toggleOption = (siteId: string) => {
     if (siteId === ALL_SITE_ID) {
+      if (selectedSites.includes(ALL_SITE_ID)) {
+        onChange([]);
+        return;
+      }
       onChange([ALL_SITE_ID]);
       return;
     }
@@ -83,6 +89,7 @@ const SiteMultiSelect: React.FC<SiteMultiSelectProps> = ({
           })}
         </div>
       ) : null}
+      {error ? <div className="settings-inline-error settings-multiselect-error">{error}</div> : null}
     </div>
   );
 };

--- a/frontend/src/features/settings/components/UsersTable.tsx
+++ b/frontend/src/features/settings/components/UsersTable.tsx
@@ -9,7 +9,6 @@ type UsersTableProps = {
   currentUserSites: string[];
   currentUserSitesError?: string | null;
   onCurrentUserSitesChange: (sites: string[]) => void;
-  onCurrentUserSitesSave: () => void;
   siteOptions: Array<{ id: string; label: string }>;
 };
 
@@ -19,7 +18,6 @@ const UsersTable: React.FC<UsersTableProps> = ({
   currentUserSites,
   currentUserSitesError,
   onCurrentUserSitesChange,
-  onCurrentUserSitesSave,
   siteOptions,
 }) => (
   <div className="settings-table-wrap">
@@ -41,18 +39,13 @@ const UsersTable: React.FC<UsersTableProps> = ({
               <td>{user.email}</td>
               <td>
                 {isCurrentUser ? (
-                  <div className="settings-current-user-site-cell">
-                    <SiteMultiSelect
-                      options={siteOptions}
-                      selectedSites={currentUserSites}
-                      onChange={onCurrentUserSitesChange}
-                      placeholder="Select sites"
-                      error={currentUserSitesError}
-                    />
-                    <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={onCurrentUserSitesSave}>
-                      Save
-                    </button>
-                  </div>
+                  <SiteMultiSelect
+                    options={siteOptions}
+                    selectedSites={currentUserSites}
+                    onChange={onCurrentUserSitesChange}
+                    placeholder="Select sites"
+                    error={currentUserSitesError}
+                  />
                 ) : (
                   user.site
                 )}

--- a/frontend/src/features/settings/components/UsersTable.tsx
+++ b/frontend/src/features/settings/components/UsersTable.tsx
@@ -1,19 +1,22 @@
 import React from "react";
+import SiteMultiSelect from "./SiteMultiSelect";
 
 import type { ManagedUser } from "../types";
 
 type UsersTableProps = {
   users: ManagedUser[];
   currentUsername?: string;
-  currentUserSite: string;
-  onCurrentUserSiteChange: (site: string) => void;
+  currentUserSites: string[];
+  onCurrentUserSitesChange: (sites: string[]) => void;
+  siteOptions: Array<{ id: string; label: string }>;
 };
 
 const UsersTable: React.FC<UsersTableProps> = ({
   users,
   currentUsername,
-  currentUserSite,
-  onCurrentUserSiteChange,
+  currentUserSites,
+  onCurrentUserSitesChange,
+  siteOptions,
 }) => (
   <div className="settings-table-wrap">
     <table className="vrm-table settings-table">
@@ -34,13 +37,12 @@ const UsersTable: React.FC<UsersTableProps> = ({
               <td>{user.email}</td>
               <td>
                 {isCurrentUser ? (
-                  <select
-                    className="settings-select settings-site-select"
-                    value={currentUserSite}
-                    onChange={(event) => onCurrentUserSiteChange(event.target.value)}
-                  >
-                    <option value="all-sites">All Sites</option>
-                  </select>
+                  <SiteMultiSelect
+                    options={siteOptions}
+                    selectedSites={currentUserSites}
+                    onChange={onCurrentUserSitesChange}
+                    placeholder="Select sites"
+                  />
                 ) : (
                   user.site
                 )}

--- a/frontend/src/features/settings/components/UsersTable.tsx
+++ b/frontend/src/features/settings/components/UsersTable.tsx
@@ -7,7 +7,9 @@ type UsersTableProps = {
   users: ManagedUser[];
   currentUsername?: string;
   currentUserSites: string[];
+  currentUserSitesError?: string | null;
   onCurrentUserSitesChange: (sites: string[]) => void;
+  onCurrentUserSitesSave: () => void;
   siteOptions: Array<{ id: string; label: string }>;
 };
 
@@ -15,7 +17,9 @@ const UsersTable: React.FC<UsersTableProps> = ({
   users,
   currentUsername,
   currentUserSites,
+  currentUserSitesError,
   onCurrentUserSitesChange,
+  onCurrentUserSitesSave,
   siteOptions,
 }) => (
   <div className="settings-table-wrap">
@@ -37,12 +41,18 @@ const UsersTable: React.FC<UsersTableProps> = ({
               <td>{user.email}</td>
               <td>
                 {isCurrentUser ? (
-                  <SiteMultiSelect
-                    options={siteOptions}
-                    selectedSites={currentUserSites}
-                    onChange={onCurrentUserSitesChange}
-                    placeholder="Select sites"
-                  />
+                  <div className="settings-current-user-site-cell">
+                    <SiteMultiSelect
+                      options={siteOptions}
+                      selectedSites={currentUserSites}
+                      onChange={onCurrentUserSitesChange}
+                      placeholder="Select sites"
+                      error={currentUserSitesError}
+                    />
+                    <button type="button" className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={onCurrentUserSitesSave}>
+                      Save
+                    </button>
+                  </div>
                 ) : (
                   user.site
                 )}

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -19,9 +19,13 @@ const ManageAccessPage: React.FC = () => {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const [currentUser, setCurrentUser] = useState<SettingsUser | null>(null);
-  const [currentUserSite, setCurrentUserSite] = useState("all-sites");
+  const [currentUserSites, setCurrentUserSites] = useState<string[]>(["all-sites"]);
   const [isInviteOpen, setIsInviteOpen] = useState(false);
   const inviteButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const siteOptions = [
+    { id: "all-sites", label: "All Sites" },
+  ];
 
   useEffect(() => {
     const load = async () => {
@@ -89,8 +93,9 @@ const ManageAccessPage: React.FC = () => {
           <UsersTable
             users={users}
             currentUsername={currentUser?.name}
-            currentUserSite={currentUserSite}
-            onCurrentUserSiteChange={setCurrentUserSite}
+            currentUserSites={currentUserSites}
+            onCurrentUserSitesChange={setCurrentUserSites}
+            siteOptions={siteOptions}
           />
         </div>
       </div>

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -21,11 +21,27 @@ const ManageAccessPage: React.FC = () => {
   const [currentUser, setCurrentUser] = useState<SettingsUser | null>(null);
   const [currentUserSites, setCurrentUserSites] = useState<string[]>(["all-sites"]);
   const [isInviteOpen, setIsInviteOpen] = useState(false);
+  const [currentUserSitesError, setCurrentUserSitesError] = useState<string | null>(null);
   const inviteButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const siteOptions = [
     { id: "all-sites", label: "All Sites" },
   ];
+
+  const handleCurrentUserSitesChange = (sites: string[]) => {
+    setCurrentUserSites(sites);
+    if (sites.length > 0) {
+      setCurrentUserSitesError(null);
+    }
+  };
+
+  const handleCurrentUserSitesSave = () => {
+    if (currentUserSites.length === 0) {
+      setCurrentUserSitesError("Sites required");
+      return;
+    }
+    setCurrentUserSitesError(null);
+  };
 
   useEffect(() => {
     const load = async () => {
@@ -94,7 +110,9 @@ const ManageAccessPage: React.FC = () => {
             users={users}
             currentUsername={currentUser?.name}
             currentUserSites={currentUserSites}
-            onCurrentUserSitesChange={setCurrentUserSites}
+            currentUserSitesError={currentUserSitesError}
+            onCurrentUserSitesChange={handleCurrentUserSitesChange}
+            onCurrentUserSitesSave={handleCurrentUserSitesSave}
             siteOptions={siteOptions}
           />
         </div>

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import {
   getManagedUsers,
@@ -19,29 +19,22 @@ const ManageAccessPage: React.FC = () => {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [invites, setInvites] = useState<PendingInvite[]>([]);
   const [currentUser, setCurrentUser] = useState<SettingsUser | null>(null);
+  const [baselineCurrentUserSites, setBaselineCurrentUserSites] = useState<string[]>(["all-sites"]);
   const [currentUserSites, setCurrentUserSites] = useState<string[]>(["all-sites"]);
-  const [isInviteOpen, setIsInviteOpen] = useState(false);
   const [currentUserSitesError, setCurrentUserSitesError] = useState<string | null>(null);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [isInviteOpen, setIsInviteOpen] = useState(false);
   const inviteButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const siteOptions = [
     { id: "all-sites", label: "All Sites" },
   ];
 
-  const handleCurrentUserSitesChange = (sites: string[]) => {
-    setCurrentUserSites(sites);
-    if (sites.length > 0) {
-      setCurrentUserSitesError(null);
-    }
-  };
-
-  const handleCurrentUserSitesSave = () => {
-    if (currentUserSites.length === 0) {
-      setCurrentUserSitesError("Sites required");
-      return;
-    }
-    setCurrentUserSitesError(null);
-  };
+  const isDirty = useMemo(() => {
+    const left = [...baselineCurrentUserSites].sort().join("|");
+    const right = [...currentUserSites].sort().join("|");
+    return left !== right;
+  }, [baselineCurrentUserSites, currentUserSites]);
 
   useEffect(() => {
     const load = async () => {
@@ -61,10 +54,30 @@ const ManageAccessPage: React.FC = () => {
 
       setUsers([currentUserRow, ...loadedUsers]);
       setInvites(loadedInvites);
+      setBaselineCurrentUserSites(["all-sites"]);
+      setCurrentUserSites(["all-sites"]);
     };
 
     load();
   }, []);
+
+  const handleCurrentUserSitesChange = (sites: string[]) => {
+    setCurrentUserSites(sites);
+    setSaveMessage(null);
+    if (sites.length > 0) {
+      setCurrentUserSitesError(null);
+    }
+  };
+
+  const handleCurrentUserSitesSave = () => {
+    if (currentUserSites.length === 0) {
+      setCurrentUserSitesError("Sites required");
+      return;
+    }
+    setCurrentUserSitesError(null);
+    setBaselineCurrentUserSites(currentUserSites);
+    setSaveMessage("Access settings saved.");
+  };
 
   const handleInviteSubmit = async (payload: {
     email: string;
@@ -102,7 +115,14 @@ const ManageAccessPage: React.FC = () => {
       />
 
       <div className="vrm-card">
-        <div className="vrm-card-header">
+        <div className="vrm-card-header settings-users-card-header">
+          <button
+            type="button"
+            className={`vrm-btn vrm-btn-sm ${isDirty ? "vrm-btn-primary settings-save-cta--active" : "vrm-btn-secondary settings-save-cta--inactive"}`}
+            onClick={handleCurrentUserSitesSave}
+          >
+            Save
+          </button>
           <h2 className="vrm-card-title">Users</h2>
         </div>
         <div className="vrm-card-body settings-table-card-body">
@@ -112,9 +132,9 @@ const ManageAccessPage: React.FC = () => {
             currentUserSites={currentUserSites}
             currentUserSitesError={currentUserSitesError}
             onCurrentUserSitesChange={handleCurrentUserSitesChange}
-            onCurrentUserSitesSave={handleCurrentUserSitesSave}
             siteOptions={siteOptions}
           />
+          {saveMessage ? <div className="settings-form-message settings-manage-access-save-message">{saveMessage}</div> : null}
         </div>
       </div>
 

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -33,6 +33,7 @@ type FormErrorState = {
 };
 
 const PHONE_RE = /^\+[1-9]\d{6,14}$/;
+const INTERNAL_UNLOCK_SESSION_SECONDS = 300;
 
 const maskEmail = (email: string) => {
   const [localPart, domain] = email.split("@");
@@ -181,7 +182,14 @@ const MyAccountPage: React.FC = () => {
       const updatedUser = await updateMe(payload);
       setUser(updatedUser);
       setSaveMessage("Account updated successfully.");
-      relock(updatedUser);
+      setActiveEditingRowId(null);
+      setErrors({});
+      setDrafts({
+        name: updatedUser.name,
+        phone: updatedUser.phone ?? "",
+        password: "",
+        confirmPassword: "",
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unable to save";
       if (message.toLowerCase().includes("unlock")) {
@@ -259,7 +267,7 @@ const MyAccountPage: React.FC = () => {
             onChange={(value) => setDrafts((prev) => ({ ...prev, phone: value }))}
           />
 
-          <div className="settings-field-row">
+          <div className={`settings-field-row ${activeEditingRowId !== "password" ? "settings-field-row--readonly" : ""}`}>
             <div className="settings-field-label">Password</div>
             <div className="settings-field-main">
               {activeEditingRowId !== "password" ? (
@@ -295,9 +303,9 @@ const MyAccountPage: React.FC = () => {
       <ReenterPasswordModal
         isOpen={isUnlockOpen}
         onClose={() => setIsUnlockOpen(false)}
-        onVerified={({ unlockToken: verifiedUnlockToken, unlockExpiresInSeconds }) => {
+        onVerified={({ unlockToken: verifiedUnlockToken }) => {
           setUnlockToken(verifiedUnlockToken);
-          setUnlockExpiresAt(Date.now() + (unlockExpiresInSeconds * 1000));
+          setUnlockExpiresAt(Date.now() + (INTERNAL_UNLOCK_SESSION_SECONDS * 1000));
           setIsUnlocked(true);
           setIsUnlockOpen(false);
           setErrors({});

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { PenLine } from "lucide-react";
 
 import {
@@ -32,6 +32,11 @@ type FormErrorState = {
   form?: string;
 };
 
+type UnlockSession = {
+  token: string;
+  expiresAt: number;
+} | null;
+
 const PHONE_RE = /^\+[1-9]\d{6,14}$/;
 const INTERNAL_UNLOCK_SESSION_SECONDS = 300;
 
@@ -56,9 +61,7 @@ const MyAccountPage: React.FC = () => {
   const [user, setUser] = useState<SettingsUser | null>(null);
   const [loadingError, setLoadingError] = useState<string | null>(null);
   const [isUnlockOpen, setIsUnlockOpen] = useState(false);
-  const [isUnlocked, setIsUnlocked] = useState(false);
-  const [unlockToken, setUnlockToken] = useState<string | null>(null);
-  const [unlockExpiresAt, setUnlockExpiresAt] = useState<number | null>(null);
+  const [unlockSession, setUnlockSession] = useState<UnlockSession>(null);
   const [saveMessage, setSaveMessage] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [activeEditingRowId, setActiveEditingRowId] = useState<RowId>(null);
@@ -69,6 +72,8 @@ const MyAccountPage: React.FC = () => {
     password: "",
     confirmPassword: "",
   });
+
+  const isUnlocked = useMemo(() => Boolean(unlockSession && Date.now() < unlockSession.expiresAt), [unlockSession]);
 
   useEffect(() => {
     const load = async () => {
@@ -84,36 +89,25 @@ const MyAccountPage: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    if (!isUnlocked || !unlockExpiresAt) {
+    if (!unlockSession) {
       return;
     }
     const timer = window.setInterval(() => {
-      if (Date.now() >= unlockExpiresAt) {
-        setIsUnlocked(false);
-        setUnlockToken(null);
-        setUnlockExpiresAt(null);
+      if (Date.now() >= unlockSession.expiresAt) {
+        setUnlockSession(null);
         setActiveEditingRowId(null);
         setErrors((prev) => ({ ...prev, form: "Editing lock expired. Unlock again to continue." }));
       }
     }, 1000);
     return () => window.clearInterval(timer);
-  }, [isUnlocked, unlockExpiresAt]);
+  }, [unlockSession]);
 
   const resetDrafts = (nextUser: SettingsUser) => {
     setDrafts({ name: nextUser.name, phone: nextUser.phone ?? "", password: "", confirmPassword: "" });
   };
 
-  const isUnlockSessionActive = () => {
-    if (!unlockToken || !unlockExpiresAt) {
-      return false;
-    }
-    return Date.now() < unlockExpiresAt;
-  };
-
   const relock = (nextUser?: SettingsUser) => {
-    setIsUnlocked(false);
-    setUnlockToken(null);
-    setUnlockExpiresAt(null);
+    setUnlockSession(null);
     setActiveEditingRowId(null);
     setErrors({});
     if (nextUser) {
@@ -124,7 +118,7 @@ const MyAccountPage: React.FC = () => {
   };
 
   const requestEdit = (rowId: Exclude<RowId, null>) => {
-    if (!isUnlocked || !isUnlockSessionActive()) {
+    if (!isUnlocked || !unlockSession) {
       relock();
       setIsUnlockOpen(true);
       return;
@@ -138,14 +132,14 @@ const MyAccountPage: React.FC = () => {
   };
 
   const handleSave = async (rowId: Exclude<RowId, null>) => {
-    if (!user || !unlockToken || !isUnlockSessionActive()) {
+    if (!user || !unlockSession || !isUnlocked) {
       relock();
       setErrors({ form: "Unlock required before saving" });
       return;
     }
 
     const nextErrors: FormErrorState = {};
-    const payload: Record<string, string> = { unlock_token: unlockToken };
+    const payload: Record<string, string> = { unlock_token: unlockSession.token };
 
     if (rowId === "name") {
       const trimmedName = drafts.name.trim();
@@ -233,7 +227,7 @@ const MyAccountPage: React.FC = () => {
         )}
       />
       <div className="vrm-card">
-        <div className={`vrm-card-body settings-account-card-body ${!isUnlocked ? "settings-account-locked-layout" : ""}`}>
+        <div className="vrm-card-body settings-account-card-body">
           <EditableFieldRow
             label="Username"
             displayValue={user.name}
@@ -251,12 +245,13 @@ const MyAccountPage: React.FC = () => {
             onChange={(value) => setDrafts((prev) => ({ ...prev, name: value }))}
           />
 
-          <div className="settings-field-row">
+          <div className="settings-field-row settings-field-row--readonly">
             <div className="settings-field-label">Email</div>
             <div className="settings-field-main">
               <div className="settings-field-value">{maskEmail(user.email)}</div>
               <div className="settings-field-help">Email cannot be changed from My Account.</div>
             </div>
+            <div className="settings-field-actions" aria-hidden="true" />
           </div>
 
           <EditableFieldRow
@@ -313,9 +308,10 @@ const MyAccountPage: React.FC = () => {
         isOpen={isUnlockOpen}
         onClose={() => setIsUnlockOpen(false)}
         onVerified={({ unlockToken: verifiedUnlockToken }) => {
-          setUnlockToken(verifiedUnlockToken);
-          setUnlockExpiresAt(Date.now() + (INTERNAL_UNLOCK_SESSION_SECONDS * 1000));
-          setIsUnlocked(true);
+          setUnlockSession({
+            token: verifiedUnlockToken,
+            expiresAt: Date.now() + (INTERNAL_UNLOCK_SESSION_SECONDS * 1000),
+          });
           setIsUnlockOpen(false);
           setErrors({});
           setSaveMessage(null);

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { PenLine } from "lucide-react";
 
 import {
   getMe,
@@ -215,7 +216,7 @@ const MyAccountPage: React.FC = () => {
         )}
       />
       <div className="vrm-card">
-        <div className="vrm-card-body settings-account-card-body settings-account-locked-layout">
+        <div className={`vrm-card-body settings-account-card-body ${!isUnlocked ? "settings-account-locked-layout" : ""}`}>
           <EditableFieldRow
             label="Username"
             displayValue={user.name}
@@ -274,7 +275,9 @@ const MyAccountPage: React.FC = () => {
             </div>
             <div className="settings-field-actions">
               {activeEditingRowId !== "password" ? (
-                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => requestEdit("password")}>Edit</button>
+                <button className="settings-edit-icon-btn" onClick={() => requestEdit("password")} aria-label="Edit password">
+                  <PenLine size={14} aria-hidden="true" />
+                </button>
               ) : (
                 <>
                   <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={() => { setActiveEditingRowId(null); setDrafts((prev) => ({ ...prev, password: "", confirmPassword: "" })); setErrors({}); }} disabled={saving}>Cancel</button>

--- a/frontend/src/features/settings/pages/MyAccountPage.tsx
+++ b/frontend/src/features/settings/pages/MyAccountPage.tsx
@@ -103,6 +103,13 @@ const MyAccountPage: React.FC = () => {
     setDrafts({ name: nextUser.name, phone: nextUser.phone ?? "", password: "", confirmPassword: "" });
   };
 
+  const isUnlockSessionActive = () => {
+    if (!unlockToken || !unlockExpiresAt) {
+      return false;
+    }
+    return Date.now() < unlockExpiresAt;
+  };
+
   const relock = (nextUser?: SettingsUser) => {
     setIsUnlocked(false);
     setUnlockToken(null);
@@ -117,7 +124,8 @@ const MyAccountPage: React.FC = () => {
   };
 
   const requestEdit = (rowId: Exclude<RowId, null>) => {
-    if (!isUnlocked) {
+    if (!isUnlocked || !isUnlockSessionActive()) {
+      relock();
       setIsUnlockOpen(true);
       return;
     }
@@ -130,7 +138,8 @@ const MyAccountPage: React.FC = () => {
   };
 
   const handleSave = async (rowId: Exclude<RowId, null>) => {
-    if (!user || !unlockToken) {
+    if (!user || !unlockToken || !isUnlockSessionActive()) {
+      relock();
       setErrors({ form: "Unlock required before saving" });
       return;
     }


### PR DESCRIPTION
### Motivation
- Implement a more secure, multi-step password reset flow that separates code verification from setting a new password and enforces a short reset session lifetime.
- Improve email error handling and require admin notification address only where needed for admin emails.
- Improve frontend UX for password reset, contact submission, account phone selection, and settings inline editing.

### Description
- Backend: introduce `PASSWORD_RESET_SESSION_TTL_SECONDS`, add `_raise_password_reset_mail_delivery_error`, split password reset into `/api/password-reset/verify-code` (returns a short-lived `resetToken`) and `/api/password-reset/set-password` (consumes `reset_token` to set the new password), keep a legacy `/api/password-reset/verify` endpoint for compatibility, and persist hashed reset session tokens in pending resets.
- Backend: simplify Postmark config to not store `ADMIN_NOTIFY_EMAIL` in the base config and add `_require_admin_notify_email()` so admin-targeted senders fetch and validate the admin email only when used; update admin notification and contact-sending calls accordingly.
- Frontend: update routing and app mode logic and add routes for the new reset steps (`/reset-password/code`, `/reset-password/new`), update `LoginPage` to start password reset and navigate to code entry, and refactor `ResetPasswordPage` into distinct code verification and set-password flows with a resend cooldown and client-side navigation using the returned `resetToken`.
- Frontend: add `countryPhoneData` dataset and use it in `CreateAccountPage`; add contact success modal and file input clearing in `ContactPage`; introduce a compact edit icon button and `PenLine` usage for inline editing in settings (`EditableFieldRow` and `MyAccountPage`); add `orgIdOverride` support in `useDashboardManifest` and supply a preview org id in the system overview preview.
- Misc: multiple small CSS spacing/tweak changes to CreateAccount, Contact, and Settings pages, and new transport modules `passwordResetVerifyCode` and `passwordResetSetPassword` for API calls.

### Testing
- Ran frontend TypeScript build and checks (`pnpm build` / typecheck) which completed successfully.
- Ran frontend linting and tests (`pnpm test` / lint) with no failures reported.
- Ran backend lint and unit tests (via `pytest`) which passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad685f45cc83328bc301603d09e6cd)