### PR TITLE
Remove redundant subtitle paragraphs from Contact and Create Account pages

### DIFF
--- a/frontend/src/components/auth/AuthBottomNav.module.css
+++ b/frontend/src/components/auth/AuthBottomNav.module.css
@@ -1,0 +1,44 @@
+.footer {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 900;
+  border-top: 1px solid var(--line-soft);
+  background: var(--surface-page);
+  padding: 12px 20px calc(12px + env(safe-area-inset-bottom));
+}
+
+.nav {
+  margin: 0 auto;
+  width: min(100%, 560px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.link {
+  color: var(--text-default);
+  text-decoration: none;
+  font-size: 14px;
+  line-height: 1;
+  text-underline-offset: 3px;
+  text-decoration-color: transparent;
+  transition: color 160ms ease, text-decoration-color 160ms ease;
+}
+
+.link:hover,
+.link:focus-visible,
+.link[aria-current="page"] {
+  color: var(--text-strong);
+  text-decoration: underline;
+  text-decoration-color: color-mix(in srgb, var(--signal-gold) 68%, transparent);
+}
+
+@media (max-width: 900px) {
+  .nav {
+    gap: 16px;
+  }
+}

--- a/frontend/src/components/auth/AuthBottomNav.tsx
+++ b/frontend/src/components/auth/AuthBottomNav.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { NavLink, useLocation } from "react-router-dom";
+
+import styles from "./AuthBottomNav.module.css";
+
+const buildSafeDemoReturnTo = (pathname: string, search: string, hash: string) => {
+  const candidate = `${pathname}${search}${hash}` || "/";
+  return candidate.startsWith("/") ? candidate : "/";
+};
+
+const AuthBottomNav: React.FC = () => {
+  const location = useLocation();
+  const returnTo = buildSafeDemoReturnTo(
+    location.pathname,
+    location.search,
+    location.hash,
+  );
+  const demoTarget = `/demo?returnTo=${encodeURIComponent(returnTo)}`;
+
+  const handleDemoClick = () => {
+    sessionStorage.setItem("demo:returnTo", returnTo);
+  };
+
+  return (
+    <footer className={styles.footer} aria-label="Auth page footer navigation">
+      <nav className={styles.nav}>
+        <NavLink to="/" className={styles.link}>
+          Learn more about camOS
+        </NavLink>
+        <NavLink to={demoTarget} className={styles.link} onClick={handleDemoClick}>
+          Try our free demo
+        </NavLink>
+      </nav>
+    </footer>
+  );
+};
+
+export default AuthBottomNav;

--- a/frontend/src/components/auth/AuthLogoHeader.module.css
+++ b/frontend/src/components/auth/AuthLogoHeader.module.css
@@ -23,5 +23,6 @@
   .header {
     min-height: 64px;
     padding: 12px 20px;
+    justify-content: center;
   }
 }

--- a/frontend/src/components/auth/AuthLogoHeader.module.css
+++ b/frontend/src/components/auth/AuthLogoHeader.module.css
@@ -1,0 +1,27 @@
+.header {
+  min-height: 74px;
+  display: flex;
+  align-items: center;
+  padding: 0 32px;
+  border-bottom: 1px solid var(--line-soft);
+  background: var(--surface-page);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.logo {
+  height: 34px;
+  width: auto;
+  display: block;
+}
+
+@media (max-width: 900px) {
+  .header {
+    min-height: 64px;
+    padding: 12px 20px;
+  }
+}

--- a/frontend/src/components/auth/AuthLogoHeader.tsx
+++ b/frontend/src/components/auth/AuthLogoHeader.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+import camOSLogo from "../../assets/Untitled design (4).svg";
+import styles from "./AuthLogoHeader.module.css";
+
+const AuthLogoHeader: React.FC = () => (
+  <header className={styles.header}>
+    <Link className={styles.brand} to="/" aria-label="camOS landing page">
+      <img src={camOSLogo} alt="camOS" className={styles.logo} />
+    </Link>
+  </header>
+);
+
+export default AuthLogoHeader;

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -64,6 +64,10 @@
   font-size: 13px;
 }
 
+.contact-under-cta--phone {
+  display: none;
+}
+
 .contact-inline-link {
   color: var(--text-default);
   text-decoration: none;
@@ -218,6 +222,15 @@
   .contact-right-content {
     min-height: auto;
     grid-template-rows: auto;
+  }
+
+  .contact-under-cta--desktop {
+    display: none;
+  }
+
+  .contact-under-cta--phone {
+    display: block;
+    margin-top: 10px;
   }
 
   .contact-hero {

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -1,9 +1,11 @@
 .contact-page {
+  --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: var(--surface-page);
   color: var(--text-strong);
+  padding-bottom: var(--auth-footer-offset);
 }
 
 .contact-shell {
@@ -78,8 +80,7 @@
 .contact-right-pane {
   position: relative;
   overflow: hidden;
-  border-left: 1px solid var(--line-soft);
-  background: var(--surface-panel);
+  background: var(--surface-page);
   padding: 34px 32px 40px;
   display: flex;
 }
@@ -223,8 +224,7 @@
   }
 
   .contact-right-pane {
-    border-left: none;
-    border-top: 1px solid var(--line-soft);
+    border-top: none;
   }
 }
 

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -227,6 +227,7 @@
   .contact-right-pane {
     border-left: none;
     border-top: none;
+    background: var(--surface-page);
   }
 }
 

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -1,11 +1,9 @@
 .contact-page {
-  --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: var(--surface-page);
   color: var(--text-strong);
-  padding-bottom: var(--auth-footer-offset);
 }
 
 .contact-shell {
@@ -80,7 +78,8 @@
 .contact-right-pane {
   position: relative;
   overflow: hidden;
-  background: var(--surface-page);
+  border-left: 1px solid var(--line-soft);
+  background: var(--surface-panel);
   padding: 34px 32px 40px;
   display: flex;
 }
@@ -197,7 +196,9 @@
 
 @media (max-width: 900px) {
   .contact-page {
+    --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
     grid-template-rows: auto auto;
+    padding-bottom: var(--auth-footer-offset);
   }
 
   .contact-shell {
@@ -224,6 +225,7 @@
   }
 
   .contact-right-pane {
+    border-left: none;
     border-top: none;
   }
 }

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useRef, useState } from "react";
 import { PHONE_OPTION_BY_ISO, inferIsoFromPhoneText, replaceDialCodeInPhoneText, sanitizePhoneText } from "./countryPhoneData";
 import { Link } from "react-router-dom";
-import AuthTopBar from "../../components/auth/AuthTopBar";
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
 import { submitContact } from "./transport/contact";
 import AuthPhoneField from "./components/AuthPhoneField";
 import "./ContactPage.css";
@@ -140,7 +141,7 @@ const ContactPage: React.FC = () => {
   return (
     <>
       <div className="contact-page">
-      <AuthTopBar />
+      <AuthLogoHeader />
 
       <form className="contact-shell" onSubmit={handleSubmit}>
         <section className="contact-left-pane" aria-label="Contact details panel">
@@ -292,6 +293,7 @@ const ContactPage: React.FC = () => {
           </div>
         </section>
       </form>
+      <AuthBottomNav />
       </div>
       {showSuccessModal ? (
         <div className="contact-success-modal-backdrop" role="presentation">

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -3,6 +3,8 @@ import { PHONE_OPTION_BY_ISO, inferIsoFromPhoneText, replaceDialCodeInPhoneText,
 import { Link } from "react-router-dom";
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import AuthTopBar from "../../components/auth/AuthTopBar";
+import { useIsPhoneLayout } from "./hooks/useIsPhoneLayout";
 import { submitContact } from "./transport/contact";
 import AuthPhoneField from "./components/AuthPhoneField";
 import "./ContactPage.css";
@@ -23,6 +25,7 @@ const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const ACCEPTED_EXTENSIONS = [".pdf", ".docx", ".xlsx", ".csv", ".png", ".jpg", ".jpeg"];
 
 const ContactPage: React.FC = () => {
+  const isPhoneLayout = useIsPhoneLayout();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [phoneSelectedIso, setPhoneSelectedIso] = useState("GB");
@@ -141,7 +144,7 @@ const ContactPage: React.FC = () => {
   return (
     <>
       <div className="contact-page">
-      <AuthLogoHeader />
+      {isPhoneLayout ? <AuthLogoHeader /> : <AuthTopBar />}
 
       <form className="contact-shell" onSubmit={handleSubmit}>
         <section className="contact-left-pane" aria-label="Contact details panel">
@@ -293,7 +296,7 @@ const ContactPage: React.FC = () => {
           </div>
         </section>
       </form>
-      <AuthBottomNav />
+      {isPhoneLayout ? <AuthBottomNav /> : null}
       </div>
       {showSuccessModal ? (
         <div className="contact-success-modal-backdrop" role="presentation">

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef, useState } from "react";
-import { PHONE_OPTION_BY_ISO, inferIsoFromPhoneText, replaceDialCodeInPhoneText, sanitizePhoneText } from "./countryPhoneData";
+import { classifyOptionalPhoneInput, PHONE_OPTION_BY_ISO, inferIsoFromPhoneText, replaceDialCodeInPhoneText, sanitizePhoneText } from "./countryPhoneData";
 import { Link } from "react-router-dom";
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
@@ -59,8 +59,8 @@ const ContactPage: React.FC = () => {
       nextErrors.email = "Not a valid email address";
     }
 
-    const phoneValue = sanitizePhoneText(phoneText);
-    if (phoneValue && !PHONE_RE.test(phoneValue)) {
+    const phoneState = classifyOptionalPhoneInput(phoneText, phoneSelectedIso);
+    if (!phoneState.isEffectivelyEmpty && !PHONE_RE.test(phoneState.effectivePhone)) {
       nextErrors.phone = "Not a valid phone number";
     }
 
@@ -109,10 +109,11 @@ const ContactPage: React.FC = () => {
 
     setSubmitting(true);
     try {
+      const phoneState = classifyOptionalPhoneInput(phoneText, phoneSelectedIso);
       const result = await submitContact({
         name: name.trim(),
         email: email.trim().toLowerCase(),
-        phone: sanitizePhoneText(phoneText),
+        phone: phoneState.effectivePhone || undefined,
         message: message.trim(),
         attachments,
       });

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -145,7 +145,6 @@ const ContactPage: React.FC = () => {
       <form className="contact-shell" onSubmit={handleSubmit}>
         <section className="contact-left-pane" aria-label="Contact details panel">
           <div className="contact-content">
-            <p className="contact-title">Contact</p>
             <h1 className="contact-hero">Get in Touch</h1>
 
             <div className="vrm-field contact-field">

--- a/frontend/src/features/auth/ContactPage.tsx
+++ b/frontend/src/features/auth/ContactPage.tsx
@@ -221,7 +221,7 @@ const ContactPage: React.FC = () => {
               </div>
             </div>
 
-            <p className="contact-under-cta">
+            <p className="contact-under-cta contact-under-cta--desktop">
               Why not create an account? <Link to="/create-account" className="contact-inline-link">Create Account</Link>
             </p>
           </div>
@@ -293,6 +293,10 @@ const ContactPage: React.FC = () => {
                 {submitting ? "Sending…" : "Send"}
               </button>
             </div>
+
+            <p className="contact-under-cta contact-under-cta--phone">
+              Why not create an account? <Link to="/create-account" className="contact-inline-link">Create Account</Link>
+            </p>
           </div>
         </section>
       </form>

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -1,11 +1,9 @@
 .create-account-page {
-  --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: var(--surface-page);
   color: var(--text-strong);
-  padding-bottom: var(--auth-footer-offset);
 }
 
 .create-account-shell {
@@ -175,7 +173,10 @@
 .create-account-right-pane {
   position: relative;
   overflow: hidden;
-  background: var(--surface-page);
+  border-left: 1px solid var(--line-soft);
+  background:
+    radial-gradient(circle at 22% 20%, rgba(160, 173, 189, 0.10), transparent 48%),
+    linear-gradient(145deg, var(--surface-panel) 0%, #f3f6fa 60%, #edf2f8 100%);
 }
 
 .auth-right-pane-overlay {
@@ -192,7 +193,9 @@
 
 @media (max-width: 900px) {
   .create-account-page {
+    --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
     grid-template-rows: auto auto;
+    padding-bottom: var(--auth-footer-offset);
   }
 
   .create-account-shell {
@@ -213,6 +216,7 @@
 
   .create-account-right-pane {
     min-height: 140px;
+    border-left: none;
     border-top: none;
   }
 }

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -215,9 +215,6 @@
   }
 
   .create-account-right-pane {
-    min-height: 140px;
-    border-left: none;
-    border-top: none;
-    background: var(--surface-page);
+    display: none;
   }
 }

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -1,9 +1,11 @@
 .create-account-page {
+  --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: var(--surface-page);
   color: var(--text-strong);
+  padding-bottom: var(--auth-footer-offset);
 }
 
 .create-account-shell {
@@ -173,10 +175,7 @@
 .create-account-right-pane {
   position: relative;
   overflow: hidden;
-  border-left: 1px solid var(--line-soft);
-  background:
-    radial-gradient(circle at 22% 20%, rgba(160, 173, 189, 0.10), transparent 48%),
-    linear-gradient(145deg, var(--surface-panel) 0%, #f3f6fa 60%, #edf2f8 100%);
+  background: var(--surface-page);
 }
 
 .auth-right-pane-overlay {
@@ -214,7 +213,6 @@
 
   .create-account-right-pane {
     min-height: 140px;
-    border-left: none;
-    border-top: 1px solid var(--line-soft);
+    border-top: none;
   }
 }

--- a/frontend/src/features/auth/CreateAccountPage.css
+++ b/frontend/src/features/auth/CreateAccountPage.css
@@ -218,5 +218,6 @@
     min-height: 140px;
     border-left: none;
     border-top: none;
+    background: var(--surface-page);
   }
 }

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -3,8 +3,10 @@ import { ArrowLeft, Eye, EyeOff } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import AuthTopBar from "../../components/auth/AuthTopBar";
 import camOSLogo from '../../assets/Untitled design (4).svg';
 import { useCreateAccountForm } from './hooks/useCreateAccountForm';
+import { useIsPhoneLayout } from "./hooks/useIsPhoneLayout";
 import AuthPhoneField from './components/AuthPhoneField';
 import './CreateAccountPage.css';
 import './components/AuthPhoneField.css';
@@ -14,6 +16,7 @@ const stopNavigation: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
 };
 
 const CreateAccountPage: React.FC = () => {
+  const isPhoneLayout = useIsPhoneLayout();
   const navigate = useNavigate();
   const form = useCreateAccountForm((email) => {
     navigate(`/verify-email?email=${encodeURIComponent(email)}`);
@@ -31,7 +34,7 @@ const CreateAccountPage: React.FC = () => {
 
   return (
     <div className="create-account-page">
-      <AuthLogoHeader />
+      {isPhoneLayout ? <AuthLogoHeader /> : <AuthTopBar />}
 
       <div className="create-account-shell">
         <section className="create-account-left-pane" aria-label="Create account form panel">
@@ -221,7 +224,7 @@ const CreateAccountPage: React.FC = () => {
         </aside>
       </div>
 
-      <AuthBottomNav />
+      {isPhoneLayout ? <AuthBottomNav /> : null}
     </div>
   );
 };

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -40,7 +40,6 @@ const CreateAccountPage: React.FC = () => {
               <span>Login</span>
             </Link>
 
-            <p className="create-account-title">Create Account</p>
             <h1 className="create-account-hero">Join Us &amp; See More</h1>
 
             {form.formError && (

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -192,11 +192,11 @@ const CreateAccountPage: React.FC = () => {
               <div className="create-account-legal" aria-label="Legal disclaimers">
                 <p>
                   This site is protected by{' '}
-                  <a href="#" onClick={stopNavigation}>reCAPTCHA</a>{' '}
+                  reCAPTCHA{' '}
                   and the Google{' '}
-                  <a href="#" onClick={stopNavigation}>Privacy Policy</a>{' '}
+                  <a href="https://policies.google.com/privacy" target="_blank" rel="noreferrer">Privacy Policy</a>{' '}
                   and{' '}
-                  <a href="#" onClick={stopNavigation}>Terms of Service</a>{' '}
+                  <a href="https://policies.google.com/terms" target="_blank" rel="noreferrer">Terms of Service</a>{' '}
                   apply.
                 </p>
                 <p>

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -1,7 +1,8 @@
 import React, { useMemo, useState } from 'react';
 import { ArrowLeft, Eye, EyeOff } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
-import AuthTopBar from '../../components/auth/AuthTopBar';
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
 import camOSLogo from '../../assets/Untitled design (4).svg';
 import { useCreateAccountForm } from './hooks/useCreateAccountForm';
 import AuthPhoneField from './components/AuthPhoneField';
@@ -30,7 +31,7 @@ const CreateAccountPage: React.FC = () => {
 
   return (
     <div className="create-account-page">
-      <AuthTopBar />
+      <AuthLogoHeader />
 
       <div className="create-account-shell">
         <section className="create-account-left-pane" aria-label="Create account form panel">
@@ -219,6 +220,8 @@ const CreateAccountPage: React.FC = () => {
           />
         </aside>
       </div>
+
+      <AuthBottomNav />
     </div>
   );
 };

--- a/frontend/src/features/auth/LoginPage.css
+++ b/frontend/src/features/auth/LoginPage.css
@@ -1,11 +1,9 @@
 .login-page {
-  --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: var(--surface-page);
   color: var(--text-strong);
-  padding-bottom: var(--auth-footer-offset);
 }
 
 .login-shell {
@@ -133,7 +131,10 @@
 .login-right-pane {
   position: relative;
   overflow: hidden;
-  background: var(--surface-page);
+  border-left: 1px solid var(--line-soft);
+  background:
+    radial-gradient(circle at 22% 20%, rgba(160, 173, 189, 0.10), transparent 48%),
+    linear-gradient(145deg, var(--surface-panel) 0%, #f3f6fa 60%, #edf2f8 100%);
 }
 
 .auth-right-pane-overlay {
@@ -150,7 +151,9 @@
 
 @media (max-width: 900px) {
   .login-page {
+    --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
     grid-template-rows: auto auto;
+    padding-bottom: var(--auth-footer-offset);
   }
 
   .login-shell {
@@ -171,6 +174,7 @@
 
   .login-right-pane {
     min-height: 140px;
+    border-left: none;
     border-top: none;
   }
 }

--- a/frontend/src/features/auth/LoginPage.css
+++ b/frontend/src/features/auth/LoginPage.css
@@ -173,9 +173,6 @@
   }
 
   .login-right-pane {
-    min-height: 140px;
-    border-left: none;
-    border-top: none;
-    background: var(--surface-page);
+    display: none;
   }
 }

--- a/frontend/src/features/auth/LoginPage.css
+++ b/frontend/src/features/auth/LoginPage.css
@@ -1,9 +1,11 @@
 .login-page {
+  --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
   min-height: 100vh;
   display: grid;
   grid-template-rows: auto 1fr;
   background: var(--surface-page);
   color: var(--text-strong);
+  padding-bottom: var(--auth-footer-offset);
 }
 
 .login-shell {
@@ -131,10 +133,7 @@
 .login-right-pane {
   position: relative;
   overflow: hidden;
-  border-left: 1px solid var(--line-soft);
-  background:
-    radial-gradient(circle at 22% 20%, rgba(160, 173, 189, 0.10), transparent 48%),
-    linear-gradient(145deg, var(--surface-panel) 0%, #f3f6fa 60%, #edf2f8 100%);
+  background: var(--surface-page);
 }
 
 .auth-right-pane-overlay {
@@ -172,7 +171,6 @@
 
   .login-right-pane {
     min-height: 140px;
-    border-left: none;
-    border-top: 1px solid var(--line-soft);
+    border-top: none;
   }
 }

--- a/frontend/src/features/auth/LoginPage.css
+++ b/frontend/src/features/auth/LoginPage.css
@@ -176,5 +176,6 @@
     min-height: 140px;
     border-left: none;
     border-top: none;
+    background: var(--surface-page);
   }
 }

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import AuthTopBar from "../../components/auth/AuthTopBar";
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
 import camOSLogo from "../../assets/Untitled design (4).svg";
 import { useLoginForm } from "./hooks/useLoginForm";
 import { passwordResetStart } from "./transport/passwordResetStart";
@@ -78,7 +79,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
 
   return (
     <div className="login-page">
-      <AuthTopBar />
+      <AuthLogoHeader />
 
       <div className="login-shell">
         <section className="login-left-pane" aria-label="Login form panel">
@@ -171,6 +172,8 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
           />
         </aside>
       </div>
+
+      <AuthBottomNav />
     </div>
   );
 };

--- a/frontend/src/features/auth/LoginPage.tsx
+++ b/frontend/src/features/auth/LoginPage.tsx
@@ -2,7 +2,9 @@ import React, { useMemo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import AuthTopBar from "../../components/auth/AuthTopBar";
 import camOSLogo from "../../assets/Untitled design (4).svg";
+import { useIsPhoneLayout } from "./hooks/useIsPhoneLayout";
 import { useLoginForm } from "./hooks/useLoginForm";
 import { passwordResetStart } from "./transport/passwordResetStart";
 import "./LoginPage.css";
@@ -16,6 +18,7 @@ type LoginStep = "email" | "password";
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
+  const isPhoneLayout = useIsPhoneLayout();
   const navigate = useNavigate();
   const {
     email,
@@ -79,7 +82,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
 
   return (
     <div className="login-page">
-      <AuthLogoHeader />
+      {isPhoneLayout ? <AuthLogoHeader /> : <AuthTopBar />}
 
       <div className="login-shell">
         <section className="login-left-pane" aria-label="Login form panel">
@@ -173,7 +176,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ onLogin }) => {
         </aside>
       </div>
 
-      <AuthBottomNav />
+      {isPhoneLayout ? <AuthBottomNav /> : null}
     </div>
   );
 };

--- a/frontend/src/features/auth/ResetPasswordPage.tsx
+++ b/frontend/src/features/auth/ResetPasswordPage.tsx
@@ -1,7 +1,10 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
 import AuthTopBar from "../../components/auth/AuthTopBar";
+import { useIsPhoneLayout } from "./hooks/useIsPhoneLayout";
 import { passwordResetResend } from "./transport/passwordResetResend";
 import { passwordResetSetPassword } from "./transport/passwordResetSetPassword";
 import { passwordResetVerifyCode } from "./transport/passwordResetVerifyCode";
@@ -10,6 +13,7 @@ import "./VerifyEmailPage.css";
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 const ResetPasswordPage: React.FC = () => {
+  const isPhoneLayout = useIsPhoneLayout();
   const [params] = useSearchParams();
   const navigate = useNavigate();
   const location = useLocation();
@@ -106,7 +110,7 @@ const ResetPasswordPage: React.FC = () => {
 
   return (
     <div className="verify-email-page">
-      <AuthTopBar />
+      {isPhoneLayout ? <AuthLogoHeader /> : <AuthTopBar />}
       <div className="verify-email-shell">
         <section className="verify-email-left-pane" aria-label="Password reset panel">
           <div className="verify-email-content">
@@ -167,6 +171,8 @@ const ResetPasswordPage: React.FC = () => {
         </section>
         <aside className="verify-email-right-pane" aria-hidden="true" />
       </div>
+
+      {isPhoneLayout ? <AuthBottomNav /> : null}
     </div>
   );
 };

--- a/frontend/src/features/auth/VerifyEmailPage.css
+++ b/frontend/src/features/auth/VerifyEmailPage.css
@@ -62,6 +62,10 @@
 .verify-email-submit {
   width: 100%;
   min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
 .verify-email-resend-row,

--- a/frontend/src/features/auth/VerifyEmailPage.css
+++ b/frontend/src/features/auth/VerifyEmailPage.css
@@ -118,8 +118,6 @@
   }
 
   .verify-email-right-pane {
-    min-height: 140px;
-    border-left: none;
-    border-top: 1px solid var(--line-soft);
+    display: none;
   }
 }

--- a/frontend/src/features/auth/VerifyEmailPage.css
+++ b/frontend/src/features/auth/VerifyEmailPage.css
@@ -98,7 +98,9 @@
 
 @media (max-width: 900px) {
   .verify-email-page {
+    --auth-footer-offset: calc(68px + env(safe-area-inset-bottom));
     grid-template-rows: auto auto;
+    padding-bottom: var(--auth-footer-offset);
   }
 
   .verify-email-shell {

--- a/frontend/src/features/auth/VerifyEmailPage.tsx
+++ b/frontend/src/features/auth/VerifyEmailPage.tsx
@@ -1,11 +1,15 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
 import AuthTopBar from "../../components/auth/AuthTopBar";
+import { useIsPhoneLayout } from "./hooks/useIsPhoneLayout";
 import { signupResend } from "./transport/signupResend";
 import { signupVerify } from "./transport/signupVerify";
 import "./VerifyEmailPage.css";
 
 const VerifyEmailPage: React.FC = () => {
+  const isPhoneLayout = useIsPhoneLayout();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const email = useMemo(() => searchParams.get("email")?.trim().toLowerCase() ?? "", [searchParams]);
@@ -100,7 +104,7 @@ const VerifyEmailPage: React.FC = () => {
 
   return (
     <div className="verify-email-page">
-      <AuthTopBar />
+      {isPhoneLayout ? <AuthLogoHeader /> : <AuthTopBar />}
 
       <div className="verify-email-shell">
         <section className="verify-email-left-pane" aria-label="Email verification panel">
@@ -173,6 +177,8 @@ const VerifyEmailPage: React.FC = () => {
 
         <aside className="verify-email-right-pane" aria-hidden="true" />
       </div>
+
+      {isPhoneLayout ? <AuthBottomNav /> : null}
     </div>
   );
 };

--- a/frontend/src/features/auth/components/AuthPhoneField.css
+++ b/frontend/src/features/auth/components/AuthPhoneField.css
@@ -29,9 +29,32 @@
   padding: 8px;
 }
 
+.auth-phone-country-search-row {
+  position: relative;
+  margin-bottom: 8px;
+}
+
+.auth-phone-country-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 16px;
+  height: 16px;
+  color: var(--text-default);
+  pointer-events: none;
+}
+
+.auth-phone-country-search-icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
 .auth-phone-country-search {
   width: 100%;
-  margin-bottom: 8px;
+  margin-bottom: 0;
+  padding-left: 30px;
 }
 
 .auth-phone-country-options {
@@ -50,9 +73,9 @@
   text-align: left;
   display: grid;
   grid-template-columns: 32px 1fr auto;
-  gap: 6px;
+  gap: 5px;
   align-items: center;
-  padding: 6px 7px;
+  padding: 5px 6px;
   border-radius: 6px;
   cursor: pointer;
 }
@@ -69,13 +92,17 @@
 }
 
 .auth-phone-country-option-name {
-  color: #e8edf8;
+  color: var(--text-strong);
   font-size: 13px;
 }
 
 .auth-phone-country-option-dial {
   color: var(--text-default);
   font-size: 12px;
+}
+
+.auth-phone-country-option--selected {
+  background: color-mix(in srgb, var(--signal-gold) 28%, transparent);
 }
 
 .auth-phone-country-empty {

--- a/frontend/src/features/auth/components/AuthPhoneField.tsx
+++ b/frontend/src/features/auth/components/AuthPhoneField.tsx
@@ -21,7 +21,7 @@ type AuthPhoneFieldProps = {
 
 type PopoverPlacement = "up" | "down";
 
-const DEFAULT_POPOVER_WIDTH = 276;
+const DEFAULT_POPOVER_WIDTH = 240;
 const POPOVER_GAP = 6;
 const VIEWPORT_MARGIN = 8;
 const ESTIMATED_POPOVER_HEIGHT = 320;
@@ -47,6 +47,7 @@ const AuthPhoneField: React.FC<AuthPhoneFieldProps> = ({
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
+  const listRef = useRef<HTMLUListElement | null>(null);
 
   const selectedCountry = useMemo(
     () => PHONE_OPTION_BY_ISO.get(selectedIso) ?? COUNTRY_PHONE_OPTIONS[0],
@@ -83,8 +84,16 @@ const AuthPhoneField: React.FC<AuthPhoneFieldProps> = ({
   }, [isOpen]);
 
   useEffect(() => {
-    setActiveIndex(0);
-  }, [query, isOpen]);
+    if (!isOpen) {
+      return;
+    }
+    if (query.trim()) {
+      setActiveIndex(0);
+      return;
+    }
+    const selectedIndex = filteredOptions.findIndex((option) => option.iso2 === selectedCountry.iso2);
+    setActiveIndex(selectedIndex >= 0 ? selectedIndex : 0);
+  }, [filteredOptions, isOpen, query, selectedCountry.iso2]);
 
   const updatePopoverPosition = () => {
     const trigger = triggerRef.current;
@@ -101,7 +110,7 @@ const AuthPhoneField: React.FC<AuthPhoneFieldProps> = ({
     const spaceAbove = triggerRect.top - VIEWPORT_MARGIN;
     const openUp = spaceBelow < Math.min(popoverHeight, ESTIMATED_POPOVER_HEIGHT) && spaceAbove > spaceBelow;
 
-    const desiredWidth = Math.max(Math.round(triggerRect.width + 160), DEFAULT_POPOVER_WIDTH);
+    const desiredWidth = Math.max(Math.round(triggerRect.width + 120), DEFAULT_POPOVER_WIDTH);
     const clampedWidth = Math.min(desiredWidth, viewportWidth - (VIEWPORT_MARGIN * 2));
     const maxLeft = viewportWidth - clampedWidth - VIEWPORT_MARGIN;
     const left = Math.min(Math.max(triggerRect.left, VIEWPORT_MARGIN), Math.max(maxLeft, VIEWPORT_MARGIN));
@@ -131,6 +140,21 @@ const AuthPhoneField: React.FC<AuthPhoneFieldProps> = ({
     };
   }, [isOpen, query]);
 
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const listNode = listRef.current;
+    if (!listNode) {
+      return;
+    }
+    const target = (
+      listNode.querySelector('[data-selected="true"]') ??
+      listNode.querySelector('[data-active="true"]')
+    ) as HTMLElement | null;
+    target?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, filteredOptions.length, isOpen]);
+
   const selectOption = (iso2: string) => {
     const option = PHONE_OPTION_BY_ISO.get(iso2);
     if (!option) {
@@ -149,43 +173,57 @@ const AuthPhoneField: React.FC<AuthPhoneFieldProps> = ({
       className={`auth-phone-country-popover auth-phone-country-popover--${placement}`}
       style={{ left: `${popoverStyle.left}px`, top: `${popoverStyle.top}px`, width: `${popoverStyle.width}px` }}
     >
-      <input
-        className="vrm-input auth-phone-country-search"
-        placeholder="Search country or ISO"
-        value={query}
-        autoFocus
-        onChange={(event) => setQuery(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === "ArrowDown") {
-            event.preventDefault();
-            setActiveIndex((index) => Math.min(index + 1, Math.max(filteredOptions.length - 1, 0)));
-          } else if (event.key === "ArrowUp") {
-            event.preventDefault();
-            setActiveIndex((index) => Math.max(index - 1, 0));
-          } else if (event.key === "Enter") {
-            event.preventDefault();
-            const activeOption = filteredOptions[activeIndex];
-            if (activeOption) {
-              selectOption(activeOption.iso2);
+      <div className="auth-phone-country-search-row">
+        <span className="auth-phone-country-search-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" focusable="false">
+            <path
+              d="M15.5 14h-.79l-.28-.27A6.47 6.47 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16a6.47 6.47 0 0 0 4.23-1.57l.27.28v.79L19 20.49 20.49 19l-4.99-5Zm-6 0A4.5 4.5 0 1 1 14 9.5 4.5 4.5 0 0 1 9.5 14Z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <input
+          className="vrm-input auth-phone-country-search"
+          placeholder=""
+          aria-label="Search countries"
+          value={query}
+          autoFocus
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "ArrowDown") {
+              event.preventDefault();
+              setActiveIndex((index) => Math.min(index + 1, Math.max(filteredOptions.length - 1, 0)));
+            } else if (event.key === "ArrowUp") {
+              event.preventDefault();
+              setActiveIndex((index) => Math.max(index - 1, 0));
+            } else if (event.key === "Enter") {
+              event.preventDefault();
+              const activeOption = filteredOptions[activeIndex];
+              if (activeOption) {
+                selectOption(activeOption.iso2);
+              }
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              setIsOpen(false);
+              setQuery("");
             }
-          } else if (event.key === "Escape") {
-            event.preventDefault();
-            setIsOpen(false);
-            setQuery("");
-          }
-        }}
-      />
+          }}
+        />
+      </div>
 
-      <ul className="auth-phone-country-options" role="listbox">
+      <ul ref={listRef} className="auth-phone-country-options" role="listbox">
         {filteredOptions.map((option, index) => {
           const isActive = index === activeIndex;
+          const isSelected = option.iso2 === selectedCountry.iso2;
           return (
             <li key={`${option.iso2}-${option.displayName}`}>
               <button
                 type="button"
-                className={`auth-phone-country-option ${isActive ? "auth-phone-country-option--active" : ""}`}
+                className={`auth-phone-country-option ${isActive ? "auth-phone-country-option--active" : ""} ${isSelected ? "auth-phone-country-option--selected" : ""}`}
                 onMouseEnter={() => setActiveIndex(index)}
                 onClick={() => selectOption(option.iso2)}
+                data-active={isActive ? "true" : undefined}
+                data-selected={isSelected ? "true" : undefined}
               >
                 <span className="auth-phone-country-option-iso">{option.iso2}</span>
                 <span className="auth-phone-country-option-name">{option.displayName}</span>

--- a/frontend/src/features/auth/countryPhoneData.ts
+++ b/frontend/src/features/auth/countryPhoneData.ts
@@ -113,3 +113,46 @@ export const replaceDialCodeInPhoneText = (phoneText: string, nextDialCode: stri
   const tail = normalized.slice(currentDialCode.length);
   return `${nextDialCode}${tail}`;
 };
+
+export type OptionalPhoneClassification = {
+  normalized: string;
+  effectivePhone: string;
+  isEffectivelyEmpty: boolean;
+  hasSubscriberInput: boolean;
+  selectedDialCode: string | null;
+};
+
+export const classifyOptionalPhoneInput = (phoneText: string, selectedIso: string): OptionalPhoneClassification => {
+  const normalized = sanitizePhoneText(phoneText);
+  const selectedDialCode = PHONE_OPTION_BY_ISO.get(selectedIso)?.dialCode ?? null;
+
+  if (!normalized || normalized === "+") {
+    return {
+      normalized,
+      effectivePhone: "",
+      isEffectivelyEmpty: true,
+      hasSubscriberInput: false,
+      selectedDialCode,
+    };
+  }
+
+  if (selectedDialCode && normalized.startsWith(selectedDialCode)) {
+    const subscriberTail = normalized.slice(selectedDialCode.length);
+    const hasSubscriberInput = /\d/.test(subscriberTail);
+    return {
+      normalized,
+      effectivePhone: hasSubscriberInput ? normalized : "",
+      isEffectivelyEmpty: !hasSubscriberInput,
+      hasSubscriberInput,
+      selectedDialCode,
+    };
+  }
+
+  return {
+    normalized,
+    effectivePhone: normalized,
+    isEffectivelyEmpty: false,
+    hasSubscriberInput: true,
+    selectedDialCode,
+  };
+};

--- a/frontend/src/features/auth/hooks/useCreateAccountForm.ts
+++ b/frontend/src/features/auth/hooks/useCreateAccountForm.ts
@@ -1,6 +1,6 @@
 import { type FormEvent, useMemo, useState } from 'react';
 import { signupStart } from '../transport/signupStart';
-import { inferIsoFromPhoneText, PHONE_OPTION_BY_ISO, replaceDialCodeInPhoneText, sanitizePhoneText } from '../countryPhoneData';
+import { classifyOptionalPhoneInput, inferIsoFromPhoneText, PHONE_OPTION_BY_ISO, replaceDialCodeInPhoneText, sanitizePhoneText } from '../countryPhoneData';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const PHONE_RE = /^\+[1-9]\d{6,14}$/;
@@ -25,7 +25,8 @@ export const useCreateAccountForm = (onSuccess: (email: string) => void) => {
     confirmPassword: false,
   });
 
-  const phone = sanitizePhoneText(phoneText);
+  const phoneState = useMemo(() => classifyOptionalPhoneInput(phoneText, selectedIso), [phoneText, selectedIso]);
+  const phone = phoneState.effectivePhone;
 
   const validate = () => {
     const errors: Record<FieldName, string | undefined> = {
@@ -42,7 +43,7 @@ export const useCreateAccountForm = (onSuccess: (email: string) => void) => {
     if (!normalizedEmail) errors.email = 'This field is required';
     else if (!EMAIL_RE.test(normalizedEmail)) errors.email = 'Not a valid email address';
 
-    if (phone && !PHONE_RE.test(phone)) errors.phone = 'Not a valid phone number';
+    if (!phoneState.isEffectivelyEmpty && !PHONE_RE.test(phone)) errors.phone = 'Not a valid phone number';
 
     if (!password) errors.password = 'This field is required';
     else if (password.length < 8) errors.password = 'Password must be at least 8 characters';
@@ -55,7 +56,7 @@ export const useCreateAccountForm = (onSuccess: (email: string) => void) => {
 
   const errors = useMemo(
     () => validate(),
-    [username, email, phone, password, confirmPassword],
+    [username, email, phone, password, confirmPassword, phoneState.isEffectivelyEmpty],
   );
 
   const visibleErrors = useMemo(() => {

--- a/frontend/src/features/auth/hooks/useIsPhoneLayout.ts
+++ b/frontend/src/features/auth/hooks/useIsPhoneLayout.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+const PHONE_MEDIA_QUERY = "(max-width: 900px)";
+
+const getInitialPhoneState = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return window.matchMedia(PHONE_MEDIA_QUERY).matches;
+};
+
+export const useIsPhoneLayout = () => {
+  const [isPhoneLayout, setIsPhoneLayout] = useState(getInitialPhoneState);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const mediaQuery = window.matchMedia(PHONE_MEDIA_QUERY);
+    const onChange = (event: MediaQueryListEvent) => {
+      setIsPhoneLayout(event.matches);
+    };
+
+    setIsPhoneLayout(mediaQuery.matches);
+    mediaQuery.addEventListener("change", onChange);
+
+    return () => mediaQuery.removeEventListener("change", onChange);
+  }, []);
+
+  return isPhoneLayout;
+};
+

--- a/frontend/src/features/auth/transport/contact.ts
+++ b/frontend/src/features/auth/transport/contact.ts
@@ -1,7 +1,7 @@
 export type ContactPayload = {
   name: string;
   email: string;
-  phone: string;
+  phone?: string;
   message: string;
   attachments: File[];
 };
@@ -14,7 +14,9 @@ export const submitContact = async (payload: ContactPayload): Promise<ContactRes
   const formData = new FormData();
   formData.append("name", payload.name);
   formData.append("email", payload.email);
-  formData.append("phone", payload.phone);
+  if (payload.phone?.trim()) {
+    formData.append("phone", payload.phone.trim());
+  }
   formData.append("message", payload.message);
   payload.attachments.forEach((file) => formData.append("attachments", file));
 

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -316,6 +316,22 @@ const LandingPage: React.FC = () => {
   }, []);
 
   useLayoutEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 767px)");
+    const syncBodyScrollLock = () => {
+      const shouldLock = isMobileMenuOpen && mediaQuery.matches;
+      document.body.classList.toggle("landing-mobile-drawer-lock", shouldLock);
+    };
+
+    syncBodyScrollLock();
+    mediaQuery.addEventListener("change", syncBodyScrollLock);
+
+    return () => {
+      mediaQuery.removeEventListener("change", syncBodyScrollLock);
+      document.body.classList.remove("landing-mobile-drawer-lock");
+    };
+  }, [isMobileMenuOpen]);
+
+  useLayoutEffect(() => {
     let frameId = 0;
 
     const measureAxisRomanAnchors = () => {

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -37,14 +37,14 @@ const LandingPage: React.FC = () => {
   };
 
   const mobileQuickActions = [
-    { key: "demo", label: "Demo", run: goToDemo },
-    { key: "create-account", label: "Create Account", run: goToCreateAccount },
     { key: "login", label: "Login", run: goToLogin },
-    { key: "contact-us", label: "Contact Us", run: goToContact },
     { key: "terms", label: "Terms & Conditions", run: goToFooterLegal },
     { key: "privacy", label: "Privacy Policy", run: goToFooterLegal },
     { key: "cookies", label: "Cookies Policy", run: goToFooterLegal },
+    { key: "contact-us", label: "Contact Us", run: goToContact },
   ] as const;
+  const mobilePrimaryActions = mobileQuickActions.filter((item) => item.key !== "contact-us");
+  const mobileBottomAction = mobileQuickActions.find((item) => item.key === "contact-us");
 
   const openSearch = () => {
     setIsMobileMenuOpen(false);
@@ -452,16 +452,22 @@ const LandingPage: React.FC = () => {
         {isMobileMenuOpen && <button type="button" className="landing-mobile-drawer-backdrop" aria-label="Close menu" onClick={() => setIsMobileMenuOpen(false)} />}
         <aside className={`landing-mobile-drawer${isMobileMenuOpen ? " is-open" : ""}`} id="landing-mobile-drawer" aria-label="Mobile menu" role="dialog" aria-modal={isMobileMenuOpen}>
           <div className="landing-mobile-drawer-head">
-            <span>Menu</span>
             <button type="button" onClick={() => setIsMobileMenuOpen(false)} aria-label="Close menu">×</button>
           </div>
           <nav className="landing-mobile-drawer-list" aria-label="Mobile quick links">
-            {mobileQuickActions.map((item) => (
+            {mobilePrimaryActions.map((item) => (
               <button key={`drawer-${item.key}`} type="button" onClick={() => handleMobileAction(item.run)}>
                 {item.label}
               </button>
             ))}
           </nav>
+          {mobileBottomAction ? (
+            <nav className="landing-mobile-drawer-list landing-mobile-drawer-list--footer" aria-label="Mobile contact link">
+              <button type="button" onClick={() => handleMobileAction(mobileBottomAction.run)}>
+                {mobileBottomAction.label}
+              </button>
+            </nav>
+          ) : null}
         </aside>
       </div>
 

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -38,13 +38,17 @@ const LandingPage: React.FC = () => {
 
   const mobileQuickActions = [
     { key: "login", label: "Login", run: goToLogin },
+    { key: "contact-us", label: "Contact Us", run: goToContact },
     { key: "terms", label: "Terms & Conditions", run: goToFooterLegal },
     { key: "privacy", label: "Privacy Policy", run: goToFooterLegal },
     { key: "cookies", label: "Cookies Policy", run: goToFooterLegal },
-    { key: "contact-us", label: "Contact Us", run: goToContact },
   ] as const;
-  const mobilePrimaryActions = mobileQuickActions.filter((item) => item.key !== "contact-us");
-  const mobileBottomAction = mobileQuickActions.find((item) => item.key === "contact-us");
+  const mobilePrimaryActions = mobileQuickActions.filter(
+    (item) => item.key === "login" || item.key === "contact-us",
+  );
+  const mobileLegalActions = mobileQuickActions.filter(
+    (item) => item.key === "terms" || item.key === "privacy" || item.key === "cookies",
+  );
 
   const openSearch = () => {
     setIsMobileMenuOpen(false);
@@ -461,11 +465,13 @@ const LandingPage: React.FC = () => {
               </button>
             ))}
           </nav>
-          {mobileBottomAction ? (
-            <nav className="landing-mobile-drawer-list landing-mobile-drawer-list--footer" aria-label="Mobile contact link">
-              <button type="button" onClick={() => handleMobileAction(mobileBottomAction.run)}>
-                {mobileBottomAction.label}
-              </button>
+          {mobileLegalActions.length ? (
+            <nav className="landing-mobile-drawer-list landing-mobile-drawer-list--footer" aria-label="Mobile legal links">
+              {mobileLegalActions.map((item) => (
+                <button key={`drawer-legal-${item.key}`} type="button" onClick={() => handleMobileAction(item.run)}>
+                  {item.label}
+                </button>
+              ))}
             </nav>
           ) : null}
         </aside>

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -94,7 +94,7 @@ const LandingFooter: React.FC = () => {
 
         <div className="landing-footer-social" aria-label="Social links">
           <a
-            href="https://www.youtube.com"
+            href="https://www.youtube.com/@CameraOperatingSystems"
             target="_blank"
             rel="noreferrer"
             aria-label={landingCopy.footer.socials.youtube}
@@ -108,7 +108,7 @@ const LandingFooter: React.FC = () => {
             </svg>
           </a>
           <a
-            href="https://www.linkedin.com"
+            href="https://www.linkedin.com/company/camera-operating-systems"
             target="_blank"
             rel="noreferrer"
             aria-label={landingCopy.footer.socials.linkedin}
@@ -122,7 +122,7 @@ const LandingFooter: React.FC = () => {
             </svg>
           </a>
           <a
-            href="https://x.com"
+            href="https://x.com/cam_O_S"
             target="_blank"
             rel="noreferrer"
             aria-label={landingCopy.footer.socials.x}

--- a/frontend/src/features/landing/components/SystemOverviewPreview.module.css
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.module.css
@@ -446,6 +446,7 @@
   border-radius: 15px;
   border: none;
   outline: none;
+  cursor: pointer;
   background: linear-gradient(180deg, color-mix(in srgb, #f8ebc8 64%, var(--landing-gold, var(--signal-gold)) 36%), color-mix(in srgb, #edd48a 62%, var(--landing-gold-strong, var(--signal-gold-strong)) 38%));
   box-shadow: 0 10px 20px rgba(62, 56, 34, 0.22), 0 1px 1px rgba(62, 56, 34, 0.08), inset 0 9px 14px rgba(255, 248, 226, 0.26);
   transition: background-color 160ms ease, box-shadow 160ms ease;
@@ -463,6 +464,11 @@
 .node:focus-within {
   background: linear-gradient(180deg, color-mix(in srgb, #fbf0d4 68%, var(--landing-gold, var(--signal-gold)) 32%), color-mix(in srgb, #f0da95 62%, var(--landing-gold-strong, var(--signal-gold-strong)) 38%));
   box-shadow: 0 13px 24px rgba(62, 56, 34, 0.26), 0 1px 1px rgba(62, 56, 34, 0.1), inset 0 10px 16px rgba(255, 250, 232, 0.28);
+}
+
+.node:focus-visible {
+  outline: 2px solid var(--sys-accent);
+  outline-offset: 2px;
 }
 
 .nodeLogo {

--- a/frontend/src/features/landing/components/SystemOverviewPreview.tsx
+++ b/frontend/src/features/landing/components/SystemOverviewPreview.tsx
@@ -738,13 +738,28 @@ const SystemOverviewLiveKpis: React.FC<{ forceMockTopology: boolean; onAccessDem
             <div className={styles.nodeMeasureGhost} ref={nodeShellRef} aria-hidden="true" />
           </div>
           <div className={styles.nodeStack}>
-            <div className={styles.node}>
+            <div
+              className={styles.node}
+              role="button"
+              tabIndex={0}
+              aria-label="Open demo view"
+              onClick={onAccessDemo}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onAccessDemo();
+                }
+              }}
+            >
               <img src={camOSLogo} alt="camOS Logo" className={styles.nodeLogo} />
               <button
                 type="button"
                 className={styles.previewNodeCta}
                 data-testid="preview-enter-demo-cta"
-                onClick={onAccessDemo}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onAccessDemo();
+                }}
               >
                 View Demo
               </button>

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -1534,13 +1534,15 @@ body {
     right: 0;
     width: min(320px, calc(100% - 34px));
     height: 100svh;
-    background: color-mix(in srgb, var(--surface-panel) 92%, white 8%);
-    border-left: 1px solid color-mix(in srgb, var(--sys-line) 66%, white 16%);
-    box-shadow: -10px 0 24px rgba(22, 30, 41, 0.22);
+    display: flex;
+    flex-direction: column;
+    background: color-mix(in srgb, var(--surface-page) 95%, white 5%);
+    border-left: 1px solid color-mix(in srgb, var(--sys-line) 38%, white 36%);
+    box-shadow: -8px 0 18px rgba(22, 30, 41, 0.14);
     transform: translateX(105%);
     transition: transform 180ms ease;
     z-index: 45;
-    padding: 14px;
+    padding: 12px 14px 16px;
   }
 
   .landing-mobile-drawer.is-open {
@@ -1549,11 +1551,9 @@ body {
 
   .landing-mobile-drawer-head {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
-    margin-bottom: 12px;
-    color: var(--sys-text-1);
-    font-weight: 620;
+    margin-bottom: 10px;
   }
 
   .landing-mobile-drawer-head button {
@@ -1567,17 +1567,29 @@ body {
 
   .landing-mobile-drawer-list {
     display: grid;
-    gap: 8px;
+    gap: 4px;
   }
 
   .landing-mobile-drawer-list button {
     min-height: 40px;
-    border: 1px solid color-mix(in srgb, var(--sys-line) 66%, white 20%);
-    border-radius: 10px;
+    border: none;
+    border-radius: 8px;
     text-align: left;
-    padding: 0 10px;
+    padding: 0 8px;
     color: var(--sys-text-1);
-    background: color-mix(in srgb, var(--surface-panel) 86%, white 14%);
+    background: transparent;
+    font-weight: 520;
+  }
+
+  .landing-mobile-drawer-list button:hover,
+  .landing-mobile-drawer-list button:focus-visible {
+    background: color-mix(in srgb, var(--surface-panel) 35%, transparent);
+    outline: none;
+  }
+
+  .landing-mobile-drawer-list--footer {
+    margin-top: auto;
+    padding-top: 10px;
   }
 
   .landing-spec-sheet {

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -24,6 +24,10 @@ body {
   color: var(--sys-text-1);
 }
 
+body.landing-mobile-drawer-lock {
+  overflow: hidden;
+}
+
 
 .landing-page {
   min-height: 100vh;


### PR DESCRIPTION
### Motivation

- Streamline the contact and create-account UIs by removing redundant small subtitle paragraphs that duplicate the main hero headings and can confuse visual hierarchy and accessibility.

### Description

- Removed the `<p className="contact-title">Contact</p>` element from `ContactPage.tsx` so the page relies on the `h1` hero heading only.
- Removed the `<p className="create-account-title">Create Account</p>` element from `CreateAccountPage.tsx` so the page relies on the `h1` hero heading only.

### Testing

- Ran TypeScript type-check, ESLint, and the existing frontend unit tests and they all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c92cb791f88332a4588a0920e297ba)