### PR TITLE
Add Terms and Conditions page and wire up footer/mobile links

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -34,6 +34,7 @@ const ResetPasswordPage = React.lazy(() => import("../pages/ResetPasswordPage"))
 const ContactPage = React.lazy(() => import("../pages/ContactPage"));
 const DemoPage = React.lazy(() => import("../pages/DemoPage"));
 const TermsAndConditionsPage = React.lazy(() => import("../pages/TermsAndConditionsPage"));
+const PrivacyPolicyPage = React.lazy(() => import("../pages/PrivacyPolicyPage"));
 
 const AppRoutes: React.FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -277,6 +278,16 @@ const AppRoutes: React.FC = () => {
         element={
           !isAuthenticatedMode ? (
             lazyRoute(<TermsAndConditionsPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/privacy-policy"
+        element={
+          !isAuthenticatedMode ? (
+            lazyRoute(<PrivacyPolicyPage />)
           ) : (
             <Navigate to="/home" replace />
           )

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -35,6 +35,7 @@ const ContactPage = React.lazy(() => import("../pages/ContactPage"));
 const DemoPage = React.lazy(() => import("../pages/DemoPage"));
 const TermsAndConditionsPage = React.lazy(() => import("../pages/TermsAndConditionsPage"));
 const PrivacyPolicyPage = React.lazy(() => import("../pages/PrivacyPolicyPage"));
+const SubProcessorRegisterPage = React.lazy(() => import("../pages/SubProcessorRegisterPage"));
 
 const AppRoutes: React.FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -288,6 +289,16 @@ const AppRoutes: React.FC = () => {
         element={
           !isAuthenticatedMode ? (
             lazyRoute(<PrivacyPolicyPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/sub-processor-register"
+        element={
+          !isAuthenticatedMode ? (
+            lazyRoute(<SubProcessorRegisterPage />)
           ) : (
             <Navigate to="/home" replace />
           )

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -33,6 +33,7 @@ const VerifyEmailPage = React.lazy(() => import("../pages/VerifyEmailPage"));
 const ResetPasswordPage = React.lazy(() => import("../pages/ResetPasswordPage"));
 const ContactPage = React.lazy(() => import("../pages/ContactPage"));
 const DemoPage = React.lazy(() => import("../pages/DemoPage"));
+const TermsAndConditionsPage = React.lazy(() => import("../pages/TermsAndConditionsPage"));
 
 const AppRoutes: React.FC = () => {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
@@ -266,6 +267,16 @@ const AppRoutes: React.FC = () => {
         element={
           !isAuthenticatedMode ? (
             lazyRoute(<ContactPage />)
+          ) : (
+            <Navigate to="/home" replace />
+          )
+        }
+      />
+      <Route
+        path="/terms-and-conditions"
+        element={
+          !isAuthenticatedMode ? (
+            lazyRoute(<TermsAndConditionsPage />)
           ) : (
             <Navigate to="/home" replace />
           )

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -172,10 +172,16 @@
   right: 10px;
   width: 28px;
   height: 28px;
-  border: 1px solid var(--line-default);
+  border: none;
   border-radius: 999px;
-  background: var(--surface-page);
-  color: var(--text-default);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, #dce4ec 56%, white 44%),
+    color-mix(in srgb, #c5d0dc 64%, white 36%)
+  );
+  color: color-mix(in srgb, #1e2732 88%, #000 12%);
+  box-shadow: 0 3px 9px rgba(52, 61, 74, 0.12), 0 1px 1px rgba(52, 61, 74, 0.08),
+    inset 0 8px 12px rgba(255, 255, 255, 0.28);
   cursor: pointer;
   font-size: 20px;
   line-height: 1;
@@ -246,6 +252,10 @@
 
 .contact-success-close:hover,
 .contact-success-close:focus-visible {
-  border-color: var(--text-default);
-  color: var(--text-default);
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, #e2e9f0 62%, white 38%),
+    color-mix(in srgb, #cad4df 68%, white 32%)
+  );
+  color: color-mix(in srgb, #1e2732 92%, #000 8%);
 }

--- a/frontend/src/features/auth/ContactPage.css
+++ b/frontend/src/features/auth/ContactPage.css
@@ -174,12 +174,8 @@
   height: 28px;
   border: none;
   border-radius: 999px;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, #dce4ec 56%, white 44%),
-    color-mix(in srgb, #c5d0dc 64%, white 36%)
-  );
-  color: color-mix(in srgb, #1e2732 88%, #000 12%);
+  background: var(--cta-secondary-bg);
+  color: var(--cta-secondary-text);
   box-shadow: 0 3px 9px rgba(52, 61, 74, 0.12), 0 1px 1px rgba(52, 61, 74, 0.08),
     inset 0 8px 12px rgba(255, 255, 255, 0.28);
   cursor: pointer;
@@ -252,10 +248,6 @@
 
 .contact-success-close:hover,
 .contact-success-close:focus-visible {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, #e2e9f0 62%, white 38%),
-    color-mix(in srgb, #cad4df 68%, white 32%)
-  );
-  color: color-mix(in srgb, #1e2732 92%, #000 8%);
+  background: var(--cta-secondary-bg-hover);
+  color: var(--cta-secondary-text);
 }

--- a/frontend/src/features/auth/CreateAccountPage.tsx
+++ b/frontend/src/features/auth/CreateAccountPage.tsx
@@ -11,10 +11,6 @@ import AuthPhoneField from './components/AuthPhoneField';
 import './CreateAccountPage.css';
 import './components/AuthPhoneField.css';
 
-const stopNavigation: React.MouseEventHandler<HTMLAnchorElement> = (event) => {
-  event.preventDefault();
-};
-
 const CreateAccountPage: React.FC = () => {
   const isPhoneLayout = useIsPhoneLayout();
   const navigate = useNavigate();
@@ -201,9 +197,9 @@ const CreateAccountPage: React.FC = () => {
                 </p>
                 <p>
                   By creating an account you comply to our{' '}
-                  <a href="#" onClick={stopNavigation}>privacy policy</a>.{' '}
+                  <Link to="/privacy-policy">privacy policy</Link>.{' '}
                   You can find the policy{' '}
-                  <a href="#" onClick={stopNavigation}>here</a>
+                  <Link to="/privacy-policy">here</Link>
                 </p>
                 <p>
                   Already have an Account? <Link to="/login">Login here</Link>

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -36,10 +36,14 @@ const LandingPage: React.FC = () => {
     footer?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
+  const goToTermsAndConditions = () => {
+    navigate("/terms-and-conditions");
+  };
+
   const mobileQuickActions = [
     { key: "login", label: "Login", run: goToLogin },
     { key: "contact-us", label: "Contact Us", run: goToContact },
-    { key: "terms", label: "Terms & Conditions", run: goToFooterLegal },
+    { key: "terms", label: "Terms & Conditions", run: goToTermsAndConditions },
     { key: "privacy", label: "Privacy Policy", run: goToFooterLegal },
     { key: "cookies", label: "Cookies Policy", run: goToFooterLegal },
   ] as const;

--- a/frontend/src/features/landing/LandingPage.tsx
+++ b/frontend/src/features/landing/LandingPage.tsx
@@ -29,7 +29,6 @@ const LandingPage: React.FC = () => {
 
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
   const [mobileSearchQuery, setMobileSearchQuery] = useState("");
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const goToFooterLegal = () => {
     const footer = document.querySelector(".landing-footer");
@@ -47,15 +46,7 @@ const LandingPage: React.FC = () => {
     { key: "privacy", label: "Privacy Policy", run: goToFooterLegal },
     { key: "cookies", label: "Cookies Policy", run: goToFooterLegal },
   ] as const;
-  const mobilePrimaryActions = mobileQuickActions.filter(
-    (item) => item.key === "login" || item.key === "contact-us",
-  );
-  const mobileLegalActions = mobileQuickActions.filter(
-    (item) => item.key === "terms" || item.key === "privacy" || item.key === "cookies",
-  );
-
   const openSearch = () => {
-    setIsMobileMenuOpen(false);
     setMobileSearchQuery("");
     setIsMobileSearchOpen((prev) => !prev);
   };
@@ -65,14 +56,8 @@ const LandingPage: React.FC = () => {
     setIsMobileSearchOpen(false);
   };
 
-  const openMenu = () => {
-    closeSearch();
-    setIsMobileMenuOpen((prev) => !prev);
-  };
-
   const handleMobileAction = (run: () => void) => {
     closeSearch();
-    setIsMobileMenuOpen(false);
     run();
   };
 
@@ -308,7 +293,6 @@ const LandingPage: React.FC = () => {
   useLayoutEffect(() => {
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
-        setIsMobileMenuOpen(false);
         setIsMobileSearchOpen(false);
       }
     };
@@ -318,22 +302,6 @@ const LandingPage: React.FC = () => {
       window.removeEventListener("keydown", handleEscape);
     };
   }, []);
-
-  useLayoutEffect(() => {
-    const mediaQuery = window.matchMedia("(max-width: 767px)");
-    const syncBodyScrollLock = () => {
-      const shouldLock = isMobileMenuOpen && mediaQuery.matches;
-      document.body.classList.toggle("landing-mobile-drawer-lock", shouldLock);
-    };
-
-    syncBodyScrollLock();
-    mediaQuery.addEventListener("change", syncBodyScrollLock);
-
-    return () => {
-      mediaQuery.removeEventListener("change", syncBodyScrollLock);
-      document.body.classList.remove("landing-mobile-drawer-lock");
-    };
-  }, [isMobileMenuOpen]);
 
   useLayoutEffect(() => {
     let frameId = 0;
@@ -427,11 +395,7 @@ const LandingPage: React.FC = () => {
 
   return (
     <div className="landing-page">
-      <LandingHeader
-        onLogin={goToLogin}
-        onMenuToggle={openMenu}
-        isMenuOpen={isMobileMenuOpen}
-      />
+      <LandingHeader onLogin={goToLogin} />
 
       <div className="landing-mobile-header-overlays" aria-live="polite">
         {isMobileSearchOpen && (
@@ -472,29 +436,6 @@ const LandingPage: React.FC = () => {
             </div>
           </>
         )}
-
-        {isMobileMenuOpen && <button type="button" className="landing-mobile-drawer-backdrop" aria-label="Close menu" onClick={() => setIsMobileMenuOpen(false)} />}
-        <aside className={`landing-mobile-drawer${isMobileMenuOpen ? " is-open" : ""}`} id="landing-mobile-drawer" aria-label="Mobile menu" role="dialog" aria-modal={isMobileMenuOpen}>
-          <div className="landing-mobile-drawer-head">
-            <button type="button" onClick={() => setIsMobileMenuOpen(false)} aria-label="Close menu">×</button>
-          </div>
-          <nav className="landing-mobile-drawer-list" aria-label="Mobile quick links">
-            {mobilePrimaryActions.map((item) => (
-              <button key={`drawer-${item.key}`} type="button" onClick={() => handleMobileAction(item.run)}>
-                {item.label}
-              </button>
-            ))}
-          </nav>
-          {mobileLegalActions.length ? (
-            <nav className="landing-mobile-drawer-list landing-mobile-drawer-list--footer" aria-label="Mobile legal links">
-              {mobileLegalActions.map((item) => (
-                <button key={`drawer-legal-${item.key}`} type="button" onClick={() => handleMobileAction(item.run)}>
-                  {item.label}
-                </button>
-              ))}
-            </nav>
-          ) : null}
-        </aside>
       </div>
 
       <main>

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -37,7 +37,11 @@ const LandingFooter: React.FC = () => {
               >
                 {termsAndConditions}
               </button>
-              <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+              <button
+                type="button"
+                className="landing-footer-link-item landing-footer-link-item-button"
+                onClick={() => navigate("/privacy-policy")}
+              >
                 {privacyPolicy}
               </button>
             </nav>
@@ -83,7 +87,11 @@ const LandingFooter: React.FC = () => {
             <button type="button" className="landing-footer-link-item landing-footer-link-item-button landing-footer-mobile-top-link landing-footer-mobile-top-link-cookie-policy">
               {cookiePolicy}
             </button>
-            <button type="button" className="landing-footer-link-item landing-footer-link-item-button landing-footer-mobile-top-link landing-footer-mobile-top-link-privacy">
+            <button
+              type="button"
+              className="landing-footer-link-item landing-footer-link-item-button landing-footer-mobile-top-link landing-footer-mobile-top-link-privacy"
+              onClick={() => navigate("/privacy-policy")}
+            >
               {privacyPolicy}
             </button>
             <button

--- a/frontend/src/features/landing/components/LandingFooter.tsx
+++ b/frontend/src/features/landing/components/LandingFooter.tsx
@@ -30,7 +30,11 @@ const LandingFooter: React.FC = () => {
               <span className="landing-footer-copyright-brand">Camera Operating Systems</span>
             </p>
             <nav className="landing-footer-links-column landing-footer-links-column-primary" aria-label="Primary legal links">
-              <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
+              <button
+                type="button"
+                className="landing-footer-link-item landing-footer-link-item-button"
+                onClick={() => navigate("/terms-and-conditions")}
+              >
                 {termsAndConditions}
               </button>
               <button type="button" className="landing-footer-link-item landing-footer-link-item-button">
@@ -62,7 +66,11 @@ const LandingFooter: React.FC = () => {
           <div className="landing-footer-mobile-top-links" aria-label="Mobile legal links">
             <span className="landing-footer-mobile-top-item landing-footer-mobile-top-item-year">© 2026</span>
             <span className="landing-footer-mobile-top-item landing-footer-mobile-top-item-brand">Camera Operating Systems</span>
-            <button type="button" className="landing-footer-link-item landing-footer-link-item-button landing-footer-mobile-top-link landing-footer-mobile-top-link-terms">
+            <button
+              type="button"
+              className="landing-footer-link-item landing-footer-link-item-button landing-footer-mobile-top-link landing-footer-mobile-top-link-terms"
+              onClick={() => navigate("/terms-and-conditions")}
+            >
               {termsAndConditions}
             </button>
             <button

--- a/frontend/src/features/landing/components/LandingHeader.tsx
+++ b/frontend/src/features/landing/components/LandingHeader.tsx
@@ -4,14 +4,10 @@ import { landingCopy } from "../content";
 
 type LandingHeaderProps = {
   onLogin: () => void;
-  onMenuToggle: () => void;
-  isMenuOpen?: boolean;
 };
 
 const LandingHeader: React.FC<LandingHeaderProps> = ({
   onLogin,
-  onMenuToggle,
-  isMenuOpen = false,
 }) => (
   <header className="landing-header">
     <div className="landing-container landing-header-top">
@@ -38,13 +34,6 @@ const LandingHeader: React.FC<LandingHeaderProps> = ({
             <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <circle cx="12" cy="8" r="3.3" fill="none" stroke="currentColor" strokeWidth="1.8" />
               <path d="M5.5 19.2c1.5-2.8 4-4.2 6.5-4.2s5 1.4 6.5 4.2" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-            </svg>
-          </button>
-          <button type="button" className="landing-header-icon-btn" aria-label="Menu" onClick={onMenuToggle} aria-expanded={isMenuOpen} aria-controls="landing-mobile-drawer">
-            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-              <line x1="4" y1="7" x2="20" y2="7" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-              <line x1="4" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-              <line x1="4" y1="17" x2="20" y2="17" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
             </svg>
           </button>
         </div>

--- a/frontend/src/features/landing/content.ts
+++ b/frontend/src/features/landing/content.ts
@@ -53,7 +53,7 @@ export const landingCopy = {
     primaryLinks: ["Terms & Conditions", "Privacy Policy"],
     secondaryLinks: ["Cookie Policy", "Cookie Preferences", "Contact Us"],
     legalLines: [
-      "Camera Operating Systems Limited is registered with the Information Commissioner's Office. Registered Number: Z1234567",
+      "Camera Operating Systems Limited is registered with the Information Commissioner's Office. Registered Number: ZC113561",
       "Camera Operating Systems Limited is registered in England and Wales. Registered Number: 16937639",
       "Registered Address: 71-75 Shelton Street, Covent Garden, London, WC2H 9FD, England",
     ],

--- a/frontend/src/features/legal/PrivacyPolicyPage.css
+++ b/frontend/src/features/legal/PrivacyPolicyPage.css
@@ -1,0 +1,79 @@
+.privacy-page {
+  min-height: 100vh;
+  background: var(--surface-page);
+  color: var(--text-strong);
+}
+
+.privacy-page__main {
+  display: flex;
+  justify-content: center;
+  padding: 36px 24px 48px;
+}
+
+.privacy-page__document {
+  width: min(100%, 860px);
+  padding: 0;
+}
+
+.privacy-page__back-link {
+  border: 0;
+  background: transparent;
+  color: var(--text-default);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  justify-self: start;
+  margin-bottom: 10px;
+  font-size: 14px;
+  text-decoration: none;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.privacy-page__back-link:hover,
+.privacy-page__back-link:focus-visible {
+  color: var(--text-strong);
+  text-decoration: underline;
+}
+
+.privacy-page__title {
+  margin: 0 0 16px;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+}
+
+.privacy-page__body {
+  color: var(--text-default);
+  line-height: 1.65;
+  font-size: 0.98rem;
+}
+
+.privacy-page__body p {
+  margin: 0;
+}
+
+.privacy-page__body p + p {
+  margin-top: 16px;
+}
+
+.privacy-page__meta {
+  margin: 22px 0 0;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+@media (max-width: 900px) {
+  .privacy-page {
+    padding-bottom: calc(68px + env(safe-area-inset-bottom));
+  }
+
+  .privacy-page__main {
+    padding: 22px 16px 20px;
+  }
+
+  .privacy-page__document {
+    padding: 0;
+  }
+}

--- a/frontend/src/features/legal/PrivacyPolicyPage.css
+++ b/frontend/src/features/legal/PrivacyPolicyPage.css
@@ -57,6 +57,16 @@
   margin-top: 16px;
 }
 
+.privacy-page__body a {
+  color: var(--text-strong);
+  text-underline-offset: 3px;
+}
+
+.privacy-page__body a:hover,
+.privacy-page__body a:focus-visible {
+  text-decoration-thickness: 2px;
+}
+
 .privacy-page__meta {
   margin: 22px 0 0;
   font-size: 0.88rem;

--- a/frontend/src/features/legal/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/legal/PrivacyPolicyPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { ArrowLeft } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
@@ -9,7 +9,6 @@ import LandingHeader from "../landing/components/LandingHeader";
 import "./PrivacyPolicyPage.css";
 
 const PRIVACY_POLICY_PARAGRAPHS = [
-  "Camera Operating Systems Limited (“the Company”) is a company incorporated in England and Wales under registration number 16937639, with a registered address at 71-75 Shelton Street, Covent Garden, London, WC2H 9FD, England. The Company is registered with the Information Commissioner’s Office under registration number ZC113561. Enquiries regarding this Privacy Notice may be sent to [compliance@camos.app](mailto:compliance@camos.app).",
   "In this Privacy Notice, “UK GDPR” means the United Kingdom General Data Protection Regulation. The terms “personal data” and “sub-processor” have the meanings given to them in the UK GDPR.",
   "The Company primarily acts as a data processor within the meaning of the UK GDPR when processing personal data on behalf of customers. The Company processes personal data only pursuant to contract and on the instructions of customers. Customers are responsible for determining the purposes of processing and the lawful basis for such processing, which typically consists of legitimate interests.",
   "The Company provides automated data processing services using video supplied by customers. Processing is fully automated. No human review is performed.",
@@ -19,7 +18,6 @@ const PRIVACY_POLICY_PARAGRAPHS = [
   "Personal data is processed solely for the provision of services to customers.",
   "The Company does not perform biometric identification or facial recognition. The Company does not identify individuals and does not attempt to do so. Biometric templates or information intended to uniquely identify individuals are not created or stored.",
   "Video is retained for a maximum period of sixty days and deleted thereafter. Anonymised and aggregated analytical outputs may be retained by the Company. Such outputs do not identify individuals and do not constitute personal data under the UK GDPR.",
-  "Personal data may be processed outside the United Kingdom. Where such processing occurs, appropriate safeguards are implemented in accordance with applicable data protection law, including the use of standard contractual clauses or other approved mechanisms. Further information regarding sub-processors, processing locations, and transfer safeguards is set out in the Sub-Processor Register maintained by the Company.",
   "Appropriate technical and organisational measures are applied to protect personal data.",
   "Individuals wishing to exercise data protection rights should contact the customer operating the relevant camera system. The Company assists customers in fulfilling such requests where required.",
   "Individuals have the right to lodge a complaint with the UK Information Commissioner’s Office.",
@@ -60,9 +58,24 @@ const PrivacyPolicyPage: React.FC = () => {
           <h1 className="privacy-page__title">Privacy Policy</h1>
 
           <div className="privacy-page__body">
+            <p>
+              Camera Operating Systems Limited (“the Company”) is a company incorporated in England and Wales under
+              registration number 16937639, with a registered address at 71-75 Shelton Street, Covent Garden, London,
+              WC2H 9FD, England. The Company is registered with the Information Commissioner’s Office under registration
+              number ZC113561. Enquiries regarding this Privacy Notice may be sent to compliance@camos.app.
+            </p>
+
             {PRIVACY_POLICY_PARAGRAPHS.map((paragraph) => (
               <p key={paragraph}>{paragraph}</p>
             ))}
+
+            <p>
+              Personal data may be processed outside the United Kingdom. Where such processing occurs, appropriate
+              safeguards are implemented in accordance with applicable data protection law, including the use of
+              standard contractual clauses or other approved mechanisms. Further information regarding sub-processors,
+              processing locations, and transfer safeguards is set out in the <Link to="/sub-processor-register">Sub-Processor Register</Link>{" "}
+              maintained by the Company.
+            </p>
           </div>
 
           <p className="privacy-page__meta">Last updated: 01 April 2026</p>

--- a/frontend/src/features/legal/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/legal/PrivacyPolicyPage.tsx
@@ -4,8 +4,8 @@ import { Link, useNavigate } from "react-router-dom";
 
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import AuthTopBar from "../../components/auth/AuthTopBar";
 import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
-import LandingHeader from "../landing/components/LandingHeader";
 import "./PrivacyPolicyPage.css";
 
 const PRIVACY_POLICY_PARAGRAPHS = [
@@ -27,10 +27,6 @@ const PrivacyPolicyPage: React.FC = () => {
   const navigate = useNavigate();
   const isPhoneLayout = useIsPhoneLayout();
 
-  const goToLogin = () => {
-    navigate("/login");
-  };
-
   const handleGoBack = () => {
     if (typeof window !== "undefined" && window.history.length > 1) {
       navigate(-1);
@@ -45,7 +41,7 @@ const PrivacyPolicyPage: React.FC = () => {
       {isPhoneLayout ? (
         <AuthLogoHeader />
       ) : (
-        <LandingHeader onLogin={goToLogin} />
+        <AuthTopBar />
       )}
 
       <main className="privacy-page__main" aria-label="Privacy Policy content">

--- a/frontend/src/features/legal/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/legal/PrivacyPolicyPage.tsx
@@ -45,7 +45,7 @@ const PrivacyPolicyPage: React.FC = () => {
       {isPhoneLayout ? (
         <AuthLogoHeader />
       ) : (
-        <LandingHeader onLogin={goToLogin} onMenuToggle={() => undefined} />
+        <LandingHeader onLogin={goToLogin} />
       )}
 
       <main className="privacy-page__main" aria-label="Privacy Policy content">

--- a/frontend/src/features/legal/PrivacyPolicyPage.tsx
+++ b/frontend/src/features/legal/PrivacyPolicyPage.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
+import LandingHeader from "../landing/components/LandingHeader";
+import "./PrivacyPolicyPage.css";
+
+const PRIVACY_POLICY_PARAGRAPHS = [
+  "Camera Operating Systems Limited (“the Company”) is a company incorporated in England and Wales under registration number 16937639, with a registered address at 71-75 Shelton Street, Covent Garden, London, WC2H 9FD, England. The Company is registered with the Information Commissioner’s Office under registration number ZC113561. Enquiries regarding this Privacy Notice may be sent to [compliance@camos.app](mailto:compliance@camos.app).",
+  "In this Privacy Notice, “UK GDPR” means the United Kingdom General Data Protection Regulation. The terms “personal data” and “sub-processor” have the meanings given to them in the UK GDPR.",
+  "The Company primarily acts as a data processor within the meaning of the UK GDPR when processing personal data on behalf of customers. The Company processes personal data only pursuant to contract and on the instructions of customers. Customers are responsible for determining the purposes of processing and the lawful basis for such processing, which typically consists of legitimate interests.",
+  "The Company provides automated data processing services using video supplied by customers. Processing is fully automated. No human review is performed.",
+  "Processing may relate to members of the public present in areas monitored by camera systems operated by customers.",
+  "The categories of personal data processed consist of video and associated metadata. Processing includes automated analysis such as detection of individuals, counting, and occupancy estimation. Audio data is not processed. Direct identifiers are not collected.",
+  "All video processed by the Company is supplied by customers from camera systems they operate.",
+  "Personal data is processed solely for the provision of services to customers.",
+  "The Company does not perform biometric identification or facial recognition. The Company does not identify individuals and does not attempt to do so. Biometric templates or information intended to uniquely identify individuals are not created or stored.",
+  "Video is retained for a maximum period of sixty days and deleted thereafter. Anonymised and aggregated analytical outputs may be retained by the Company. Such outputs do not identify individuals and do not constitute personal data under the UK GDPR.",
+  "Personal data may be processed outside the United Kingdom. Where such processing occurs, appropriate safeguards are implemented in accordance with applicable data protection law, including the use of standard contractual clauses or other approved mechanisms. Further information regarding sub-processors, processing locations, and transfer safeguards is set out in the Sub-Processor Register maintained by the Company.",
+  "Appropriate technical and organisational measures are applied to protect personal data.",
+  "Individuals wishing to exercise data protection rights should contact the customer operating the relevant camera system. The Company assists customers in fulfilling such requests where required.",
+  "Individuals have the right to lodge a complaint with the UK Information Commissioner’s Office.",
+] as const;
+
+const PrivacyPolicyPage: React.FC = () => {
+  const navigate = useNavigate();
+  const isPhoneLayout = useIsPhoneLayout();
+
+  const goToLogin = () => {
+    navigate("/login");
+  };
+
+  const handleGoBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      navigate(-1);
+      return;
+    }
+
+    navigate("/", { replace: true });
+  };
+
+  return (
+    <div className="privacy-page">
+      {isPhoneLayout ? (
+        <AuthLogoHeader />
+      ) : (
+        <LandingHeader onLogin={goToLogin} onMenuToggle={() => undefined} />
+      )}
+
+      <main className="privacy-page__main" aria-label="Privacy Policy content">
+        <section className="privacy-page__document">
+          <button type="button" className="privacy-page__back-link" onClick={handleGoBack}>
+            <ArrowLeft size={18} aria-hidden="true" />
+            <span>Go back</span>
+          </button>
+
+          <h1 className="privacy-page__title">Privacy Policy</h1>
+
+          <div className="privacy-page__body">
+            {PRIVACY_POLICY_PARAGRAPHS.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+
+          <p className="privacy-page__meta">Last updated: 01 April 2026</p>
+        </section>
+      </main>
+
+      {isPhoneLayout ? <AuthBottomNav /> : null}
+    </div>
+  );
+};
+
+export default PrivacyPolicyPage;

--- a/frontend/src/features/legal/SubProcessorRegisterPage.css
+++ b/frontend/src/features/legal/SubProcessorRegisterPage.css
@@ -91,28 +91,35 @@
   font-weight: 600;
 }
 
-.subprocessor-page__mobile-record {
+.subprocessor-page__mobile-table {
+  width: 100%;
+  border-collapse: collapse;
   margin-top: 8px;
-  border-top: 1px solid var(--border-subtle);
+  font-size: 0.9rem;
 }
 
-.subprocessor-page__mobile-field {
-  padding: 12px 0;
-  border-bottom: 1px solid var(--border-subtle);
+.subprocessor-page__mobile-table th,
+.subprocessor-page__mobile-table td {
+  border: 1px solid var(--border-default);
+  padding: 10px;
+  text-align: left;
+  vertical-align: top;
 }
 
-.subprocessor-page__mobile-label {
-  margin: 0;
+.subprocessor-page__mobile-table th {
+  width: 38%;
+  color: var(--text-strong);
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  color: var(--text-muted);
+  background: var(--surface-soft);
 }
 
-.subprocessor-page__mobile-value {
-  margin: 6px 0 0;
+.subprocessor-page__mobile-table td {
+  width: 62%;
   color: var(--text-default);
-  line-height: 1.55;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/legal/SubProcessorRegisterPage.css
+++ b/frontend/src/features/legal/SubProcessorRegisterPage.css
@@ -1,0 +1,130 @@
+.subprocessor-page {
+  min-height: 100vh;
+  background: var(--surface-page);
+  color: var(--text-strong);
+}
+
+.subprocessor-page__main {
+  display: flex;
+  justify-content: center;
+  padding: 36px 24px 48px;
+}
+
+.subprocessor-page__document {
+  width: min(100%, 1100px);
+  padding: 0;
+}
+
+.subprocessor-page__back-link {
+  border: 0;
+  background: transparent;
+  color: var(--text-default);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  justify-self: start;
+  margin-bottom: 10px;
+  font-size: 14px;
+  text-decoration: none;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.subprocessor-page__back-link:hover,
+.subprocessor-page__back-link:focus-visible {
+  color: var(--text-strong);
+  text-decoration: underline;
+}
+
+.subprocessor-page__title {
+  margin: 0 0 16px;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+}
+
+.subprocessor-page__subtitle {
+  margin: 28px 0 12px;
+  font-size: 1.1rem;
+  line-height: 1.35;
+}
+
+.subprocessor-page__body {
+  color: var(--text-default);
+  line-height: 1.65;
+  font-size: 0.98rem;
+}
+
+.subprocessor-page__body p {
+  margin: 0;
+}
+
+.subprocessor-page__body p + p {
+  margin-top: 16px;
+}
+
+.subprocessor-page__meta {
+  margin: 22px 0 0;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--text-muted);
+}
+
+.subprocessor-page__table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+  font-size: 0.94rem;
+}
+
+.subprocessor-page__table th,
+.subprocessor-page__table td {
+  border: 1px solid var(--border-default);
+  padding: 12px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.subprocessor-page__table th {
+  color: var(--text-strong);
+  background: var(--surface-soft);
+  font-weight: 600;
+}
+
+.subprocessor-page__mobile-record {
+  margin-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.subprocessor-page__mobile-field {
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.subprocessor-page__mobile-label {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--text-muted);
+}
+
+.subprocessor-page__mobile-value {
+  margin: 6px 0 0;
+  color: var(--text-default);
+  line-height: 1.55;
+}
+
+@media (max-width: 900px) {
+  .subprocessor-page {
+    padding-bottom: calc(68px + env(safe-area-inset-bottom));
+  }
+
+  .subprocessor-page__main {
+    padding: 22px 16px 20px;
+  }
+
+  .subprocessor-page__document {
+    width: min(100%, 860px);
+  }
+}

--- a/frontend/src/features/legal/SubProcessorRegisterPage.tsx
+++ b/frontend/src/features/legal/SubProcessorRegisterPage.tsx
@@ -67,7 +67,7 @@ const SubProcessorRegisterPage: React.FC = () => {
       {isPhoneLayout ? (
         <AuthLogoHeader />
       ) : (
-        <LandingHeader onLogin={goToLogin} onMenuToggle={() => undefined} />
+        <LandingHeader onLogin={goToLogin} />
       )}
 
       <main className="subprocessor-page__main" aria-label="Sub-Processor Register content">

--- a/frontend/src/features/legal/SubProcessorRegisterPage.tsx
+++ b/frontend/src/features/legal/SubProcessorRegisterPage.tsx
@@ -4,8 +4,8 @@ import { useNavigate } from "react-router-dom";
 
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import AuthTopBar from "../../components/auth/AuthTopBar";
 import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
-import LandingHeader from "../landing/components/LandingHeader";
 import "./SubProcessorRegisterPage.css";
 
 const REGISTER_INTRO_PARAGRAPHS = [
@@ -49,10 +49,6 @@ const SubProcessorRegisterPage: React.FC = () => {
   const navigate = useNavigate();
   const isPhoneLayout = useIsPhoneLayout();
 
-  const goToLogin = () => {
-    navigate("/login");
-  };
-
   const handleGoBack = () => {
     if (typeof window !== "undefined" && window.history.length > 1) {
       navigate(-1);
@@ -67,7 +63,7 @@ const SubProcessorRegisterPage: React.FC = () => {
       {isPhoneLayout ? (
         <AuthLogoHeader />
       ) : (
-        <LandingHeader onLogin={goToLogin} />
+        <AuthTopBar />
       )}
 
       <main className="subprocessor-page__main" aria-label="Sub-Processor Register content">

--- a/frontend/src/features/legal/SubProcessorRegisterPage.tsx
+++ b/frontend/src/features/legal/SubProcessorRegisterPage.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
+import LandingHeader from "../landing/components/LandingHeader";
+import "./SubProcessorRegisterPage.css";
+
+const REGISTER_INTRO_PARAGRAPHS = [
+  "This Sub-Processor Register identifies the sub-processors engaged by Camera Operating Systems Limited (“the Company”) in connection with the processing of personal data on behalf of customers.",
+  "The Company engages sub-processors solely to support the provision of its services. Sub-processors are contractually required to process personal data only on the Company’s instructions and in accordance with applicable data protection law.",
+  "Sub-processors may process personal data only to the extent necessary to provide the services described below.",
+  "The Company may update this Register from time to time to reflect changes to its sub-processing arrangements.",
+] as const;
+
+const REGISTER_HEADERS = [
+  "Sub-Processor",
+  "Legal Entity",
+  "Processing Activities",
+  "Categories of Personal Data",
+  "Processing Locations",
+  "International Transfers",
+  "Transfer Safeguards",
+] as const;
+
+const REGISTER_ROW = {
+  subProcessor: "Google Cloud Platform",
+  legalEntity: "Google LLC and affiliated entities",
+  processingActivities: "Provision of cloud infrastructure services, including hosting, processing, and storage",
+  categoriesOfPersonalData: "Video and associated metadata",
+  processingLocations: "United Kingdom, European Economic Area, United States",
+  internationalTransfers: "Yes",
+  transferSafeguards: "Standard Contractual Clauses or other approved transfer mechanisms",
+} as const;
+
+const MOBILE_FIELDS = [
+  { label: "Sub-Processor", value: REGISTER_ROW.subProcessor },
+  { label: "Legal Entity", value: REGISTER_ROW.legalEntity },
+  { label: "Processing Activities", value: REGISTER_ROW.processingActivities },
+  { label: "Categories of Personal Data", value: REGISTER_ROW.categoriesOfPersonalData },
+  { label: "Processing Locations", value: REGISTER_ROW.processingLocations },
+  { label: "International Transfers", value: REGISTER_ROW.internationalTransfers },
+  { label: "Transfer Safeguards", value: REGISTER_ROW.transferSafeguards },
+] as const;
+
+const SubProcessorRegisterPage: React.FC = () => {
+  const navigate = useNavigate();
+  const isPhoneLayout = useIsPhoneLayout();
+
+  const goToLogin = () => {
+    navigate("/login");
+  };
+
+  const handleGoBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      navigate(-1);
+      return;
+    }
+
+    navigate("/privacy-policy", { replace: true });
+  };
+
+  return (
+    <div className="subprocessor-page">
+      {isPhoneLayout ? (
+        <AuthLogoHeader />
+      ) : (
+        <LandingHeader onLogin={goToLogin} onMenuToggle={() => undefined} />
+      )}
+
+      <main className="subprocessor-page__main" aria-label="Sub-Processor Register content">
+        <section className="subprocessor-page__document">
+          <button type="button" className="subprocessor-page__back-link" onClick={handleGoBack}>
+            <ArrowLeft size={18} aria-hidden="true" />
+            <span>Go back</span>
+          </button>
+
+          <h1 className="subprocessor-page__title">Sub-Processor Register</h1>
+
+          <div className="subprocessor-page__body">
+            {REGISTER_INTRO_PARAGRAPHS.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+
+            <p className="subprocessor-page__meta">Last updated: 01 April 2026</p>
+
+            <h2 className="subprocessor-page__subtitle">Sub-Processors</h2>
+
+            {isPhoneLayout ? (
+              <article className="subprocessor-page__mobile-record" aria-label="Sub-Processor Register entry">
+                {MOBILE_FIELDS.map((field) => (
+                  <div className="subprocessor-page__mobile-field" key={field.label}>
+                    <p className="subprocessor-page__mobile-label">{field.label}</p>
+                    <p className="subprocessor-page__mobile-value">{field.value}</p>
+                  </div>
+                ))}
+              </article>
+            ) : (
+              <table className="subprocessor-page__table">
+                <thead>
+                  <tr>
+                    {REGISTER_HEADERS.map((header) => (
+                      <th key={header} scope="col">
+                        {header}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>{REGISTER_ROW.subProcessor}</td>
+                    <td>{REGISTER_ROW.legalEntity}</td>
+                    <td>{REGISTER_ROW.processingActivities}</td>
+                    <td>{REGISTER_ROW.categoriesOfPersonalData}</td>
+                    <td>{REGISTER_ROW.processingLocations}</td>
+                    <td>{REGISTER_ROW.internationalTransfers}</td>
+                    <td>{REGISTER_ROW.transferSafeguards}</td>
+                  </tr>
+                </tbody>
+              </table>
+            )}
+          </div>
+        </section>
+      </main>
+
+      {isPhoneLayout ? <AuthBottomNav /> : null}
+    </div>
+  );
+};
+
+export default SubProcessorRegisterPage;

--- a/frontend/src/features/legal/SubProcessorRegisterPage.tsx
+++ b/frontend/src/features/legal/SubProcessorRegisterPage.tsx
@@ -89,14 +89,16 @@ const SubProcessorRegisterPage: React.FC = () => {
             <h2 className="subprocessor-page__subtitle">Sub-Processors</h2>
 
             {isPhoneLayout ? (
-              <article className="subprocessor-page__mobile-record" aria-label="Sub-Processor Register entry">
-                {MOBILE_FIELDS.map((field) => (
-                  <div className="subprocessor-page__mobile-field" key={field.label}>
-                    <p className="subprocessor-page__mobile-label">{field.label}</p>
-                    <p className="subprocessor-page__mobile-value">{field.value}</p>
-                  </div>
-                ))}
-              </article>
+              <table className="subprocessor-page__mobile-table" aria-label="Sub-Processor Register entry">
+                <tbody>
+                  {MOBILE_FIELDS.map((field) => (
+                    <tr key={field.label}>
+                      <th scope="row">{field.label}</th>
+                      <td>{field.value}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             ) : (
               <table className="subprocessor-page__table">
                 <thead>

--- a/frontend/src/features/legal/TermsAndConditionsPage.css
+++ b/frontend/src/features/legal/TermsAndConditionsPage.css
@@ -12,11 +12,7 @@
 
 .terms-page__document {
   width: min(100%, 860px);
-  background: color-mix(in srgb, var(--surface-page) 92%, white 8%);
-  border: 1px solid var(--line-soft);
-  border-radius: 12px;
-  padding: 24px;
-  box-shadow: 0 8px 24px rgba(52, 61, 74, 0.08);
+  padding: 0;
 }
 
 .terms-page__back {
@@ -61,8 +57,6 @@
   }
 
   .terms-page__document {
-    border-radius: 10px;
-    padding: 18px;
-    box-shadow: 0 6px 18px rgba(52, 61, 74, 0.08);
+    padding: 0;
   }
 }

--- a/frontend/src/features/legal/TermsAndConditionsPage.css
+++ b/frontend/src/features/legal/TermsAndConditionsPage.css
@@ -15,36 +15,62 @@
   padding: 0;
 }
 
-.terms-page__back {
-  border: 1px solid var(--line-soft);
-  background: var(--surface-page);
+.terms-page__back-link {
+  border: 0;
+  background: transparent;
   color: var(--text-default);
-  border-radius: 999px;
-  padding: 8px 14px;
+  padding: 0;
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  justify-self: start;
+  margin-bottom: 10px;
+  font-size: 14px;
+  text-decoration: none;
+  text-underline-offset: 3px;
   cursor: pointer;
 }
 
-.terms-page__back:hover,
-.terms-page__back:focus-visible {
-  border-color: var(--line-default);
+.terms-page__back-link:hover,
+.terms-page__back-link:focus-visible {
   color: var(--text-strong);
+  text-decoration: underline;
 }
 
 .terms-page__title {
-  margin: 16px 0 16px;
+  margin: 0 0 16px;
   font-size: clamp(1.5rem, 3vw, 2rem);
   line-height: 1.2;
 }
 
 .terms-page__body {
-  margin: 0;
   color: var(--text-default);
   line-height: 1.65;
-  white-space: pre-line;
   font-size: 0.98rem;
+}
+
+.terms-page__body p {
+  margin: 0;
+}
+
+.terms-page__body p + p {
+  margin-top: 16px;
+}
+
+.terms-page__list {
+  margin: 10px 0 16px 24px;
+  padding: 0;
+}
+
+.terms-page__list li + li {
+  margin-top: 8px;
+}
+
+.terms-page__meta {
+  margin: 22px 0 0;
+  font-size: 0.88rem;
+  line-height: 1.4;
+  color: var(--text-muted);
 }
 
 @media (max-width: 900px) {

--- a/frontend/src/features/legal/TermsAndConditionsPage.css
+++ b/frontend/src/features/legal/TermsAndConditionsPage.css
@@ -1,0 +1,68 @@
+.terms-page {
+  min-height: 100vh;
+  background: var(--surface-page);
+  color: var(--text-strong);
+}
+
+.terms-page__main {
+  display: flex;
+  justify-content: center;
+  padding: 36px 24px 48px;
+}
+
+.terms-page__document {
+  width: min(100%, 860px);
+  background: color-mix(in srgb, var(--surface-page) 92%, white 8%);
+  border: 1px solid var(--line-soft);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 8px 24px rgba(52, 61, 74, 0.08);
+}
+
+.terms-page__back {
+  border: 1px solid var(--line-soft);
+  background: var(--surface-page);
+  color: var(--text-default);
+  border-radius: 999px;
+  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.terms-page__back:hover,
+.terms-page__back:focus-visible {
+  border-color: var(--line-default);
+  color: var(--text-strong);
+}
+
+.terms-page__title {
+  margin: 16px 0 16px;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+}
+
+.terms-page__body {
+  margin: 0;
+  color: var(--text-default);
+  line-height: 1.65;
+  white-space: pre-line;
+  font-size: 0.98rem;
+}
+
+@media (max-width: 900px) {
+  .terms-page {
+    padding-bottom: calc(68px + env(safe-area-inset-bottom));
+  }
+
+  .terms-page__main {
+    padding: 22px 16px 20px;
+  }
+
+  .terms-page__document {
+    border-radius: 10px;
+    padding: 18px;
+    box-shadow: 0 6px 18px rgba(52, 61, 74, 0.08);
+  }
+}

--- a/frontend/src/features/legal/TermsAndConditionsPage.tsx
+++ b/frontend/src/features/legal/TermsAndConditionsPage.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+import AuthBottomNav from "../../components/auth/AuthBottomNav";
+import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
+import LandingHeader from "../landing/components/LandingHeader";
+import "./TermsAndConditionsPage.css";
+
+const TERMS_AND_CONDITIONS_TEXT = `These Terms and Conditions ("Terms") govern the use of services provided by Camera Operating Systems Limited ("the Company", "we", "us", "our"). By accessing or using the services, the customer ("Customer", "you") agrees to these Terms.
+
+The Company provides automated video analytics services using video data supplied by the Customer. The services generate aggregated insights such as footfall, occupancy, and traffic patterns.
+
+The Customer is responsible for:
+
+Operating camera systems lawfully
+
+Ensuring a valid lawful basis for processing personal data
+
+Providing appropriate notices to individuals where required
+
+Ensuring that video data supplied to the Company complies with applicable law
+
+The Company processes personal data on behalf of the Customer as a data processor under the UK GDPR. Processing is carried out solely to provide the services and in accordance with the Customer’s instructions.
+
+The Company does not identify individuals and does not perform facial recognition or biometric identification.
+
+The Company may generate anonymised and aggregated data derived from service usage. Such data does not identify individuals and may be used by the Company for analytics, service improvement, and commercial purposes.
+
+The services are provided on an "as is" and "as available" basis. The Company does not guarantee uninterrupted, secure, or error-free operation of the services.
+
+The core analytics service is provided free of charge unless otherwise agreed. The Company reserves the right to introduce paid features or services in the future.
+
+The Customer must not use the services in any way that is unlawful, infringes the rights of others, or interferes with the operation of the services.
+
+All intellectual property rights in the services remain the property of the Company. The Customer is granted a limited, non-exclusive, non-transferable right to use the services.
+
+To the fullest extent permitted by law, the Company shall not be liable for any indirect, incidental, or consequential loss, including loss of profits, revenue, or business opportunities.
+
+The Company’s total liability arising out of or in connection with the services shall not exceed £1,000.
+
+The Customer may stop using the services at any time. The Company may suspend or terminate access where necessary to protect the services, comply with law, or address misuse.
+
+The Company may update the services or these Terms from time to time. Continued use of the services constitutes acceptance of the updated Terms.
+
+These Terms are governed by the laws of England and Wales. Any disputes shall be subject to the jurisdiction of the courts of England and Wales.
+
+Enquiries may be sent to [compliance@camos.app](mailto:compliance@camos.app).`;
+
+const TermsAndConditionsPage: React.FC = () => {
+  const navigate = useNavigate();
+  const isPhoneLayout = useIsPhoneLayout();
+
+  const goToLogin = () => {
+    navigate("/login");
+  };
+
+  const handleGoBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      navigate(-1);
+      return;
+    }
+
+    navigate("/", { replace: true });
+  };
+
+  return (
+    <div className="terms-page">
+      {isPhoneLayout ? (
+        <AuthLogoHeader />
+      ) : (
+        <LandingHeader onLogin={goToLogin} onMenuToggle={() => undefined} />
+      )}
+
+      <main className="terms-page__main" aria-label="Terms and Conditions content">
+        <section className="terms-page__document">
+          <button type="button" className="terms-page__back" onClick={handleGoBack}>
+            <ArrowLeft size={18} aria-hidden="true" />
+            <span>Go back</span>
+          </button>
+
+          <h1 className="terms-page__title">Terms and Conditions</h1>
+          <p className="terms-page__body">{TERMS_AND_CONDITIONS_TEXT}</p>
+        </section>
+      </main>
+
+      {isPhoneLayout ? <AuthBottomNav /> : null}
+    </div>
+  );
+};
+
+export default TermsAndConditionsPage;

--- a/frontend/src/features/legal/TermsAndConditionsPage.tsx
+++ b/frontend/src/features/legal/TermsAndConditionsPage.tsx
@@ -4,8 +4,8 @@ import { useNavigate } from "react-router-dom";
 
 import AuthBottomNav from "../../components/auth/AuthBottomNav";
 import AuthLogoHeader from "../../components/auth/AuthLogoHeader";
+import AuthTopBar from "../../components/auth/AuthTopBar";
 import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
-import LandingHeader from "../landing/components/LandingHeader";
 import "./TermsAndConditionsPage.css";
 
 const TERMS_PARAGRAPHS_BEFORE_RESPONSIBILITIES = [
@@ -40,10 +40,6 @@ const TermsAndConditionsPage: React.FC = () => {
   const navigate = useNavigate();
   const isPhoneLayout = useIsPhoneLayout();
 
-  const goToLogin = () => {
-    navigate("/login");
-  };
-
   const handleGoBack = () => {
     if (typeof window !== "undefined" && window.history.length > 1) {
       navigate(-1);
@@ -58,7 +54,7 @@ const TermsAndConditionsPage: React.FC = () => {
       {isPhoneLayout ? (
         <AuthLogoHeader />
       ) : (
-        <LandingHeader onLogin={goToLogin} />
+        <AuthTopBar />
       )}
 
       <main className="terms-page__main" aria-label="Terms and Conditions content">

--- a/frontend/src/features/legal/TermsAndConditionsPage.tsx
+++ b/frontend/src/features/legal/TermsAndConditionsPage.tsx
@@ -46,7 +46,7 @@ The Company may update the services or these Terms from time to time. Continued 
 
 These Terms are governed by the laws of England and Wales. Any disputes shall be subject to the jurisdiction of the courts of England and Wales.
 
-Enquiries may be sent to [compliance@camos.app](mailto:compliance@camos.app).`;
+Enquiries may be sent to compliance@camos.app.`;
 
 const TermsAndConditionsPage: React.FC = () => {
   const navigate = useNavigate();

--- a/frontend/src/features/legal/TermsAndConditionsPage.tsx
+++ b/frontend/src/features/legal/TermsAndConditionsPage.tsx
@@ -58,7 +58,7 @@ const TermsAndConditionsPage: React.FC = () => {
       {isPhoneLayout ? (
         <AuthLogoHeader />
       ) : (
-        <LandingHeader onLogin={goToLogin} onMenuToggle={() => undefined} />
+        <LandingHeader onLogin={goToLogin} />
       )}
 
       <main className="terms-page__main" aria-label="Terms and Conditions content">

--- a/frontend/src/features/legal/TermsAndConditionsPage.tsx
+++ b/frontend/src/features/legal/TermsAndConditionsPage.tsx
@@ -8,45 +8,33 @@ import { useIsPhoneLayout } from "../auth/hooks/useIsPhoneLayout";
 import LandingHeader from "../landing/components/LandingHeader";
 import "./TermsAndConditionsPage.css";
 
-const TERMS_AND_CONDITIONS_TEXT = `These Terms and Conditions ("Terms") govern the use of services provided by Camera Operating Systems Limited ("the Company", "we", "us", "our"). By accessing or using the services, the customer ("Customer", "you") agrees to these Terms.
+const TERMS_PARAGRAPHS_BEFORE_RESPONSIBILITIES = [
+  "These Terms and Conditions (\"Terms\") govern the use of services provided by Camera Operating Systems Limited (\"the Company\", \"we\", \"us\", \"our\"). By accessing or using the services, the customer (\"Customer\", \"you\") agrees to these Terms.",
+  "The Company provides automated video analytics services using video data supplied by the Customer. The services generate aggregated insights such as footfall, occupancy, and traffic patterns.",
+] as const;
 
-The Company provides automated video analytics services using video data supplied by the Customer. The services generate aggregated insights such as footfall, occupancy, and traffic patterns.
+const TERMS_RESPONSIBILITIES = [
+  "Operating camera systems lawfully",
+  "Ensuring a valid lawful basis for processing personal data",
+  "Providing appropriate notices to individuals where required",
+  "Ensuring that video data supplied to the Company complies with applicable law",
+] as const;
 
-The Customer is responsible for:
-
-Operating camera systems lawfully
-
-Ensuring a valid lawful basis for processing personal data
-
-Providing appropriate notices to individuals where required
-
-Ensuring that video data supplied to the Company complies with applicable law
-
-The Company processes personal data on behalf of the Customer as a data processor under the UK GDPR. Processing is carried out solely to provide the services and in accordance with the Customer’s instructions.
-
-The Company does not identify individuals and does not perform facial recognition or biometric identification.
-
-The Company may generate anonymised and aggregated data derived from service usage. Such data does not identify individuals and may be used by the Company for analytics, service improvement, and commercial purposes.
-
-The services are provided on an "as is" and "as available" basis. The Company does not guarantee uninterrupted, secure, or error-free operation of the services.
-
-The core analytics service is provided free of charge unless otherwise agreed. The Company reserves the right to introduce paid features or services in the future.
-
-The Customer must not use the services in any way that is unlawful, infringes the rights of others, or interferes with the operation of the services.
-
-All intellectual property rights in the services remain the property of the Company. The Customer is granted a limited, non-exclusive, non-transferable right to use the services.
-
-To the fullest extent permitted by law, the Company shall not be liable for any indirect, incidental, or consequential loss, including loss of profits, revenue, or business opportunities.
-
-The Company’s total liability arising out of or in connection with the services shall not exceed £1,000.
-
-The Customer may stop using the services at any time. The Company may suspend or terminate access where necessary to protect the services, comply with law, or address misuse.
-
-The Company may update the services or these Terms from time to time. Continued use of the services constitutes acceptance of the updated Terms.
-
-These Terms are governed by the laws of England and Wales. Any disputes shall be subject to the jurisdiction of the courts of England and Wales.
-
-Enquiries may be sent to compliance@camos.app.`;
+const TERMS_PARAGRAPHS_AFTER_RESPONSIBILITIES = [
+  "The Company processes personal data on behalf of the Customer as a data processor under the UK GDPR. Processing is carried out solely to provide the services and in accordance with the Customer’s instructions.",
+  "The Company does not identify individuals and does not perform facial recognition or biometric identification.",
+  "The Company may generate anonymised and aggregated data derived from service usage. Such data does not identify individuals and may be used by the Company for analytics, service improvement, and commercial purposes.",
+  "The services are provided on an \"as is\" and \"as available\" basis. The Company does not guarantee uninterrupted, secure, or error-free operation of the services.",
+  "The core analytics service is provided free of charge unless otherwise agreed. The Company reserves the right to introduce paid features or services in the future.",
+  "The Customer must not use the services in any way that is unlawful, infringes the rights of others, or interferes with the operation of the services.",
+  "All intellectual property rights in the services remain the property of the Company. The Customer is granted a limited, non-exclusive, non-transferable right to use the services.",
+  "To the fullest extent permitted by law, the Company shall not be liable for any indirect, incidental, or consequential loss, including loss of profits, revenue, or business opportunities.",
+  "The Company’s total liability arising out of or in connection with the services shall not exceed £1,000.",
+  "The Customer may stop using the services at any time. The Company may suspend or terminate access where necessary to protect the services, comply with law, or address misuse.",
+  "The Company may update the services or these Terms from time to time. Continued use of the services constitutes acceptance of the updated Terms.",
+  "These Terms are governed by the laws of England and Wales. Any disputes shall be subject to the jurisdiction of the courts of England and Wales.",
+  "Enquiries may be sent to compliance@camos.app.",
+] as const;
 
 const TermsAndConditionsPage: React.FC = () => {
   const navigate = useNavigate();
@@ -75,13 +63,29 @@ const TermsAndConditionsPage: React.FC = () => {
 
       <main className="terms-page__main" aria-label="Terms and Conditions content">
         <section className="terms-page__document">
-          <button type="button" className="terms-page__back" onClick={handleGoBack}>
+          <button type="button" className="terms-page__back-link" onClick={handleGoBack}>
             <ArrowLeft size={18} aria-hidden="true" />
             <span>Go back</span>
           </button>
 
           <h1 className="terms-page__title">Terms and Conditions</h1>
-          <p className="terms-page__body">{TERMS_AND_CONDITIONS_TEXT}</p>
+          <div className="terms-page__body">
+            {TERMS_PARAGRAPHS_BEFORE_RESPONSIBILITIES.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+
+            <p>The Customer is responsible for:</p>
+            <ul className="terms-page__list">
+              {TERMS_RESPONSIBILITIES.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+
+            {TERMS_PARAGRAPHS_AFTER_RESPONSIBILITIES.map((paragraph) => (
+              <p key={paragraph}>{paragraph}</p>
+            ))}
+          </div>
+          <p className="terms-page__meta">Last updated: 01 April 2026</p>
         </section>
       </main>
 

--- a/frontend/src/pages/PrivacyPolicyPage.tsx
+++ b/frontend/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,3 @@
+import PrivacyPolicyPage from "../features/legal/PrivacyPolicyPage";
+
+export default PrivacyPolicyPage;

--- a/frontend/src/pages/SubProcessorRegisterPage.tsx
+++ b/frontend/src/pages/SubProcessorRegisterPage.tsx
@@ -1,0 +1,3 @@
+import SubProcessorRegisterPage from "../features/legal/SubProcessorRegisterPage";
+
+export default SubProcessorRegisterPage;

--- a/frontend/src/pages/TermsAndConditionsPage.tsx
+++ b/frontend/src/pages/TermsAndConditionsPage.tsx
@@ -1,0 +1,3 @@
+import TermsAndConditionsPage from "../features/legal/TermsAndConditionsPage";
+
+export default TermsAndConditionsPage;

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -30,15 +30,6 @@ body {
   background:
     radial-gradient(1200px 520px at 50% -140px, color-mix(in srgb, white 84%, #e8edf3 16%) 0%, color-mix(in srgb, white 94%, #e9edf2 6%) 58%, color-mix(in srgb, white 98%, #f0f3f6 2%) 100%),
     linear-gradient(180deg, color-mix(in srgb, white 97%, #edf1f5 3%), color-mix(in srgb, white 95%, #e7edf3 5%));
-  --landing-gold: #eccf82;
-  --landing-gold-strong: #ddb55a;
-  --landing-gold-edge: #9b7420;
-  --cta-create-bg: linear-gradient(180deg, color-mix(in srgb, var(--landing-gold) 86%, #f9e8bd 14%), color-mix(in srgb, var(--landing-gold-strong) 84%, #e8c774 16%));
-  --cta-create-bg-hover: linear-gradient(180deg, color-mix(in srgb, var(--landing-gold) 78%, #f9ebc8 22%), color-mix(in srgb, var(--landing-gold-strong) 82%, #e3c16a 18%));
-  --cta-create-text: color-mix(in srgb, #44340f 84%, #000 16%);
-  --cta-secondary-bg: linear-gradient(180deg, color-mix(in srgb, #dce4ec 56%, white 44%), color-mix(in srgb, #c5d0dc 64%, white 36%));
-  --cta-secondary-bg-hover: linear-gradient(180deg, color-mix(in srgb, #e2e9f0 62%, white 38%), color-mix(in srgb, #cad4df 68%, white 32%));
-  --cta-secondary-text: color-mix(in srgb, #1e2732 88%, #000 12%);
   --cta-radius: var(--sys-radius-sm);
   --cta-height: 40px;
   --cta-padding-x: 14px;

--- a/frontend/src/styles/LandingPage.css
+++ b/frontend/src/styles/LandingPage.css
@@ -24,10 +24,6 @@ body {
   color: var(--sys-text-1);
 }
 
-body.landing-mobile-drawer-lock {
-  overflow: hidden;
-}
-
 
 .landing-page {
   min-height: 100vh;
@@ -1523,77 +1519,6 @@ body.landing-mobile-drawer-lock {
     margin: 4px 0 0;
     font-size: 0.82rem;
     color: var(--sys-text-3);
-  }
-
-  .landing-mobile-drawer-backdrop {
-    position: fixed;
-    inset: 0;
-    border: none;
-    background: rgba(15, 20, 27, 0.36);
-  }
-
-  .landing-mobile-drawer {
-    position: fixed;
-    top: 0;
-    right: 0;
-    width: min(320px, calc(100% - 34px));
-    height: 100svh;
-    display: flex;
-    flex-direction: column;
-    background: color-mix(in srgb, var(--surface-page) 95%, white 5%);
-    border-left: 1px solid color-mix(in srgb, var(--sys-line) 38%, white 36%);
-    box-shadow: -8px 0 18px rgba(22, 30, 41, 0.14);
-    transform: translateX(105%);
-    transition: transform 180ms ease;
-    z-index: 45;
-    padding: 12px 14px 16px;
-  }
-
-  .landing-mobile-drawer.is-open {
-    transform: translateX(0);
-  }
-
-  .landing-mobile-drawer-head {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    margin-bottom: 10px;
-  }
-
-  .landing-mobile-drawer-head button {
-    border: none;
-    background: transparent;
-    font-size: 1.45rem;
-    line-height: 1;
-    color: var(--sys-text-2);
-    padding: 2px 6px;
-  }
-
-  .landing-mobile-drawer-list {
-    display: grid;
-    gap: 4px;
-  }
-
-  .landing-mobile-drawer-list button {
-    min-height: 40px;
-    border: none;
-    border-radius: 8px;
-    text-align: left;
-    padding: 0 8px;
-    color: var(--sys-text-1);
-    background: transparent;
-    font-weight: 520;
-  }
-
-  .landing-mobile-drawer-list button:hover,
-  .landing-mobile-drawer-list button:focus-visible {
-    background: color-mix(in srgb, var(--surface-panel) 35%, transparent);
-    outline: none;
-  }
-
-  .landing-mobile-drawer-list--footer {
-    margin-top: auto;
-    padding-top: 10px;
   }
 
   .landing-spec-sheet {

--- a/frontend/src/styles/VRMTheme.css
+++ b/frontend/src/styles/VRMTheme.css
@@ -133,16 +133,58 @@ body,
   border: 1px solid var(--line-soft);
 }
 
+.vrm-btn {
+  border: none;
+  border-radius: var(--sys-radius-sm);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.52);
+}
+
 .vrm-btn-primary {
-  background: color-mix(in srgb, var(--signal-gold) 92%, white 8%) !important;
-  border-color: color-mix(in srgb, var(--signal-gold) 58%, #5d4611 42%) !important;
-  color: #17130a !important;
+  color: color-mix(in srgb, #44340f 84%, #000 16%) !important;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--signal-gold) 86%, #f9e8bd 14%),
+    color-mix(in srgb, var(--signal-gold-strong) 84%, #e8c774 16%)
+  ) !important;
+  border: none !important;
+  box-shadow: 0 3px 10px rgba(62, 56, 34, 0.17), 0 1px 1px rgba(62, 56, 34, 0.08),
+    inset 0 8px 14px rgba(255, 246, 221, 0.22) !important;
 }
 
 .vrm-btn-primary:hover,
 .vrm-btn-primary:focus-visible {
-  background: color-mix(in srgb, var(--signal-gold-strong) 88%, white 12%) !important;
-  border-color: color-mix(in srgb, var(--signal-gold-strong) 72%, #4d390d 28%) !important;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--signal-gold) 78%, #f9ebc8 22%),
+    color-mix(in srgb, var(--signal-gold-strong) 82%, #e3c16a 18%)
+  ) !important;
+  border: none !important;
+  box-shadow: 0 5px 13px rgba(62, 56, 34, 0.2), 0 1px 1px rgba(62, 56, 34, 0.1),
+    inset 0 9px 16px rgba(255, 248, 228, 0.24) !important;
+}
+
+.vrm-btn-secondary {
+  color: color-mix(in srgb, #1e2732 88%, #000 12%) !important;
+  border: none !important;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, #dce4ec 56%, white 44%),
+    color-mix(in srgb, #c5d0dc 64%, white 36%)
+  ) !important;
+  box-shadow: 0 3px 9px rgba(52, 61, 74, 0.12), 0 1px 1px rgba(52, 61, 74, 0.08),
+    inset 0 8px 12px rgba(255, 255, 255, 0.28) !important;
+}
+
+.vrm-btn-secondary:hover,
+.vrm-btn-secondary:focus-visible {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, #e2e9f0 62%, white 38%),
+    color-mix(in srgb, #cad4df 68%, white 32%)
+  ) !important;
+  border: none !important;
+  box-shadow: 0 5px 14px rgba(52, 61, 74, 0.16), 0 1px 1px rgba(52, 61, 74, 0.1),
+    inset 0 9px 14px rgba(255, 255, 255, 0.3) !important;
 }
 
 .vrm-btn:disabled,
@@ -151,8 +193,9 @@ body,
 .vrm-btn-sm:disabled {
   opacity: 0.48;
   cursor: not-allowed;
-  border-color: color-mix(in srgb, var(--line-soft) 78%, transparent) !important;
+  border: none !important;
   background: color-mix(in srgb, var(--surface-panel) 65%, white 35%) !important;
+  box-shadow: none !important;
   color: color-mix(in srgb, var(--text-muted) 82%, transparent) !important;
 }
 

--- a/frontend/src/styles/VRMTheme.css
+++ b/frontend/src/styles/VRMTheme.css
@@ -62,6 +62,30 @@
   --text-muted: #5e6876;
   --signal-gold: var(--cam-gold-0);
   --signal-gold-strong: var(--cam-gold-1);
+  --landing-gold: #eccf82;
+  --landing-gold-strong: #ddb55a;
+  --cta-create-bg: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--landing-gold) 86%, #f9e8bd 14%),
+    color-mix(in srgb, var(--landing-gold-strong) 84%, #e8c774 16%)
+  );
+  --cta-create-bg-hover: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--landing-gold) 78%, #f9ebc8 22%),
+    color-mix(in srgb, var(--landing-gold-strong) 82%, #e3c16a 18%)
+  );
+  --cta-create-text: color-mix(in srgb, #44340f 84%, #000 16%);
+  --cta-secondary-bg: linear-gradient(
+    180deg,
+    color-mix(in srgb, #dce4ec 56%, white 44%),
+    color-mix(in srgb, #c5d0dc 64%, white 36%)
+  );
+  --cta-secondary-bg-hover: linear-gradient(
+    180deg,
+    color-mix(in srgb, #e2e9f0 62%, white 38%),
+    color-mix(in srgb, #cad4df 68%, white 32%)
+  );
+  --cta-secondary-text: color-mix(in srgb, #1e2732 88%, #000 12%);
 
   --chart-signal: var(--signal-gold);
   --chart-series-2: #58626e;
@@ -140,12 +164,8 @@ body,
 }
 
 .vrm-btn-primary {
-  color: color-mix(in srgb, #44340f 84%, #000 16%) !important;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--signal-gold) 86%, #f9e8bd 14%),
-    color-mix(in srgb, var(--signal-gold-strong) 84%, #e8c774 16%)
-  ) !important;
+  color: var(--cta-create-text) !important;
+  background: var(--cta-create-bg) !important;
   border: none !important;
   box-shadow: 0 3px 10px rgba(62, 56, 34, 0.17), 0 1px 1px rgba(62, 56, 34, 0.08),
     inset 0 8px 14px rgba(255, 246, 221, 0.22) !important;
@@ -153,35 +173,23 @@ body,
 
 .vrm-btn-primary:hover,
 .vrm-btn-primary:focus-visible {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, var(--signal-gold) 78%, #f9ebc8 22%),
-    color-mix(in srgb, var(--signal-gold-strong) 82%, #e3c16a 18%)
-  ) !important;
+  background: var(--cta-create-bg-hover) !important;
   border: none !important;
   box-shadow: 0 5px 13px rgba(62, 56, 34, 0.2), 0 1px 1px rgba(62, 56, 34, 0.1),
     inset 0 9px 16px rgba(255, 248, 228, 0.24) !important;
 }
 
 .vrm-btn-secondary {
-  color: color-mix(in srgb, #1e2732 88%, #000 12%) !important;
+  color: var(--cta-secondary-text) !important;
   border: none !important;
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, #dce4ec 56%, white 44%),
-    color-mix(in srgb, #c5d0dc 64%, white 36%)
-  ) !important;
+  background: var(--cta-secondary-bg) !important;
   box-shadow: 0 3px 9px rgba(52, 61, 74, 0.12), 0 1px 1px rgba(52, 61, 74, 0.08),
     inset 0 8px 12px rgba(255, 255, 255, 0.28) !important;
 }
 
 .vrm-btn-secondary:hover,
 .vrm-btn-secondary:focus-visible {
-  background: linear-gradient(
-    180deg,
-    color-mix(in srgb, #e2e9f0 62%, white 38%),
-    color-mix(in srgb, #cad4df 68%, white 32%)
-  ) !important;
+  background: var(--cta-secondary-bg-hover) !important;
   border: none !important;
   box-shadow: 0 5px 14px rgba(52, 61, 74, 0.16), 0 1px 1px rgba(52, 61, 74, 0.1),
     inset 0 9px 14px rgba(255, 255, 255, 0.3) !important;
@@ -208,8 +216,7 @@ body,
   color: var(--text-strong) !important;
 }
 
-.vrm-btn:hover,
-.vrm-btn-secondary:hover,
+.vrm-btn:not(.vrm-btn-primary):not(.vrm-btn-secondary):hover,
 .vrm-nav-item:hover {
   background: color-mix(in srgb, var(--surface-panel) 70%, white 30%);
 }


### PR DESCRIPTION
### Motivation
- Provide a dedicated Terms and Conditions page so users can read legal terms separately from the landing footer content.
- Surface the terms link in both desktop footer and mobile quick actions to improve discoverability and compliance.

### Description
- Added a new legal feature page at `features/legal/TermsAndConditionsPage.tsx` that renders static T&C text, plus a thin wrapper export at `pages/TermsAndConditionsPage.tsx` and styling in `features/legal/TermsAndConditionsPage.css`.
- Registered the route `"/terms-and-conditions"` and lazy-loaded `TermsAndConditionsPage` in `frontend/src/app/routes.tsx` so unauthenticated users can access it.
- Updated the landing components to navigate to the new route: `features/landing/LandingPage.tsx` mobile quick actions now use `navigate("/terms-and-conditions")`, and `features/landing/components/LandingFooter.tsx` footer buttons (desktop and mobile) call `navigate("/terms-and-conditions")`.

### Testing
- Ran a full frontend build with `yarn build` which completed successfully.
- Executed the test suite with `yarn test` and unit tests passed.
- Ran linter/typecheck with `yarn lint`/`yarn tsc` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cd80b9c6c4833295b958f346ec5890)