### PR TITLE
Support end-anchored assurance columns for mobile and adjust responsive layout

### DIFF
--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -111,16 +111,19 @@ const LandingPage: React.FC = () => {
     {
       id: "privacy",
       title: "PRIVACY",
+      anchor: "start",
       items: ["No Personal Data", "Anonymous & Aggregated"],
     },
     {
       id: "operation",
       title: "OPERATION",
+      anchor: "end",
       items: ["Live Reporting", "99.9% Uptime"],
     },
     {
       id: "system",
       title: "SYSTEM",
+      anchor: "start",
       items: ["Plug & Play", "<1% Error"],
     },
   ] as const;
@@ -137,7 +140,8 @@ const LandingPage: React.FC = () => {
   const assuranceLowerOpticalOffsetY = 1.8;
   const assuranceSvgHeight = assuranceTree.rowOffset + (assuranceTree.rowHeight * 2);
   const [assuranceLayoutById, setAssuranceLayoutById] = useState<Record<string, { trunkX: number; branchY1: number; branchY2: number }>>({});
-  const firstLetterRefs = useRef<Record<string, HTMLSpanElement | null>>({});
+  const [isMobileAssuranceLayout, setIsMobileAssuranceLayout] = useState(false);
+  const assuranceAnchorRefs = useRef<Record<string, HTMLSpanElement | null>>({});
   const treeSvgRefs = useRef<Record<string, SVGSVGElement | null>>({});
   const assuranceItemTextRefs = useRef<Record<string, Array<HTMLSpanElement | null>>>({});
   const previewFitRef = useRef<HTMLDivElement | null>(null);
@@ -149,6 +153,20 @@ const LandingPage: React.FC = () => {
   const mobileAxisMetricLineRefs = useRef<Record<string, Array<HTMLSpanElement | null>>>({});
 
   useLayoutEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncIsMobile = () => {
+      setIsMobileAssuranceLayout(mediaQuery.matches);
+    };
+
+    syncIsMobile();
+    mediaQuery.addEventListener("change", syncIsMobile);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncIsMobile);
+    };
+  }, []);
+
+  useLayoutEffect(() => {
     let frameId = 0;
 
     const measureTrunkAnchors = () => {
@@ -156,15 +174,16 @@ const LandingPage: React.FC = () => {
         const next = { ...prev };
         let changed = false;
 
-        assuranceColumns.forEach(({ id }) => {
-          const firstLetter = firstLetterRefs.current[id];
+        assuranceColumns.forEach(({ id, anchor }) => {
+          const activeAnchor = isMobileAssuranceLayout ? anchor : "start";
+          const titleAnchor = assuranceAnchorRefs.current[id];
           const treeSvg = treeSvgRefs.current[id];
 
-          if (!firstLetter || !treeSvg) {
+          if (!titleAnchor || !treeSvg) {
             return;
           }
 
-          const firstLetterRect = firstLetter.getBoundingClientRect();
+          const titleAnchorRect = titleAnchor.getBoundingClientRect();
           const treeSvgRect = treeSvg.getBoundingClientRect();
           const viewBoxWidth = treeSvg.viewBox.baseVal.width || treeSvgRect.width;
           const viewBoxHeight = treeSvg.viewBox.baseVal.height || treeSvgRect.height;
@@ -173,8 +192,11 @@ const LandingPage: React.FC = () => {
             return;
           }
 
-          const firstLetterCenterX = firstLetterRect.left + (firstLetterRect.width / 2);
-          const trunkX = (firstLetterCenterX - treeSvgRect.left) * (viewBoxWidth / treeSvgRect.width);
+          const anchorCenterX = titleAnchorRect.left + (titleAnchorRect.width / 2);
+          const measuredTrunkX = (anchorCenterX - treeSvgRect.left) * (viewBoxWidth / treeSvgRect.width);
+          const trunkX = activeAnchor === "end"
+            ? Math.min(viewBoxWidth, Math.max(0, measuredTrunkX))
+            : Math.min(viewBoxWidth, Math.max(0, measuredTrunkX));
           const normalizedTrunkX = Number(trunkX.toFixed(3));
 
           const textNodes = assuranceItemTextRefs.current[id] ?? [];
@@ -228,15 +250,15 @@ const LandingPage: React.FC = () => {
       ? new ResizeObserver(scheduleMeasure)
       : null;
 
-    assuranceColumns.forEach(({ id }) => {
-      const firstLetter = firstLetterRefs.current[id];
-      const treeSvg = treeSvgRefs.current[id];
+        assuranceColumns.forEach(({ id }) => {
+          const titleAnchor = assuranceAnchorRefs.current[id];
+          const treeSvg = treeSvgRefs.current[id];
 
-      if (firstLetter && resizeObserver) {
-        resizeObserver.observe(firstLetter);
-      }
+          if (titleAnchor && resizeObserver) {
+            resizeObserver.observe(titleAnchor);
+          }
 
-      if (treeSvg && resizeObserver) {
+          if (treeSvg && resizeObserver) {
         resizeObserver.observe(treeSvg);
       }
     });
@@ -246,7 +268,7 @@ const LandingPage: React.FC = () => {
       window.removeEventListener("resize", scheduleMeasure);
       resizeObserver?.disconnect();
     };
-  }, []);
+  }, [assuranceBranchY1, assuranceBranchY2, assuranceColumns, assuranceLowerOpticalOffsetY, isMobileAssuranceLayout]);
 
   useLayoutEffect(() => {
     const target = previewFitRef.current;
@@ -632,29 +654,48 @@ const LandingPage: React.FC = () => {
                     <div className="assurance-col-body">
                       {(() => {
                         const firstLetter = column.title.slice(0, 1);
-                        const remainder = column.title.slice(1);
+                        const middle = column.title.slice(1, -1);
+                        const lastLetter = column.title.slice(-1);
                         const columnLayout = assuranceLayoutById[column.id];
                         const trunkX = columnLayout?.trunkX ?? 0;
                         const branchY1 = columnLayout?.branchY1 ?? assuranceBranchY1;
                         const branchY2 = columnLayout?.branchY2 ?? assuranceBranchY2;
                         const trunkY2 = branchY2;
+                        const isEndAnchored = isMobileAssuranceLayout && column.anchor === "end";
+                        const dockX = assuranceTree.dockX - assuranceTree.dockGap;
 
                         return (
                           <>
                       <h3 className="assurance-col-title">
                         <span className="assurance-col-title-text">
-                          <span
-                            className="assurance-col-title-first-letter"
-                            ref={(node) => {
-                              firstLetterRefs.current[column.id] = node;
-                            }}
-                          >
-                            {firstLetter}
-                          </span>
-                          <span>{remainder}</span>
+                          {isEndAnchored ? (
+                            <>
+                              <span>{firstLetter}{middle}</span>
+                              <span
+                                className="assurance-col-title-anchor assurance-col-title-last-letter"
+                                ref={(node) => {
+                                  assuranceAnchorRefs.current[column.id] = node;
+                                }}
+                              >
+                                {lastLetter}
+                              </span>
+                            </>
+                          ) : (
+                            <>
+                              <span
+                                className="assurance-col-title-anchor assurance-col-title-first-letter"
+                                ref={(node) => {
+                                  assuranceAnchorRefs.current[column.id] = node;
+                                }}
+                              >
+                                {firstLetter}
+                              </span>
+                              <span>{column.title.slice(1)}</span>
+                            </>
+                          )}
                         </span>
                       </h3>
-                      <div className="assurance-col-tree">
+                      <div className="assurance-col-tree" data-anchor={isEndAnchored ? "end" : "start"}>
                         <svg
                           className="assurance-tree-svg"
                           aria-hidden="true"
@@ -666,8 +707,20 @@ const LandingPage: React.FC = () => {
                           }}
                         >
                           <line className="assurance-tree-line assurance-tree-line--trunk" x1={trunkX} y1={assuranceTree.trunkY1} x2={trunkX} y2={trunkY2} />
-                          <line className="assurance-tree-line assurance-tree-line--branch" x1={trunkX} y1={branchY1} x2={assuranceTree.dockX - assuranceTree.dockGap} y2={branchY1} />
-                          <line className="assurance-tree-line assurance-tree-line--branch" x1={trunkX} y1={branchY2} x2={assuranceTree.dockX - assuranceTree.dockGap} y2={branchY2} />
+                          <line
+                            className="assurance-tree-line assurance-tree-line--branch"
+                            x1={isEndAnchored ? dockX : trunkX}
+                            y1={branchY1}
+                            x2={isEndAnchored ? trunkX : dockX}
+                            y2={branchY1}
+                          />
+                          <line
+                            className="assurance-tree-line assurance-tree-line--branch"
+                            x1={isEndAnchored ? dockX : trunkX}
+                            y1={branchY2}
+                            x2={isEndAnchored ? trunkX : dockX}
+                            y2={branchY2}
+                          />
                         </svg>
                         <ul className="assurance-col-list">
                           {column.items.map((item, itemIndex) => (

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -109,16 +109,16 @@ const LandingPage: React.FC = () => {
   ] as const;
   const assuranceColumns = [
     {
-      id: "privacy",
-      title: "PRIVACY",
+      id: "operate",
+      title: "OPERATE",
       anchor: "start",
-      items: ["No Personal Data", "Anonymous & Aggregated"],
+      items: ["Live Reporting", "99.9% Uptime"],
     },
     {
-      id: "operation",
-      title: "OPERATION",
+      id: "private",
+      title: "PRIVATE",
       anchor: "end",
-      items: ["Live Reporting", "99.9% Uptime"],
+      items: ["No Personal Data", "Anonymous & Aggregated"],
     },
     {
       id: "system",
@@ -132,7 +132,8 @@ const LandingPage: React.FC = () => {
     rowHeight: 29,
     rowOffset: 4,
     textOpticalCenterY: 13,
-    dockX: 28,
+    dockXStart: 24,
+    dockXEnd: 4,
     dockGap: 4,
   } as const;
   const assuranceBranchY1 = assuranceTree.rowOffset + assuranceTree.textOpticalCenterY;
@@ -662,7 +663,9 @@ const LandingPage: React.FC = () => {
                         const branchY2 = columnLayout?.branchY2 ?? assuranceBranchY2;
                         const trunkY2 = branchY2;
                         const isEndAnchored = isMobileAssuranceLayout && column.anchor === "end";
-                        const dockX = assuranceTree.dockX - assuranceTree.dockGap;
+                        const dockX = isEndAnchored
+                          ? assuranceTree.dockXEnd
+                          : assuranceTree.dockXStart;
 
                         return (
                           <>
@@ -700,7 +703,7 @@ const LandingPage: React.FC = () => {
                           className="assurance-tree-svg"
                           aria-hidden="true"
                           focusable="false"
-                          viewBox={`0 0 ${assuranceTree.dockX} ${assuranceSvgHeight}`}
+                          viewBox={`0 0 ${assuranceTree.dockXStart + assuranceTree.dockGap} ${assuranceSvgHeight}`}
                           preserveAspectRatio="none"
                           ref={(node) => {
                             treeSvgRefs.current[column.id] = node;
@@ -709,16 +712,16 @@ const LandingPage: React.FC = () => {
                           <line className="assurance-tree-line assurance-tree-line--trunk" x1={trunkX} y1={assuranceTree.trunkY1} x2={trunkX} y2={trunkY2} />
                           <line
                             className="assurance-tree-line assurance-tree-line--branch"
-                            x1={isEndAnchored ? dockX : trunkX}
+                            x1={trunkX}
                             y1={branchY1}
-                            x2={isEndAnchored ? trunkX : dockX}
+                            x2={dockX}
                             y2={branchY1}
                           />
                           <line
                             className="assurance-tree-line assurance-tree-line--branch"
-                            x1={isEndAnchored ? dockX : trunkX}
+                            x1={trunkX}
                             y1={branchY2}
-                            x2={isEndAnchored ? trunkX : dockX}
+                            x2={dockX}
                             y2={branchY2}
                           />
                         </svg>

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -533,9 +533,10 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDem
           : isToNode
             ? nodeBoundaryPoint.y
             : endpointY;
-        const segmentA = Math.hypot(tapX - sourceX, wire.busY - sourceY);
-        const segmentB = Math.hypot(targetX - tapX, targetY - wire.busY);
-        const totalLength = segmentA + segmentB;
+        const verticalToBusLength = Math.abs(wire.busY - sourceY);
+        const horizontalBusLength = Math.abs(targetX - sourceX);
+        const verticalFromBusLength = Math.abs(targetY - wire.busY);
+        const totalLength = verticalToBusLength + horizontalBusLength + verticalFromBusLength;
         const windowPxTarget = Math.max(
           NODE_WINDOW_MIN_PX,
           Math.min(NODE_WINDOW_MAX_PX, totalLength * 0.3),
@@ -548,7 +549,7 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDem
           : NODE_WINDOW_RATIO_MAX;
         return {
           ...route,
-          d: `M ${sourceX} ${sourceY} L ${tapX} ${wire.busY} L ${targetX} ${targetY}`,
+          d: `M ${sourceX} ${sourceY} L ${sourceX} ${wire.busY} L ${targetX} ${wire.busY} L ${targetX} ${targetY}`,
           gradientId: `topology-gradient-${route.id}`,
           nodeBoundaryX: nodeBoundaryPoint.x,
           nodeBoundaryY: nodeBoundaryPoint.y,

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -869,11 +869,11 @@ body {
   margin-top: 0;
 }
 
-.landing-assurances .assurance-col[data-testid="assurance-col-privacy"] {
+.landing-assurances .assurance-col[data-testid="assurance-col-operate"] {
   grid-column: 1;
 }
 
-.landing-assurances .assurance-col[data-testid="assurance-col-operation"] {
+.landing-assurances .assurance-col[data-testid="assurance-col-private"] {
   grid-column: 2;
 }
 
@@ -1200,8 +1200,8 @@ body {
     row-gap: 18px;
   }
 
-  .landing-assurances .assurance-col[data-testid="assurance-col-privacy"],
-  .landing-assurances .assurance-col[data-testid="assurance-col-operation"],
+  .landing-assurances .assurance-col[data-testid="assurance-col-operate"],
+  .landing-assurances .assurance-col[data-testid="assurance-col-private"],
   .landing-assurances .assurance-col[data-testid="assurance-col-system"] {
     grid-column: auto;
   }
@@ -1398,7 +1398,7 @@ body {
   }
 
   .landing-assurance-spec {
-    row-gap: 22px;
+    row-gap: 25px;
   }
 
   .assurance-col-body {
@@ -1414,11 +1414,11 @@ body {
   }
 
   .assurance-col-tree[data-anchor="end"],
-  .landing-assurances .assurance-col[data-testid="assurance-col-operation"] .assurance-col-title {
+  .landing-assurances .assurance-col[data-testid="assurance-col-private"] .assurance-col-title {
     justify-self: end;
   }
 
-  .landing-assurances .assurance-col[data-testid="assurance-col-operation"] .assurance-col-title {
+  .landing-assurances .assurance-col[data-testid="assurance-col-private"] .assurance-col-title {
     text-align: right;
   }
 
@@ -1624,7 +1624,7 @@ body {
   }
 
   .landing-assurance-spec {
-    row-gap: 24px;
+    row-gap: 28px;
   }
 
   .assurance-cta-row {

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -1633,7 +1633,7 @@ body {
   .assurance-cta-row {
     width: 100%;
     max-width: 340px;
-    margin: 34px auto 0;
+    margin: 45px auto 0;
     gap: 14px;
   }
 

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -769,7 +769,7 @@ body {
   position: relative;
 }
 
-.assurance-col-title-first-letter {
+.assurance-col-title-anchor {
   display: inline-block;
 }
 
@@ -785,6 +785,10 @@ body {
   width: max-content;
 }
 
+.assurance-col-tree[data-anchor="end"] {
+  justify-self: end;
+}
+
 .assurance-tree-svg {
   position: absolute;
   left: 0;
@@ -794,6 +798,11 @@ body {
   pointer-events: none;
   overflow: visible;
   z-index: 0;
+}
+
+.assurance-col-tree[data-anchor="end"] .assurance-tree-svg {
+  left: auto;
+  right: 0;
 }
 
 .assurance-tree-line {
@@ -813,6 +822,10 @@ body {
   row-gap: 0;
 }
 
+.assurance-col-tree[data-anchor="end"] .assurance-col-list {
+  justify-items: end;
+}
+
 .assurance-col-item {
   position: relative;
   margin: 0;
@@ -828,14 +841,28 @@ body {
   color: color-mix(in srgb, var(--sys-text-1) 91%, var(--sys-text-2) 9%);
 }
 
+.assurance-col-tree[data-anchor="end"] .assurance-col-item {
+  grid-template-columns: auto var(--assurance-dock-indent);
+}
+
 .assurance-col-item-dock {
   width: 1px;
   height: 1px;
   justify-self: start;
 }
 
+.assurance-col-tree[data-anchor="end"] .assurance-col-item-dock {
+  grid-column: 2;
+  justify-self: end;
+}
+
 .assurance-col-item-text {
   display: inline-block;
+}
+
+.assurance-col-tree[data-anchor="end"] .assurance-col-item-text {
+  grid-column: 1;
+  text-align: right;
 }
 
 .assurance-col-item + .assurance-col-item {
@@ -1335,6 +1362,15 @@ body {
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
   }
 
+  .assurance-col-title {
+    font-size: 1.58rem;
+    font-weight: 740;
+    line-height: 0.98;
+    letter-spacing: 0.05em;
+    color: color-mix(in srgb, var(--sys-text-1) 93%, var(--sys-text-2) 7%);
+    text-shadow: 0 1px 0 rgba(255, 255, 255, 0.4);
+  }
+
   .landing-axis-mobile-list {
     gap: 34px;
   }
@@ -1354,6 +1390,39 @@ body {
   }
 
   .landing-axis-mobile-stack-line {
+    font-size: 1.04rem;
+    font-weight: 520;
+    line-height: 1.23;
+    letter-spacing: 0.01em;
+    color: color-mix(in srgb, var(--sys-text-1) 84%, var(--sys-text-2) 16%);
+  }
+
+  .landing-assurance-spec {
+    row-gap: 22px;
+  }
+
+  .assurance-col-body {
+    --assurance-dock-indent: 30px;
+    --assurance-row-h: 31px;
+    --assurance-row-gap-top: 6px;
+    width: 100%;
+  }
+
+  .assurance-col-title,
+  .assurance-col-tree[data-anchor="start"] {
+    justify-self: start;
+  }
+
+  .assurance-col-tree[data-anchor="end"],
+  .landing-assurances .assurance-col[data-testid="assurance-col-operation"] .assurance-col-title {
+    justify-self: end;
+  }
+
+  .landing-assurances .assurance-col[data-testid="assurance-col-operation"] .assurance-col-title {
+    text-align: right;
+  }
+
+  .assurance-col-item {
     font-size: 1.04rem;
     font-weight: 520;
     line-height: 1.23;

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -1619,17 +1619,33 @@ body {
   }
 
   .landing-assurances {
+    --assurance-safe-inline: clamp(16px, 7.5vw, 28px);
     margin-top: 0;
-    padding: 8px 0 26px;
+    padding: 8px var(--assurance-safe-inline) 26px;
   }
 
   .landing-assurance-spec {
+    width: 100%;
+    max-width: none;
     row-gap: 28px;
   }
 
   .assurance-cta-row {
-    margin-top: 34px;
+    width: 100%;
+    max-width: 340px;
+    margin: 34px auto 0;
     gap: 14px;
+  }
+
+  .landing-assurance-cta {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+    min-height: 52px;
+    border-radius: 12px;
+    font-size: 0.9rem;
+    font-weight: 640;
+    letter-spacing: 0.04em;
   }
 
   .landing-footer {


### PR DESCRIPTION
### Motivation
- Make the assurances column layout adaptable for narrow/mobile viewports by allowing titles and tree connectors to anchor to either the start or end, improving alignment for the middle column on mobile.
- Replace brittle measurement of a single first-letter element with an anchor element so the trunk/branch SVGs can be positioned consistently for both start- and end-anchored layouts.
- Add responsive styling to mirror the new anchor behaviour and improve spacing/typography at mobile breakpoints.

### Description
- Added `isMobileAssuranceLayout` state and a `useLayoutEffect` that watches a `(max-width: 767px)` media query to toggle mobile anchoring behaviour.  (`frontend/src/features/landing/LandingPage.tsx`)
- Replaced the `firstLetterRefs` approach with `assuranceAnchorRefs` and updated measurement logic to compute trunk X from the anchor element, with branch lines flipping endpoints when `anchor === "end"`. The measurement `useLayoutEffect` now depends on `isMobileAssuranceLayout` and other layout constants. (`frontend/src/features/landing/LandingPage.tsx`)
- Updated JSX for assurance titles to render either a start-anchored first-letter anchor or an end-anchored last-letter anchor depending on column `anchor` and mobile state, and set `data-anchor` on the tree container. (`frontend/src/features/landing/LandingPage.tsx`)
- Adjusted `ResizeObserver` setup to observe the title anchor nodes instead of the previous first-letter nodes. (`frontend/src/features/landing/LandingPage.tsx`)
- CSS changes: renamed `.assurance-col-title-first-letter` to `.assurance-col-title-anchor`, added rules for `.assurance-col-tree[data-anchor="end"]` to flip SVG alignment, list and item grid columns, and added mobile-specific sizing/spacing/typography tweaks to better support the new anchored layouts. (`frontend/src/styles/LandingPage.css`)

### Testing
- Ran type checking and build locally with `npm run build` and the build succeeded.
- Ran linting with `npm run lint` and no new lint errors were reported.
- Executed unit tests with `npm test` and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69bc638447ac8333b1c862fc58d9c779)