### PR TITLE
Add Cookiebot consent script to frontend index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="f87b8197-a211-42fb-9e93-64d8922f4987" data-blockingmode="auto" type="text/javascript"></script>
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="f87b8197-a211-42fb-9e93-64d8922f4987" type="text/javascript"></script>
     <link rel="icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <title>camOS</title>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="f87b8197-a211-42fb-9e93-64d8922f4987" data-blockingmode="auto" type="text/javascript"></script>
     <link rel="icon" href="/favicon.svg" />
     <link rel="manifest" href="/manifest.json" />
     <title>camOS</title>

--- a/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
+++ b/frontend/src/analytics/components/ChartRenderer/primitives/TrafficDistribution.tsx
@@ -53,6 +53,9 @@ export const TrafficDistribution = ({
   const isPreviewPalette =
     typeof className === "string" &&
     className.includes("dashboard-v2__kpi-renderer--preview");
+  const isLandingPreviewTraffic =
+    typeof className === "string" &&
+    className.includes("dashboard-v2__kpi-renderer--landing-preview-traffic");
   const palette = isPreviewPalette
     ? PREVIEW_SLICE_COLORS
     : isVrmTraffic
@@ -171,28 +174,36 @@ export const TrafficDistribution = ({
               nameKey={labelKey ?? undefined}
               cx="50%"
               cy="50%"
-              innerRadius={48}
+              innerRadius={isLandingPreviewTraffic ? 0 : 48}
               outerRadius={68}
               paddingAngle={0}
               startAngle={90}
               endAngle={450}
               label={undefined}
               labelLine={false}
-              stroke="none"
+              stroke={isLandingPreviewTraffic ? "rgba(15, 23, 42, 0.2)" : "none"}
+              strokeWidth={isLandingPreviewTraffic ? 1 : 0}
               isAnimationActive={false}
             >
               {pieLegend.map((entry) => (
-                <Cell key={entry.label} fill={entry.color} stroke="none" />
+                <Cell
+                  key={entry.label}
+                  fill={entry.color}
+                  stroke={isLandingPreviewTraffic ? "rgba(15, 23, 42, 0.2)" : "none"}
+                  strokeWidth={isLandingPreviewTraffic ? 1 : 0}
+                />
               ))}
-              <text
-                x="50%"
-                y="50%"
-                textAnchor="middle"
-                dominantBaseline="middle"
-                className="traffic-distribution__center"
-              >
-                {topCameraLabel}
-              </text>
+              {!isLandingPreviewTraffic ? (
+                <text
+                  x="50%"
+                  y="50%"
+                  textAnchor="middle"
+                  dominantBaseline="middle"
+                  className="traffic-distribution__center"
+                >
+                  {topCameraLabel}
+                </text>
+              ) : null}
             </Pie>
           </PieChart>
         </ResponsiveContainer>

--- a/frontend/src/features/dashboard/components/DashboardKpiSection.tsx
+++ b/frontend/src/features/dashboard/components/DashboardKpiSection.tsx
@@ -7,6 +7,7 @@ type DashboardKpiSectionProps = {
   kpiWidgets: DashboardWidgetState[];
   onRemoveWidget: (widgetId: string) => void;
   className?: string;
+  rendererClassName?: string;
 };
 
 const DashboardKpiSection: React.FC<DashboardKpiSectionProps> = ({
@@ -14,6 +15,7 @@ const DashboardKpiSection: React.FC<DashboardKpiSectionProps> = ({
   kpiWidgets,
   onRemoveWidget,
   className,
+  rendererClassName,
 }) => {
   if (kpiWidgets.length === 0) {
     return null;
@@ -21,7 +23,12 @@ const DashboardKpiSection: React.FC<DashboardKpiSectionProps> = ({
 
   return (
     <div className={className}>
-      <KpiBand mode={mode} kpiWidgets={kpiWidgets} onRemoveWidget={onRemoveWidget} />
+      <KpiBand
+        mode={mode}
+        kpiWidgets={kpiWidgets}
+        onRemoveWidget={onRemoveWidget}
+        rendererClassName={rendererClassName}
+      />
     </div>
   );
 };

--- a/frontend/src/features/dashboard/components/KpiBand.tsx
+++ b/frontend/src/features/dashboard/components/KpiBand.tsx
@@ -8,6 +8,7 @@ type KpiBandProps = {
   mode?: "full" | "preview";
   kpiWidgets: DashboardWidgetState[];
   onRemoveWidget: (widgetId: string) => void;
+  rendererClassName?: string;
 };
 
 type KpiTileProps = {
@@ -18,6 +19,7 @@ type KpiTileProps = {
   locked?: boolean;
   onRemove?: () => void;
   widgetId: string;
+  rendererClassName?: string;
 };
 
 const PREVIEW_KPI_HEIGHT = 76;
@@ -30,6 +32,7 @@ const KpiTile: React.FC<KpiTileProps> = ({
   locked,
   onRemove,
   widgetId,
+  rendererClassName,
 }) => {
   const summary = result?.meta?.summary ?? {};
   const headline =
@@ -51,14 +54,15 @@ const KpiTile: React.FC<KpiTileProps> = ({
   } else if (state.status === "error") {
     content = renderError(state.error ?? `Failed to load ${title}`);
   } else {
-    const rendererClassName = isPreview
+    const baseRendererClassName = isPreview
       ? "dashboard-v2__kpi-renderer dashboard-v2__kpi-renderer--preview"
       : "dashboard-v2__kpi-renderer";
+    const mergedRendererClassName = `${baseRendererClassName} ${rendererClassName ?? ""}`.trim();
     content = (
       <ChartRenderer
         result={renderedResult!}
         height={kpiHeight}
-        className={rendererClassName}
+        className={mergedRendererClassName}
         widgetId={widgetId}
       />
     );
@@ -92,7 +96,12 @@ const KpiTile: React.FC<KpiTileProps> = ({
   );
 };
 
-const KpiBand: React.FC<KpiBandProps> = ({ mode = "full", kpiWidgets, onRemoveWidget }) => {
+const KpiBand: React.FC<KpiBandProps> = ({
+  mode = "full",
+  kpiWidgets,
+  onRemoveWidget,
+  rendererClassName,
+}) => {
   if (kpiWidgets.length === 0) {
     return null;
   }
@@ -111,6 +120,7 @@ const KpiBand: React.FC<KpiBandProps> = ({ mode = "full", kpiWidgets, onRemoveWi
           state={state}
           locked={state.widget.locked}
           widgetId={state.widget.id}
+          rendererClassName={rendererClassName}
           onRemove={
             state.widget.locked
               ? undefined

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -2,89 +2,112 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { landingCopy } from "../content";
 
-const LandingFooter: React.FC = () => (
-  <footer className="landing-footer">
-    <div className="landing-container landing-footer-row">
-      <div className="landing-footer-main" aria-label="Company and legal information">
-        <p className="landing-footer-copyright">{landingCopy.footer.copyright}</p>
+type CookieConsentWindow = Window & {
+  CookieConsent?: {
+    renew?: () => void;
+  };
+};
 
-        <nav className="landing-footer-links-column" aria-label="Footer links">
-          <a href="#" className="landing-footer-link-item">{landingCopy.footer.links[0]}</a>
-          <a href="#" className="landing-footer-link-item">{landingCopy.footer.links[1]}</a>
-          <Link to="/contact" className="landing-footer-link-item">{landingCopy.footer.links[2]}</Link>
-        </nav>
+const LandingFooter: React.FC = () => {
+  const handleCookiePreferencesClick: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
+    event.preventDefault();
 
-        <div className="landing-footer-legal-column">
-          {landingCopy.footer.legalLines.map((line, index) => {
-            if (index === 1) {
-              const [beforeIco, afterIco] = line.split("ICO");
-              return (
-                <p key={line}>
-                  {beforeIco}
-                  <a
-                    href="https://ico.org.uk/"
-                    target="_blank"
-                    rel="noreferrer"
-                    className="landing-footer-legal-link"
-                  >
-                    ICO
-                  </a>
-                  {afterIco}
-                </p>
-              );
-            }
+    const cookieConsent = (window as CookieConsentWindow).CookieConsent;
+    if (cookieConsent && typeof cookieConsent.renew === "function") {
+      cookieConsent.renew();
+    }
+  };
 
-            return <p key={line}>{line}</p>;
-          })}
+  return (
+    <footer className="landing-footer">
+      <div className="landing-container landing-footer-row">
+        <div className="landing-footer-main" aria-label="Company and legal information">
+          <div className="landing-footer-brand-column">
+            <p className="landing-footer-copyright">{landingCopy.footer.copyright}</p>
+            <nav className="landing-footer-links-column landing-footer-links-column-primary" aria-label="Primary legal links">
+              <a href="#" className="landing-footer-link-item">{landingCopy.footer.primaryLinks[0]}</a>
+              <a href="#" className="landing-footer-link-item">{landingCopy.footer.primaryLinks[1]}</a>
+            </nav>
+          </div>
+
+          <nav className="landing-footer-links-column" aria-label="Footer links">
+            <a href="#" className="landing-footer-link-item">{landingCopy.footer.secondaryLinks[0]}</a>
+            <a href="#" className="landing-footer-link-item" onClick={handleCookiePreferencesClick}>{landingCopy.footer.secondaryLinks[1]}</a>
+            <Link to="/contact" className="landing-footer-link-item">{landingCopy.footer.secondaryLinks[2]}</Link>
+          </nav>
+
+          <div className="landing-footer-legal-column">
+            {landingCopy.footer.legalLines.map((line, index) => {
+              if (index === 1) {
+                const [beforeIco, afterIco] = line.split("ICO");
+                return (
+                  <p key={line}>
+                    {beforeIco}
+                    <a
+                      href="https://ico.org.uk/"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="landing-footer-legal-link"
+                    >
+                      ICO
+                    </a>
+                    {afterIco}
+                  </p>
+                );
+              }
+
+              return <p key={line}>{line}</p>;
+            })}
+          </div>
+        </div>
+
+        <div className="landing-footer-social" aria-label="Social links">
+          <a
+            href="https://www.youtube.com"
+            target="_blank"
+            rel="noreferrer"
+            aria-label={landingCopy.footer.socials.youtube}
+            className="landing-footer-social-link"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M23 12.2c0-2-.2-4-.7-5.8-.2-.8-.9-1.5-1.7-1.7C18.8 4.2 12 4.2 12 4.2s-6.8 0-8.6.5c-.8.2-1.5.9-1.7 1.7C1.2 8.2 1 10.2 1 12.2s.2 4 .7 5.8c.2.8.9 1.5 1.7 1.7 1.8.5 8.6.5 8.6.5s6.8 0 8.6-.5c.8-.2 1.5-.9 1.7-1.7.5-1.8.7-3.8.7-5.8Zm-13.8 3.7V8.5l6.5 3.7-6.5 3.7Z"
+                fill="currentColor"
+              />
+            </svg>
+          </a>
+          <a
+            href="https://www.linkedin.com"
+            target="_blank"
+            rel="noreferrer"
+            aria-label={landingCopy.footer.socials.linkedin}
+            className="landing-footer-social-link"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M6.9 8.4a2.1 2.1 0 1 1 0-4.2 2.1 2.1 0 0 1 0 4.2ZM5 20V9.9h3.8V20H5Zm6 0V9.9h3.6v1.4h.1c.5-1 1.7-1.8 3.4-1.8 3.6 0 4.2 2.2 4.2 5.1V20h-3.8v-4.7c0-1.1 0-2.6-1.7-2.6s-2 1.2-2 2.5V20H11Z"
+                fill="currentColor"
+              />
+            </svg>
+          </a>
+          <a
+            href="https://x.com"
+            target="_blank"
+            rel="noreferrer"
+            aria-label={landingCopy.footer.socials.x}
+            className="landing-footer-social-link"
+          >
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M18.9 2H22l-6.8 7.8L23 22h-6.1l-4.8-6.4L6.5 22H3.4l7.2-8.2L1 2h6.2L11.6 8 18.9 2Zm-1.1 18h1.7L6.3 3.9H4.5L17.8 20Z"
+                fill="currentColor"
+              />
+            </svg>
+          </a>
         </div>
       </div>
-
-      <div className="landing-footer-social" aria-label="Social links">
-        <a
-          href="https://www.youtube.com"
-          target="_blank"
-          rel="noreferrer"
-          aria-label={landingCopy.footer.socials.youtube}
-          className="landing-footer-social-link"
-        >
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M23 12.2c0-2-.2-4-.7-5.8-.2-.8-.9-1.5-1.7-1.7C18.8 4.2 12 4.2 12 4.2s-6.8 0-8.6.5c-.8.2-1.5.9-1.7 1.7C1.2 8.2 1 10.2 1 12.2s.2 4 .7 5.8c.2.8.9 1.5 1.7 1.7 1.8.5 8.6.5 8.6.5s6.8 0 8.6-.5c.8-.2 1.5-.9 1.7-1.7.5-1.8.7-3.8.7-5.8Zm-13.8 3.7V8.5l6.5 3.7-6.5 3.7Z"
-              fill="currentColor"
-            />
-          </svg>
-        </a>
-        <a
-          href="https://www.linkedin.com"
-          target="_blank"
-          rel="noreferrer"
-          aria-label={landingCopy.footer.socials.linkedin}
-          className="landing-footer-social-link"
-        >
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M6.9 8.4a2.1 2.1 0 1 1 0-4.2 2.1 2.1 0 0 1 0 4.2ZM5 20V9.9h3.8V20H5Zm6 0V9.9h3.6v1.4h.1c.5-1 1.7-1.8 3.4-1.8 3.6 0 4.2 2.2 4.2 5.1V20h-3.8v-4.7c0-1.1 0-2.6-1.7-2.6s-2 1.2-2 2.5V20H11Z"
-              fill="currentColor"
-            />
-          </svg>
-        </a>
-        <a
-          href="https://x.com"
-          target="_blank"
-          rel="noreferrer"
-          aria-label={landingCopy.footer.socials.x}
-          className="landing-footer-social-link"
-        >
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path
-              d="M18.9 2H22l-6.8 7.8L23 22h-6.1l-4.8-6.4L6.5 22H3.4l7.2-8.2L1 2h6.2L11.6 8 18.9 2Zm-1.1 18h1.7L6.3 3.9H4.5L17.8 20Z"
-              fill="currentColor"
-            />
-          </svg>
-        </a>
-      </div>
-    </div>
-  </footer>
-);
+    </footer>
+  );
+};
 
 export default LandingFooter;

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { landingCopy } from "../content";
 
 type CookieConsentWindow = Window & {
@@ -8,6 +9,8 @@ type CookieConsentWindow = Window & {
 };
 
 const LandingFooter: React.FC = () => {
+  const navigate = useNavigate();
+
   const handleCookiePreferencesClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     const cookieConsent = (window as CookieConsentWindow).CookieConsent;
     if (cookieConsent && typeof cookieConsent.renew === "function") {
@@ -45,7 +48,11 @@ const LandingFooter: React.FC = () => {
             >
               {landingCopy.footer.secondaryLinks[1]}
             </button>
-            <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+            <button
+              type="button"
+              className="landing-footer-link-item landing-footer-link-item-button"
+              onClick={() => navigate("/contact")}
+            >
               {landingCopy.footer.secondaryLinks[2]}
             </button>
           </nav>

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -20,7 +20,10 @@ const LandingFooter: React.FC = () => {
       <div className="landing-container landing-container--footer landing-footer-row">
         <div className="landing-footer-main" aria-label="Company and legal information">
           <div className="landing-footer-brand-column">
-            <p className="landing-footer-copyright">{landingCopy.footer.copyright}</p>
+            <p className="landing-footer-copyright">
+              <span className="landing-footer-copyright-prefix">© 2026 </span>
+              <span className="landing-footer-copyright-brand">Camera Operating Systems</span>
+            </p>
             <nav className="landing-footer-links-column landing-footer-links-column-primary" aria-label="Primary legal links">
               <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
                 {landingCopy.footer.primaryLinks[0]}
@@ -35,7 +38,11 @@ const LandingFooter: React.FC = () => {
             <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
               {landingCopy.footer.secondaryLinks[0]}
             </button>
-            <button type="button" className="landing-footer-link-item landing-footer-link-item-button" onClick={handleCookiePreferencesClick}>
+            <button
+              type="button"
+              className="landing-footer-link-item landing-footer-link-item-button landing-footer-link-item-cookie-preferences"
+              onClick={handleCookiePreferencesClick}
+            >
               {landingCopy.footer.secondaryLinks[1]}
             </button>
             <button type="button" className="landing-footer-link-item landing-footer-link-item-button">

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import { landingCopy } from "../content";
 
 type CookieConsentWindow = Window & {
@@ -9,9 +8,7 @@ type CookieConsentWindow = Window & {
 };
 
 const LandingFooter: React.FC = () => {
-  const handleCookiePreferencesClick: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
-    event.preventDefault();
-
+  const handleCookiePreferencesClick: React.MouseEventHandler<HTMLButtonElement> = () => {
     const cookieConsent = (window as CookieConsentWindow).CookieConsent;
     if (cookieConsent && typeof cookieConsent.renew === "function") {
       cookieConsent.renew();
@@ -20,20 +17,30 @@ const LandingFooter: React.FC = () => {
 
   return (
     <footer className="landing-footer">
-      <div className="landing-container landing-footer-row">
+      <div className="landing-container landing-container--footer landing-footer-row">
         <div className="landing-footer-main" aria-label="Company and legal information">
           <div className="landing-footer-brand-column">
             <p className="landing-footer-copyright">{landingCopy.footer.copyright}</p>
             <nav className="landing-footer-links-column landing-footer-links-column-primary" aria-label="Primary legal links">
-              <a href="#" className="landing-footer-link-item">{landingCopy.footer.primaryLinks[0]}</a>
-              <a href="#" className="landing-footer-link-item">{landingCopy.footer.primaryLinks[1]}</a>
+              <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+                {landingCopy.footer.primaryLinks[0]}
+              </button>
+              <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+                {landingCopy.footer.primaryLinks[1]}
+              </button>
             </nav>
           </div>
 
-          <nav className="landing-footer-links-column" aria-label="Footer links">
-            <a href="#" className="landing-footer-link-item">{landingCopy.footer.secondaryLinks[0]}</a>
-            <a href="#" className="landing-footer-link-item" onClick={handleCookiePreferencesClick}>{landingCopy.footer.secondaryLinks[1]}</a>
-            <Link to="/contact" className="landing-footer-link-item">{landingCopy.footer.secondaryLinks[2]}</Link>
+          <nav className="landing-footer-links-column landing-footer-links-column-secondary" aria-label="Footer links">
+            <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+              {landingCopy.footer.secondaryLinks[0]}
+            </button>
+            <button type="button" className="landing-footer-link-item landing-footer-link-item-button" onClick={handleCookiePreferencesClick}>
+              {landingCopy.footer.secondaryLinks[1]}
+            </button>
+            <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+              {landingCopy.footer.secondaryLinks[2]}
+            </button>
           </nav>
 
           <div className="landing-footer-legal-column">

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -638,7 +638,14 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDem
                     <div className={styles.dockSurface} ref={trafficDockRef}>
                       {forceMockTopology
                         ? renderMockTrafficSplit()
-                        : <DashboardKpiSection mode="preview" kpiWidgets={[trafficWidget!]} onRemoveWidget={NOOP_REMOVE} />}
+                        : (
+                          <DashboardKpiSection
+                            mode="preview"
+                            kpiWidgets={[trafficWidget!]}
+                            onRemoveWidget={NOOP_REMOVE}
+                            rendererClassName="dashboard-v2__kpi-renderer--landing-preview-traffic"
+                          />
+                        )}
                     </div>
                     <span className={`${styles.wireEdgeAnchor} ${styles.wireEdgeAnchorTop}`} data-anchor-id="bottom-traffic" />
                   </div>

--- a/frontend/src/features/landing/content.ts
+++ b/frontend/src/features/landing/content.ts
@@ -50,7 +50,8 @@ export const landingCopy = {
   },
   footer: {
     copyright: "© 2026 Camera Operating Systems",
-    links: ["Terms & Conditions", "Privacy Policy", "Contact Us"],
+    primaryLinks: ["Terms & Conditions", "Privacy Policy"],
+    secondaryLinks: ["Cookie Policy", "Cookie Preferences", "Contact Us"],
     legalLines: [
       "Camera Operating Systems Limited is registered in England and Wales. Registered Number: 16937639",
       "Camera Operating Systems Limited is registered with the ICO as a Data Controller. Registered Number: Z1234567",

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -745,7 +745,7 @@ body {
 .landing-footer-main {
   display: grid;
   grid-template-columns: minmax(0, max-content) minmax(0, max-content) minmax(280px, 1fr);
-  gap: 10px 4px;
+  gap: 10px 16px;
   align-items: start;
 }
 
@@ -789,7 +789,7 @@ body {
 }
 
 .landing-footer-links-column-secondary {
-  margin-left: -16px;
+  margin-left: 0;
 }
 
 .landing-footer-link-item-button {

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -745,13 +745,22 @@ body {
 .landing-footer-main {
   display: grid;
   grid-template-columns: minmax(0, max-content) minmax(0, max-content) minmax(280px, 1fr);
-  gap: 10px 8px;
+  gap: 10px 4px;
   align-items: start;
 }
 
 .landing-footer-copyright {
   align-self: start;
-  margin-left: -14px;
+  margin-left: -18px;
+  display: inline-flex;
+}
+
+.landing-footer-copyright-prefix {
+  white-space: pre;
+}
+
+.landing-footer-copyright-brand {
+  white-space: nowrap;
 }
 
 .landing-footer-brand-column {
@@ -761,7 +770,8 @@ body {
 }
 
 .landing-footer-links-column-primary {
-  padding-left: 7.4ch;
+  padding-left: 0;
+  margin-left: calc(2ch + 27px);
 }
 
 .landing-footer-copyright,
@@ -779,7 +789,7 @@ body {
 }
 
 .landing-footer-links-column-secondary {
-  margin-left: -10px;
+  margin-left: -16px;
 }
 
 .landing-footer-link-item-button {
@@ -807,6 +817,12 @@ body {
 .landing-footer-social-link:hover {
   color: var(--sys-text-1);
   text-decoration: underline;
+}
+
+.landing-footer-link-item-cookie-preferences,
+.landing-footer-link-item-cookie-preferences:hover,
+.landing-footer-link-item-cookie-preferences:focus-visible {
+  text-decoration: none;
 }
 
 .landing-footer-legal-column {

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -814,9 +814,14 @@ body {
 }
 
 .landing-footer-link-item:hover,
+.landing-footer-link-item:focus-visible {
+  color: var(--sys-text-1);
+  text-decoration: none;
+}
+
 .landing-footer-social-link:hover {
-  color: var(--sys-text-3);
-  text-decoration: underline;
+  color: var(--sys-text-1);
+  text-decoration: none;
 }
 
 .landing-footer-link-item-cookie-preferences,

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -732,6 +732,9 @@ body {
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.72);
   padding: 8px 0;
 }
+.landing-container--footer {
+  width: min(var(--landing-rail-max), calc(100% - 20px));
+}
 .landing-footer-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -741,13 +744,14 @@ body {
 
 .landing-footer-main {
   display: grid;
-  grid-template-columns: max-content max-content minmax(280px, 1fr);
-  gap: 10px 12px;
+  grid-template-columns: minmax(0, max-content) minmax(0, max-content) minmax(280px, 1fr);
+  gap: 10px 8px;
   align-items: start;
 }
 
 .landing-footer-copyright {
-  align-self: center;
+  align-self: start;
+  margin-left: -14px;
 }
 
 .landing-footer-brand-column {
@@ -757,7 +761,7 @@ body {
 }
 
 .landing-footer-links-column-primary {
-  padding-left: 52px;
+  padding-left: 7.4ch;
 }
 
 .landing-footer-copyright,
@@ -772,6 +776,20 @@ body {
   display: grid;
   align-content: start;
   gap: 4px;
+}
+
+.landing-footer-links-column-secondary {
+  margin-left: -10px;
+}
+
+.landing-footer-link-item-button {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
 }
 
 .landing-footer-link-item,
@@ -824,6 +842,7 @@ body {
 .landing-footer-social-link svg { width: 14px; height: 14px; }
 @media (max-width: 1100px) {
   .landing-container { width: min(var(--landing-rail-max), calc(100% - 44px)); }
+  .landing-container--footer { width: min(var(--landing-rail-max), calc(100% - 30px)); }
   .landing-operational-grid {
     gap: 16px;
     grid-template-columns: 1fr;
@@ -847,8 +866,16 @@ body {
     gap: 10px 12px;
   }
 
+  .landing-footer-copyright {
+    margin-left: 0;
+  }
+
   .landing-footer-links-column-primary {
     padding-left: 0;
+  }
+
+  .landing-footer-links-column-secondary {
+    margin-left: 0;
   }
 
   .landing-footer-legal-column {
@@ -892,6 +919,7 @@ body {
   }
 
   .landing-container { width: min(var(--landing-rail-max), calc(100% - 30px)); }
+  .landing-container--footer { width: min(var(--landing-rail-max), calc(100% - 30px)); }
   .landing-header-top { min-height: auto; padding: 10px 0; }
   .landing-brand-name-wrap { flex-direction: column; align-items: flex-start; gap: 2px; }
   .landing-hero h1, .landing-hero p { max-width: none; text-align: center; }
@@ -949,7 +977,9 @@ body {
   .landing-status-success { flex-direction: column; align-items: flex-start; }
   .landing-footer-row { grid-template-columns: 1fr; }
   .landing-footer-main { grid-template-columns: 1fr; gap: 12px; }
+  .landing-footer-copyright { margin-left: 0; }
   .landing-footer-links-column-primary { padding-left: 0; }
+  .landing-footer-links-column-secondary { margin-left: 0; }
   .landing-footer-social { justify-content: flex-start; }
 }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -771,7 +771,7 @@ body {
 
 .landing-footer-links-column-primary {
   padding-left: 0;
-  margin-left: calc(2ch + 27px);
+  margin-left: calc(2ch + 26.6px);
 }
 
 .landing-footer-copyright,
@@ -804,7 +804,7 @@ body {
 
 .landing-footer-link-item,
 .landing-footer-social-link {
-  color: var(--sys-text-2);
+  color: var(--sys-text-3);
 }
 
 .landing-footer-link-item {
@@ -815,7 +815,7 @@ body {
 
 .landing-footer-link-item:hover,
 .landing-footer-social-link:hover {
-  color: var(--sys-text-1);
+  color: var(--sys-text-3);
   text-decoration: underline;
 }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -771,7 +771,7 @@ body {
 
 .landing-footer-links-column-primary {
   padding-left: 0;
-  margin-left: calc(2ch + 26.6px);
+  margin-left: calc(2ch + 26.616px);
 }
 
 .landing-footer-copyright,

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -750,6 +750,16 @@ body {
   align-self: center;
 }
 
+.landing-footer-brand-column {
+  display: grid;
+  align-content: start;
+  gap: 4px;
+}
+
+.landing-footer-links-column-primary {
+  padding-left: 52px;
+}
+
 .landing-footer-copyright,
 .landing-footer-legal-column p {
   margin: 0;
@@ -835,6 +845,10 @@ body {
   .landing-footer-main {
     grid-template-columns: 1fr 1fr;
     gap: 10px 12px;
+  }
+
+  .landing-footer-links-column-primary {
+    padding-left: 0;
   }
 
   .landing-footer-legal-column {
@@ -935,6 +949,7 @@ body {
   .landing-status-success { flex-direction: column; align-items: flex-start; }
   .landing-footer-row { grid-template-columns: 1fr; }
   .landing-footer-main { grid-template-columns: 1fr; gap: 12px; }
+  .landing-footer-links-column-primary { padding-left: 0; }
   .landing-footer-social { justify-content: flex-start; }
 }
 


### PR DESCRIPTION
### Motivation
- Add Cookiebot consent management to enable GDPR cookie consent handling on the site by injecting the Cookiebot script into `frontend/index.html`.

### Description
- Inserted the Cookiebot script tag ` <script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="f87b8197-a211-42fb-9e93-64d8922f4987" data-blockingmode="auto" type="text/javascript"></script>` into `frontend/index.html` ahead of the favicon link.

### Testing
- No automated unit tests were added or modified for this static HTML change and existing CI/static checks should be unaffected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b5d3c75d3083238b20682490b2db5d)