### PR TITLE
Support demo-local SQLite snapshots and event search; normalize snapshot payloads (frontend + backend)

### DIFF
--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -15,6 +15,9 @@ from backend.app.analytics.org_config import (
     resolve_table_for_org,
 )
 from backend.app.services.auth_context import authenticate_chart_data_request
+from backend.app.services.demo_session import resolve_demo_org_id
+from backend.app.services.local_data import combined_logs_db, ensure_local_db_exists, LocalDataError
+from backend.app.local_logs import search_events_from_sqlite
 from backend.app.services.bigquery_client import BigQueryDataFrameError, bigquery_client
 from backend.app.services.time_bounds import resolve_time_bounds
 
@@ -130,13 +133,34 @@ async def search_events(
     per_page: int = 20,
     view_token: Optional[str] = None,
     client_id: Optional[str] = None,
+    site_view: Optional[str] = None,
 ):
     """Search BigQuery event logs with pagination."""
     try:
         org_id = authenticate_chart_data_request(request, view_token, client_id)
-        table_name = _resolve_table_for_org(org_id)
+        is_demo_request = resolve_demo_org_id(request) is not None
 
         logger.debug("Event search params: %s", dict(request.query_params))
+
+        if is_demo_request:
+            local_logs = ensure_local_db_exists(combined_logs_db(), label="combined logs source")
+            bounds = resolve_time_bounds({"start_date": start_date, "end_date": end_date})
+            return search_events_from_sqlite(
+                local_logs,
+                start=bounds["start_ts"],
+                end=bounds["end_ts"],
+                event=event,
+                sex=sex,
+                age=age,
+                race=race,
+                site_id=site_id,
+                camera_id=camera_id,
+                track_id=track_id,
+                page=page,
+                per_page=per_page,
+            )
+
+        table_name = _resolve_table_for_org(org_id)
 
         base_ctx = _resolve_event_search_context(
             org_id=org_id,
@@ -230,6 +254,9 @@ async def search_events(
                 "job_id": exc.job_id,
             },
         ) from exc
+    except LocalDataError as exc:
+        logger.error("Local event search failed: %s", exc)
+        raise HTTPException(status_code=500, detail={"error": "local_logs_lookup_failed", "message": str(exc)}) from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/backend/app/api/snapshots.py
+++ b/backend/app/api/snapshots.py
@@ -13,7 +13,15 @@ from backend.app.snapshots import (
     SNAPSHOT_ORG_IDS,
     SnapshotLookupError,
     fetch_latest_snapshot,
+    fetch_latest_snapshot_from_sqlite,
     is_snapshot_org,
+)
+from backend.app.services.demo_session import resolve_demo_org_id
+from backend.app.services.local_data import (
+    LocalDataError,
+    ensure_local_db_exists,
+    resolve_site_view,
+    snapshot_db_for_site,
 )
 
 router = APIRouter(prefix="/api")
@@ -26,6 +34,7 @@ async def get_latest_snapshot(
     org: Optional[str] = Query(None, alias="org"),
     ts: Optional[str] = Query(None, alias="ts"),
     view_token: Optional[str] = Query(None, alias="viewToken"),
+    site_view: Optional[str] = Query(None, alias="siteView"),
 ):
     resolved_org = resolve_snapshot_org(org_id=org, view_token=view_token, request=request)
     if not is_snapshot_org(resolved_org):
@@ -47,9 +56,23 @@ async def get_latest_snapshot(
                 detail={"error": "invalid_timestamp", "message": "ts must be ISO-8601"},
             ) from exc
 
+    demo_org = resolve_demo_org_id(request)
+    resolved_site_view = resolve_site_view(site_view)
+
     try:
-        snapshot = fetch_latest_snapshot(resolved_org, as_of=resolved_ts)
-    except SnapshotLookupError as exc:
+        if demo_org:
+            local_db = ensure_local_db_exists(
+                snapshot_db_for_site(resolved_site_view),
+                label=f"snapshot source for {resolved_site_view}",
+            )
+            snapshot = fetch_latest_snapshot_from_sqlite(
+                local_db,
+                org_id=resolved_org,
+                as_of=resolved_ts,
+            )
+        else:
+            snapshot = fetch_latest_snapshot(resolved_org, as_of=resolved_ts)
+    except (SnapshotLookupError, LocalDataError) as exc:
         logger.error("Snapshot lookup failed for %s: %s", resolved_org, exc)
         raise HTTPException(
             status_code=500,

--- a/backend/app/local_logs.py
+++ b/backend/app/local_logs.py
@@ -1,0 +1,171 @@
+"""Local SQLite-backed event-log search helpers for demo flows."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from backend.app.services.local_data import LocalDataError
+
+
+def _normalize_optional_int(value: Optional[str]) -> Optional[int]:
+    if value is None:
+        return None
+    text = value.strip()
+    if text == "":
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _resolve_event_filter(event: Optional[str]) -> Optional[int]:
+    if not event:
+        return None
+    normalized = event.strip().lower()
+    if normalized in {"all", ""}:
+        return None
+    if normalized in {"entry", "entrance", "1"}:
+        return 1
+    if normalized in {"exit", "0"}:
+        return 0
+    return None
+
+
+def _resolve_sex_filter(sex: Optional[str]) -> Optional[int]:
+    if not sex:
+        return None
+    normalized = sex.strip().lower()
+    if normalized in {"all", ""}:
+        return None
+    if normalized in {"0", "m", "male"}:
+        return 0
+    if normalized in {"1", "f", "female"}:
+        return 1
+    return None
+
+
+def _resolve_timestamp(value: datetime) -> str:
+    utc_value = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return utc_value.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def search_events_from_sqlite(
+    db_path: Path,
+    *,
+    start: datetime,
+    end: datetime,
+    event: Optional[str],
+    sex: Optional[str],
+    age: Optional[str],
+    race: Optional[str],
+    site_id: Optional[str],
+    camera_id: Optional[str],
+    track_id: Optional[str],
+    page: int,
+    per_page: int,
+) -> Dict[str, Any]:
+    if not db_path.exists():
+        raise LocalDataError(f"Missing combined logs SQLite database at {db_path}")
+
+    where: List[str] = [
+        "datetime(replace(CAST(timestamp AS TEXT), ' UTC', '')) BETWEEN datetime(?) AND datetime(?)",
+        "datetime(replace(CAST(timestamp AS TEXT), ' UTC', '')) <= datetime('now')",
+    ]
+    params: List[Any] = [_resolve_timestamp(start), _resolve_timestamp(end)]
+
+    event_filter = _resolve_event_filter(event)
+    if event_filter is not None:
+        where.append("CAST(event AS INTEGER) = ?")
+        params.append(event_filter)
+
+    sex_filter = _resolve_sex_filter(sex)
+    if sex_filter is not None:
+        where.append("CAST(sex AS INTEGER) = ?")
+        params.append(sex_filter)
+
+    age_filter = _normalize_optional_int(age)
+    if age_filter is not None:
+        where.append("CAST(age_bucket AS INTEGER) = ?")
+        params.append(age_filter)
+
+    race_filter = _normalize_optional_int(race)
+    if race_filter is not None:
+        where.append("CAST(race AS INTEGER) = ?")
+        params.append(race_filter)
+
+    site_filter = _normalize_optional_int(site_id)
+    if site_filter is not None:
+        where.append("CAST(site_id AS INTEGER) = ?")
+        params.append(site_filter)
+
+    camera_filter = _normalize_optional_int(camera_id)
+    if camera_filter is not None:
+        where.append("CAST(cam_id AS INTEGER) = ?")
+        params.append(camera_filter)
+
+    if track_id:
+        cleaned_track = track_id.strip().lstrip("#").strip().lower()
+        if cleaned_track:
+            where.append("LOWER(CAST(track_id AS TEXT)) LIKE ?")
+            params.append(f"%{cleaned_track}%")
+
+    where_clause = " AND ".join(where)
+    count_sql = f"SELECT COUNT(*) FROM logs WHERE {where_clause}"
+    offset = max(page - 1, 0) * per_page
+
+    rows_sql = (
+        "SELECT site_id, cam_id, track_id, event, timestamp, sex, age_bucket, race "
+        "FROM logs "
+        f"WHERE {where_clause} "
+        "ORDER BY datetime(replace(CAST(timestamp AS TEXT), ' UTC', '')) DESC "
+        "LIMIT ? OFFSET ?"
+    )
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        total_count = int(conn.execute(count_sql, params).fetchone()[0])
+        if total_count == 0:
+            return {
+                "events": [],
+                "total": 0,
+                "page": page,
+                "per_page": per_page,
+                "total_pages": 0,
+            }
+
+        rows = conn.execute(rows_sql, [*params, per_page, offset]).fetchall()
+    except sqlite3.Error as exc:
+        raise LocalDataError(f"Failed querying combined logs DB {db_path}: {exc}") from exc
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    events: List[Dict[str, Any]] = []
+    for row in rows:
+        events.append(
+            {
+                "site_id": row[0],
+                "cam_id": row[1],
+                "track_number": row[2],
+                "track_id": row[2],
+                "event": "entry" if int(row[3]) == 1 else "exit",
+                "timestamp": str(row[4]),
+                "sex": row[5],
+                "age_estimate": row[6],
+                "race": row[7],
+            }
+        )
+
+    return {
+        "events": events,
+        "total": total_count,
+        "page": page,
+        "per_page": per_page,
+        "total_pages": (total_count + per_page - 1) // per_page,
+    }

--- a/backend/app/services/local_data.py
+++ b/backend/app/services/local_data.py
@@ -1,0 +1,72 @@
+"""Local SQLite source selection for migrated demo flows."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+class LocalDataError(RuntimeError):
+    """Raised when local migrated sources are missing or unreadable."""
+
+
+SiteView = str
+
+
+@dataclass(frozen=True)
+class LocalDataPaths:
+    combined_snapshots: Path
+    site_a_snapshots: Path
+    site_b_snapshots: Path
+    combined_logs: Path
+
+
+def resolve_site_view(value: Optional[str]) -> SiteView:
+    normalized = (value or "").strip().lower()
+    if normalized in {"all", "site-a", "site_b", "site-b", "sitea", "site_a", "siteb"}:
+        if normalized == "all":
+            return "all"
+        if normalized in {"site-a", "site_a", "sitea"}:
+            return "site-a"
+        return "site-b"
+    return "site-a"
+
+
+def local_data_paths() -> LocalDataPaths:
+    return LocalDataPaths(
+        combined_snapshots=Path(
+            os.getenv("LOCAL_COMBINED_SNAPSHOTS_DB", "combined_logs_snapshots.db")
+        ),
+        site_a_snapshots=Path(
+            os.getenv("LOCAL_SITE_A_SNAPSHOTS_DB", "user0_snapshots.db")
+        ),
+        site_b_snapshots=Path(
+            os.getenv("LOCAL_SITE_B_SNAPSHOTS_DB", "user1_snapshots.db")
+        ),
+        combined_logs=Path(
+            os.getenv("LOCAL_COMBINED_LOGS_DB", "combined_logs.db")
+        ),
+    )
+
+
+def snapshot_db_for_site(site_view: SiteView) -> Path:
+    paths = local_data_paths()
+    if site_view == "all":
+        return paths.combined_snapshots
+    if site_view == "site-b":
+        return paths.site_b_snapshots
+    return paths.site_a_snapshots
+
+
+def combined_logs_db() -> Path:
+    return local_data_paths().combined_logs
+
+
+def ensure_local_db_exists(path: Path, *, label: str) -> Path:
+    if not path.exists():
+        raise LocalDataError(f"Missing {label} SQLite database at {path}")
+    if not path.is_file():
+        raise LocalDataError(f"Invalid {label} SQLite database path {path}")
+    return path

--- a/backend/app/snapshots.py
+++ b/backend/app/snapshots.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -93,6 +94,62 @@ def _format_timestamp(value: Any) -> str:
         return value.isoformat()
     return str(value)
 
+
+
+
+def _sqlite_snapshot_table(conn: sqlite3.Connection) -> str:
+    candidates = [
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    ]
+    for table in candidates:
+        columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+        if columns.intersection(_TIMESTAMP_COLUMN_CANDIDATES) and columns.intersection(_PAYLOAD_COLUMN_CANDIDATES):
+            return table
+    raise SnapshotLookupError("No snapshot table with timestamp/payload columns found in SQLite DB")
+
+
+def fetch_latest_snapshot_from_sqlite(
+    db_path: Path,
+    *,
+    org_id: str,
+    as_of: Optional[datetime] = None,
+) -> Optional[SnapshotRow]:
+    normalized = _normalize_org_id(org_id)
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.Error as exc:
+        raise SnapshotLookupError(f"Failed to open local snapshot DB {db_path}: {exc}") from exc
+
+    try:
+        table_name = _sqlite_snapshot_table(conn)
+        columns = {row[1] for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()}
+        ts_column = _select_column(columns, _TIMESTAMP_COLUMN_CANDIDATES, "timestamp")
+        payload_column = _select_column(columns, _PAYLOAD_COLUMN_CANDIDATES, "payload")
+        resolved_as_of = (as_of or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M:%S")
+        query = (
+            f"SELECT {ts_column} AS ts, {payload_column} AS payload "
+            f"FROM {table_name} "
+            f"WHERE datetime(replace(CAST({ts_column} AS TEXT), ' UTC', '')) <= datetime(?) "
+            f"ORDER BY datetime(replace(CAST({ts_column} AS TEXT), ' UTC', '')) DESC "
+            "LIMIT 1"
+        )
+        row = conn.execute(query, (resolved_as_of,)).fetchone()
+        if row is None:
+            return None
+        ts_value = row[0]
+        payload_value = row[1]
+        return SnapshotRow(
+            org_id=normalized,
+            ts=_format_timestamp(ts_value),
+            payload=_coerce_payload(payload_value),
+        )
+    except sqlite3.Error as exc:
+        raise SnapshotLookupError(f"SQLite snapshot lookup failed for {db_path}: {exc}") from exc
+    finally:
+        conn.close()
 
 def fetch_latest_snapshot(org_id: str, *, as_of: Optional[datetime] = None) -> Optional[SnapshotRow]:
     normalized = _normalize_org_id(org_id)

--- a/backend/tests/test_local_data_migration.py
+++ b/backend/tests/test_local_data_migration.py
@@ -1,0 +1,117 @@
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from backend.app.local_logs import search_events_from_sqlite
+from backend.app.services.local_data import resolve_site_view, snapshot_db_for_site
+from backend.app.snapshots import fetch_latest_snapshot_from_sqlite
+
+
+class LocalDataRoutingTests(unittest.TestCase):
+    def test_resolve_site_view(self):
+        self.assertEqual(resolve_site_view("all"), "all")
+        self.assertEqual(resolve_site_view("site-a"), "site-a")
+        self.assertEqual(resolve_site_view("site_b"), "site-b")
+        self.assertEqual(resolve_site_view(None), "site-a")
+
+    def test_snapshot_db_selection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["LOCAL_COMBINED_SNAPSHOTS_DB"] = str(Path(tmpdir) / "combined_logs_snapshots.db")
+            os.environ["LOCAL_SITE_A_SNAPSHOTS_DB"] = str(Path(tmpdir) / "user0_snapshots.db")
+            os.environ["LOCAL_SITE_B_SNAPSHOTS_DB"] = str(Path(tmpdir) / "user1_snapshots.db")
+            self.assertTrue(str(snapshot_db_for_site("all")).endswith("combined_logs_snapshots.db"))
+            self.assertTrue(str(snapshot_db_for_site("site-a")).endswith("user0_snapshots.db"))
+            self.assertTrue(str(snapshot_db_for_site("site-b")).endswith("user1_snapshots.db"))
+
+
+class LocalSnapshotSQLiteTests(unittest.TestCase):
+    def test_fetch_latest_snapshot_from_sqlite(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "user0_snapshots.db"
+            conn = sqlite3.connect(str(db_path))
+            conn.execute("CREATE TABLE snapshots (ts TEXT NOT NULL, payload TEXT NOT NULL)")
+            conn.execute(
+                "INSERT INTO snapshots (ts, payload) VALUES (?, ?)",
+                (
+                    "2026-04-14 00:00:00 UTC",
+                    json.dumps([[1] * 96, [2] * 96, [3] * 96, [4] * 96, [5] * 96, [10, 20, 70], [0, 35]]),
+                ),
+            )
+            conn.execute(
+                "INSERT INTO snapshots (ts, payload) VALUES (?, ?)",
+                (
+                    "2026-04-14 00:01:00 UTC",
+                    json.dumps([[9] * 96, [8] * 96, [7] * 96, [6] * 96, [5] * 96, [33, 33, 34], [25, 40]]),
+                ),
+            )
+            conn.commit()
+            conn.close()
+
+            row = fetch_latest_snapshot_from_sqlite(
+                db_path,
+                org_id="client1",
+                as_of=datetime(2026, 4, 14, 0, 2, tzinfo=timezone.utc),
+            )
+            self.assertIsNotNone(row)
+            assert row is not None
+            self.assertEqual(row.ts, "2026-04-14 00:01:00 UTC")
+            self.assertEqual(row.payload[5], [33, 33, 34])
+            self.assertEqual(row.payload[6], [25, 40])
+
+
+class LocalLogsSQLiteTests(unittest.TestCase):
+    def test_search_events_from_sqlite_demo_combined(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_path = Path(tmpdir) / "combined_logs.db"
+            conn = sqlite3.connect(str(db_path))
+            conn.execute(
+                """
+                CREATE TABLE logs (
+                    site_id INTEGER NOT NULL,
+                    cam_id INTEGER NOT NULL,
+                    track_id TEXT NOT NULL,
+                    event INTEGER NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    sex INTEGER NOT NULL,
+                    age_bucket INTEGER NOT NULL,
+                    race INTEGER NOT NULL
+                )
+                """
+            )
+            rows = [
+                (0, 0, "t-01", 1, "2026-04-14 00:00:00 UTC", 0, 2, 1),
+                (1, 2, "t-02", 0, "2026-04-14 00:05:00 UTC", 1, 3, 2),
+                (0, 1, "xyz", 1, "2026-04-14 00:10:00 UTC", 1, 4, 0),
+            ]
+            conn.executemany(
+                "INSERT INTO logs (site_id, cam_id, track_id, event, timestamp, sex, age_bucket, race) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+            conn.commit()
+            conn.close()
+
+            result = search_events_from_sqlite(
+                db_path,
+                start=datetime(2026, 4, 14, 0, 0, tzinfo=timezone.utc),
+                end=datetime(2026, 4, 14, 1, 0, tzinfo=timezone.utc),
+                event="entry",
+                sex="female",
+                age=None,
+                race=None,
+                site_id=None,
+                camera_id=None,
+                track_id=None,
+                page=1,
+                per_page=20,
+            )
+            self.assertEqual(result["total"], 1)
+            self.assertEqual(result["events"][0]["event"], "entry")
+            self.assertEqual(result["events"][0]["track_id"], "xyz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/features/dashboard/transport/loadWidgetResult.ts
+++ b/frontend/src/features/dashboard/transport/loadWidgetResult.ts
@@ -6,6 +6,7 @@ import type { DashboardWidget, DashboardTimeRangeOption } from "../types";
 import { buildSnapshotWidgetResult } from "../utils/snapshotPayload";
 import type { SnapshotResponse } from "../../../lib/snapshots";
 import type { SiteFlowTimeframe } from "../../../lib/siteFlowTimeframe";
+import { resolveSiteViewFromLocation } from "../../../lib/siteView";
 
 export type DashboardDataMode = "authenticated" | "demo" | "view_token";
 
@@ -37,8 +38,12 @@ async function loadSnapshotPayload(options: {
   orgId?: string;
   viewToken?: string;
   dataMode: DashboardDataMode;
+  siteView?: string | null;
 }): Promise<SnapshotResponse> {
   const params = new URLSearchParams();
+  if (options.siteView) {
+    params.append("siteView", options.siteView);
+  }
   if (options.viewToken) {
     params.append("viewToken", options.viewToken);
   } else if (options.dataMode !== "demo" && options.orgId) {
@@ -71,6 +76,7 @@ export async function loadWidgetResult(
   options: LoadWidgetOptions = {},
 ): Promise<ChartResult> {
   const { signal, orgId, viewToken, dataMode = "demo" } = options;
+  const siteView = resolveSiteViewFromLocation();
   const snapshotTimeframe = options.snapshotTimeframe ?? "all_time";
   let result: ChartResult;
 
@@ -86,6 +92,7 @@ export async function loadWidgetResult(
       orgId,
       viewToken,
       dataMode,
+      siteView,
     });
     result = buildSnapshotWidgetResult(widget.id, snapshot, snapshotTimeframe);
   } catch (error) {

--- a/frontend/src/features/dashboard/utils/snapshotPayload.ts
+++ b/frontend/src/features/dashboard/utils/snapshotPayload.ts
@@ -7,11 +7,13 @@ import type { SnapshotResponse } from "../../../lib/snapshots";
 import { buildSiteFlowBucketLabels } from "../../../lib/siteFlowBuckets";
 import type { SiteFlowTimeframe } from "../../../lib/siteFlowTimeframe";
 import { VRM_KPI_IDS, VRM_KPI_TITLES } from "./applyVRMOverrides";
+
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const NAIVE_TIMESTAMP_REGEX =
   /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(\.\d+)?$/;
-const ROLLUP_INDEX: Record<SiteFlowTimeframe, number> = {
+
+const LEGACY_ROLLUP_INDEX: Record<SiteFlowTimeframe, number> = {
   today: 0,
   yesterday: 1,
   last_week: 2,
@@ -20,21 +22,67 @@ const ROLLUP_INDEX: Record<SiteFlowTimeframe, number> = {
   last_year: 5,
   all_time: 6,
 };
+
+const TARGET_ROLLUP_SLOT: Record<SiteFlowTimeframe, number> = {
+  today: 7,
+  yesterday: 8,
+  last_week: 9,
+  last_month: 10,
+  last_quarter: 11,
+  last_year: 12,
+  all_time: 13,
+};
+
+interface NormalizedRollup {
+  entrances: number[];
+  exits: number[];
+  occupancyAvg: number[];
+  occupancyMin: number[];
+  occupancyMax: number[];
+  agePct: number[];
+  sexPct: number[];
+  racePct: number[];
+}
+
+interface NormalizedSnapshotPayload {
+  entrances96: number[];
+  occupancy96: number[];
+  exits96: number[];
+  footfall96: number[];
+  dwell96: number[];
+  trafficSplit: number[];
+  capacity: number[];
+  rollups: Record<SiteFlowTimeframe, NormalizedRollup>;
+}
+
+const EMPTY_ROLLUP: NormalizedRollup = {
+  entrances: [],
+  exits: [],
+  occupancyAvg: [],
+  occupancyMin: [],
+  occupancyMax: [],
+  agePct: [],
+  sexPct: [],
+  racePct: [],
+};
+
 const asNumberArray = (value: unknown): number[] =>
   Array.isArray(value)
     ? value.map((item) => (typeof item === "number" ? item : 0))
     : [];
-const getKpiSeries = (payload: unknown[], index: number): number[] =>
-  asNumberArray(Array.isArray(payload) ? payload[index] : []);
+
 const toIso = (value: Date): string => value.toISOString();
+
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value));
+
 const parseSnapshotTimestamp = (value: string): Date => {
   if (NAIVE_TIMESTAMP_REGEX.test(value)) {
     return new Date(`${value.replace(" ", "T")}Z`);
   }
   return new Date(value);
 };
+
 const buildTimeSeriesPoints = (
   values: number[],
   end: Date,
@@ -45,12 +93,14 @@ const buildTimeSeriesPoints = (
     y: value,
     value,
   }));
+
 const floorToQuarterHour = (value: Date): Date => {
   const timestamp = value.getTime();
   const floored =
     Math.floor(timestamp / FIFTEEN_MINUTES_MS) * FIFTEEN_MINUTES_MS;
   return new Date(floored);
 };
+
 const normalizeSeriesLength = (values: number[], count: number): number[] => {
   const sliced = values.slice(0, count);
   if (sliced.length >= count) {
@@ -58,6 +108,7 @@ const normalizeSeriesLength = (values: number[], count: number): number[] => {
   }
   return [...sliced, ...Array.from({ length: count - sliced.length }, () => 0)];
 };
+
 const normalizeKpiSeriesLength = (values: number[], count: number): number[] => {
   const sliced = values.slice(0, count);
   if (sliced.length >= count) {
@@ -68,6 +119,7 @@ const normalizeKpiSeriesLength = (values: number[], count: number): number[] => 
     ...sliced,
   ];
 };
+
 const buildKpiResult = (
   values: number[],
   snapshotTs: Date,
@@ -110,26 +162,37 @@ const buildKpiResult = (
     },
   };
 };
+
+const resolveTrafficLabels = (count: number): string[] => {
+  if (count === 2) {
+    return ["Site A", "Site B"];
+  }
+  if (count === 3) {
+    return ["Camera 0", "Camera 1", "Camera 2"];
+  }
+  return Array.from({ length: count }, (_, index) => `Segment ${index + 1}`);
+};
+
 const buildTrafficResult = (values: number[]): ChartResult => {
-  const labels = ["Camera 0", "Camera 1", "Camera 2"];
-  const normalized = Array.from({ length: 3 }, (_, index) =>
-    typeof values[index] === "number" ? values[index] : 0,
+  const labels = resolveTrafficLabels(values.length);
+  const normalized = values.map((value) =>
+    typeof value === "number" && Number.isFinite(value) ? value : 0,
   );
   const data = normalized.map((value, index) => ({
-    x: labels[index] ?? `Camera ${index + 1}`,
+    x: labels[index] ?? `Segment ${index + 1}`,
     y: value,
     value,
   }));
   const series: ChartSeries = {
     id: "traffic_share",
-    label: "Traffic by Camera",
+    label: values.length === 2 ? "Traffic by Site" : "Traffic by Camera",
     geometry: "bar",
     unit: "percentage",
     data,
   };
   return {
     chartType: "categorical",
-    xDimension: { id: "camera", type: "category" },
+    xDimension: { id: "traffic_segment", type: "category" },
     series: [series],
     meta: {
       timezone: "UTC",
@@ -143,6 +206,7 @@ const buildTrafficResult = (values: number[]): ChartResult => {
     },
   };
 };
+
 const buildCapacityResult = (values: number[]): ChartResult => {
   const [currentRaw = 0, peakRaw = 0] = values;
   const currentPct = clamp(currentRaw, 0, 100);
@@ -177,26 +241,29 @@ const buildCapacityResult = (values: number[]): ChartResult => {
     },
   };
 };
+
 const buildSiteFlowResult = (
-  rollup: unknown[],
+  rollup: NormalizedRollup,
   snapshotTs: Date,
   timeframe: SiteFlowTimeframe,
 ): ChartResult => {
-  const entrances = asNumberArray(rollup?.[0]);
-  const exits = asNumberArray(rollup?.[1]);
-  const occupancyAvg = asNumberArray(rollup?.[2]);
-  const occupancyMin = asNumberArray(rollup?.[3]);
-  const occupancyMax = asNumberArray(rollup?.[4]);
   const { bucket, timestamps, sliceCount } = buildSiteFlowBucketLabels(
     timeframe,
     snapshotTs,
-    [entrances, exits, occupancyAvg, occupancyMin, occupancyMax],
+    [
+      rollup.entrances,
+      rollup.exits,
+      rollup.occupancyAvg,
+      rollup.occupancyMin,
+      rollup.occupancyMax,
+    ],
   );
-  const normalizedEntrances = normalizeSeriesLength(entrances, sliceCount);
-  const normalizedExits = normalizeSeriesLength(exits, sliceCount);
-  const normalizedOccAvg = normalizeSeriesLength(occupancyAvg, sliceCount);
-  const normalizedOccMin = normalizeSeriesLength(occupancyMin, sliceCount);
-  const normalizedOccMax = normalizeSeriesLength(occupancyMax, sliceCount);
+  const normalizedEntrances = normalizeSeriesLength(rollup.entrances, sliceCount);
+  const normalizedExits = normalizeSeriesLength(rollup.exits, sliceCount);
+  const normalizedOccAvg = normalizeSeriesLength(rollup.occupancyAvg, sliceCount);
+  const normalizedOccMin = normalizeSeriesLength(rollup.occupancyMin, sliceCount);
+  const normalizedOccMax = normalizeSeriesLength(rollup.occupancyMax, sliceCount);
+
   const buildSeries = (id: string, values: number[]): ChartSeries => ({
     id,
     label: id,
@@ -207,6 +274,7 @@ const buildSiteFlowResult = (
       value: values[index] ?? 0,
     })),
   });
+
   const occupancySeries: ChartSeries = {
     id: "occupancy",
     label: "Occupancy",
@@ -220,6 +288,7 @@ const buildSiteFlowResult = (
       y: normalizedOccAvg[index] ?? null,
     })),
   };
+
   return {
     chartType: "composed_time",
     xDimension: { id: "timestamp", type: "time", bucket, timezone: "UTC" },
@@ -238,6 +307,7 @@ const buildSiteFlowResult = (
     },
   };
 };
+
 const buildDemographicResult = (
   values: number[],
   kind: "age" | "gender" | "race",
@@ -258,6 +328,97 @@ const buildDemographicResult = (
   ],
   meta: { timezone: "UTC", summary: { title: kind } },
 });
+
+const isLegacyPayload = (payload: unknown[]): boolean => {
+  const rollups = payload[7];
+  return (
+    Array.isArray(rollups) &&
+    rollups.length > 0 &&
+    Array.isArray(rollups[0]) &&
+    !Array.isArray(payload[8])
+  );
+};
+
+const normalizeLegacyRollup = (rawRollup: unknown[]): NormalizedRollup => ({
+  entrances: asNumberArray(rawRollup?.[0]),
+  exits: asNumberArray(rawRollup?.[1]),
+  occupancyAvg: asNumberArray(rawRollup?.[2]),
+  occupancyMin: asNumberArray(rawRollup?.[3]),
+  occupancyMax: asNumberArray(rawRollup?.[4]),
+  agePct: asNumberArray(rawRollup?.[5]),
+  sexPct: asNumberArray(rawRollup?.[6]),
+  racePct: asNumberArray(rawRollup?.[7]),
+});
+
+const normalizeTargetRollup = (rawRollup: unknown[]): NormalizedRollup => {
+  const occupancyTriplets = Array.isArray(rawRollup?.[1])
+    ? (rawRollup[1] as unknown[])
+    : [];
+
+  return {
+    entrances: asNumberArray(rawRollup?.[0]),
+    exits: asNumberArray(rawRollup?.[2]),
+    occupancyAvg: occupancyTriplets.map((bucket) =>
+      Array.isArray(bucket) && typeof bucket[0] === "number" ? bucket[0] : 0,
+    ),
+    occupancyMin: occupancyTriplets.map((bucket) =>
+      Array.isArray(bucket) && typeof bucket[1] === "number" ? bucket[1] : 0,
+    ),
+    occupancyMax: occupancyTriplets.map((bucket) =>
+      Array.isArray(bucket) && typeof bucket[2] === "number" ? bucket[2] : 0,
+    ),
+    agePct: asNumberArray(rawRollup?.[3]),
+    sexPct: asNumberArray(rawRollup?.[4]),
+    racePct: asNumberArray(rawRollup?.[5]),
+  };
+};
+
+const normalizePayload = (payload: unknown[]): NormalizedSnapshotPayload => {
+  const rollups: Record<SiteFlowTimeframe, NormalizedRollup> = {
+    today: EMPTY_ROLLUP,
+    yesterday: EMPTY_ROLLUP,
+    last_week: EMPTY_ROLLUP,
+    last_month: EMPTY_ROLLUP,
+    last_quarter: EMPTY_ROLLUP,
+    last_year: EMPTY_ROLLUP,
+    all_time: EMPTY_ROLLUP,
+  };
+
+  const legacy = isLegacyPayload(payload);
+
+  (Object.keys(TARGET_ROLLUP_SLOT) as SiteFlowTimeframe[]).forEach((timeframe) => {
+    if (legacy) {
+      const bundle = Array.isArray(payload[7]) ? (payload[7] as unknown[]) : [];
+      const raw = Array.isArray(bundle[LEGACY_ROLLUP_INDEX[timeframe]])
+        ? (bundle[LEGACY_ROLLUP_INDEX[timeframe]] as unknown[])
+        : [];
+      rollups[timeframe] = normalizeLegacyRollup(raw);
+      return;
+    }
+    const slot = TARGET_ROLLUP_SLOT[timeframe];
+    const raw = Array.isArray(payload[slot]) ? (payload[slot] as unknown[]) : [];
+    rollups[timeframe] = normalizeTargetRollup(raw);
+  });
+
+  const trafficSplit = legacy
+    ? asNumberArray(payload[6])
+    : asNumberArray(payload[5]);
+  const capacity = legacy
+    ? asNumberArray(payload[5])
+    : asNumberArray(payload[6]);
+
+  return {
+    entrances96: asNumberArray(payload[0]),
+    occupancy96: asNumberArray(payload[1]),
+    exits96: asNumberArray(payload[2]),
+    footfall96: asNumberArray(payload[3]),
+    dwell96: asNumberArray(payload[4]),
+    trafficSplit,
+    capacity,
+    rollups,
+  };
+};
+
 export const buildSnapshotWidgetResult = (
   widgetId: string,
   snapshot: SnapshotResponse,
@@ -268,63 +429,34 @@ export const buildSnapshotWidgetResult = (
   if (!Array.isArray(payload)) {
     throw new Error("Snapshot payload is not an array");
   }
-  if (!Array.isArray(payload[7])) {
-    throw new Error(
-      "Snapshot payload missing legacy rollup array at payload[7]",
-    );
-  }
+
+  const normalized = normalizePayload(payload);
+  const selectedRollup = normalized.rollups[timeframe] ?? EMPTY_ROLLUP;
+
   switch (widgetId) {
-    case VRM_KPI_IDS.entrances: {
-      const series = getKpiSeries(payload, 0);
-      return buildKpiResult(series, snapshotTs, widgetId);
-    }
+    case VRM_KPI_IDS.entrances:
+      return buildKpiResult(normalized.entrances96, snapshotTs, widgetId);
     case VRM_KPI_IDS.occupancy:
-      return buildKpiResult(getKpiSeries(payload, 1), snapshotTs, widgetId);
-    case VRM_KPI_IDS.exits: {
-      const series = getKpiSeries(payload, 2);
-      return buildKpiResult(series, snapshotTs, widgetId);
-    }
+      return buildKpiResult(normalized.occupancy96, snapshotTs, widgetId);
+    case VRM_KPI_IDS.exits:
+      return buildKpiResult(normalized.exits96, snapshotTs, widgetId);
     case VRM_KPI_IDS.footfall:
-      return buildKpiResult(getKpiSeries(payload, 3), snapshotTs, widgetId);
+      return buildKpiResult(normalized.footfall96, snapshotTs, widgetId);
     case VRM_KPI_IDS.dwell:
-      return buildKpiResult(getKpiSeries(payload, 4), snapshotTs, widgetId);
+      return buildKpiResult(normalized.dwell96, snapshotTs, widgetId);
     case VRM_KPI_IDS.capacity:
-      return buildCapacityResult(asNumberArray(payload[5]));
+      return buildCapacityResult(normalized.capacity);
     case VRM_KPI_IDS.traffic:
-      return buildTrafficResult(asNumberArray(payload[6]));
+      return buildTrafficResult(normalized.trafficSplit);
     case "live-flow":
-    case "site-flow": {
-      const rollups = payload[7];
-      const rollupIndex = ROLLUP_INDEX[timeframe];
-      const rollup = Array.isArray(rollups)
-        ? (rollups[rollupIndex] as unknown[])
-        : [];
-      return buildSiteFlowResult(rollup ?? [], snapshotTs, timeframe);
-    }
-    case "site-flow-demographics-age": {
-      const rollups = payload[7];
-      const rollupIndex = ROLLUP_INDEX[timeframe];
-      const rollup = Array.isArray(rollups)
-        ? (rollups[rollupIndex] as unknown[])
-        : [];
-      return buildDemographicResult(asNumberArray(rollup?.[5]), "age");
-    }
-    case "site-flow-demographics-gender": {
-      const rollups = payload[7];
-      const rollupIndex = ROLLUP_INDEX[timeframe];
-      const rollup = Array.isArray(rollups)
-        ? (rollups[rollupIndex] as unknown[])
-        : [];
-      return buildDemographicResult(asNumberArray(rollup?.[6]), "gender");
-    }
-    case "site-flow-demographics-race": {
-      const rollups = payload[7];
-      const rollupIndex = ROLLUP_INDEX[timeframe];
-      const rollup = Array.isArray(rollups)
-        ? (rollups[rollupIndex] as unknown[])
-        : [];
-      return buildDemographicResult(asNumberArray(rollup?.[7]), "race");
-    }
+    case "site-flow":
+      return buildSiteFlowResult(selectedRollup, snapshotTs, timeframe);
+    case "site-flow-demographics-age":
+      return buildDemographicResult(selectedRollup.agePct, "age");
+    case "site-flow-demographics-gender":
+      return buildDemographicResult(selectedRollup.sexPct, "gender");
+    case "site-flow-demographics-race":
+      return buildDemographicResult(selectedRollup.racePct, "race");
     default:
       throw new Error(
         `Snapshot payload mapping not implemented for widget ${widgetId}`,

--- a/frontend/src/features/dashboard/utils/vrmDecorators.ts
+++ b/frontend/src/features/dashboard/utils/vrmDecorators.ts
@@ -277,11 +277,10 @@ export const applyTrafficDistributionShare = (
   if (isSnapshotPct) {
     const baseSeries = seriesList[0];
     const baseData = baseSeries?.data ?? [];
-    const normalized = Array.from({ length: 3 }, (_, index) => {
-      const point = baseData[index];
+    const normalized = (baseData.length > 0 ? baseData : [{ x: "Segment 1", value: 0 }]).map((point, index) => {
       const rawValue = Number(point?.value ?? point?.y ?? 0);
       return {
-        camera: String(point?.x ?? `Camera ${index}`),
+        camera: String(point?.x ?? `Segment ${index + 1}`),
         value: Number.isFinite(rawValue) ? rawValue : 0,
       };
     });

--- a/frontend/src/features/events/transport/searchEvents.ts
+++ b/frontend/src/features/events/transport/searchEvents.ts
@@ -1,6 +1,7 @@
 import { API_ENDPOINTS } from "../../../config";
 import { isDemoSessionActive } from "../../../lib/demoSession";
 import type { Credentials } from "../../../types/credentials";
+import { resolveSiteViewFromLocation } from "../../../lib/siteView";
 
 export interface SearchEventsResult {
   events?: unknown[];
@@ -20,6 +21,10 @@ export const searchEvents = async ({
   clientId?: string | null;
 }): Promise<SearchEventsResult> => {
   const isDemoSession = isDemoSessionActive();
+  const siteView = resolveSiteViewFromLocation();
+  if (siteView && !searchParams.has("siteView")) {
+    searchParams.append("siteView", siteView);
+  }
   let apiUrl = `${API_ENDPOINTS.SEARCH_EVENTS}?${searchParams.toString()}`;
   const headers: HeadersInit = { "Content-Type": "application/json" };
   if (viewToken) {

--- a/frontend/src/lib/siteView.ts
+++ b/frontend/src/lib/siteView.ts
@@ -1,0 +1,26 @@
+export type SiteView = "all" | "site-a" | "site-b";
+
+const normalizeSiteToken = (value: string | null | undefined): SiteView | null => {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "all") return "all";
+  if (normalized === "site-a" || normalized === "site_a" || normalized === "sitea") return "site-a";
+  if (normalized === "site-b" || normalized === "site_b" || normalized === "siteb") return "site-b";
+  return null;
+};
+
+export const resolveSiteViewFromPathname = (
+  pathname: string | null | undefined,
+): SiteView | null => {
+  if (!pathname) return null;
+  const match = pathname.match(/^\/(?:demo|sites)\/([^/]+)(?:\/|$)/i);
+  if (!match) return null;
+  return normalizeSiteToken(match[1]);
+};
+
+export const resolveSiteViewFromLocation = (): SiteView | null => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return resolveSiteViewFromPathname(window.location.pathname);
+};


### PR DESCRIPTION
### Motivation

- Enable demo sessions to serve snapshot and event data from local SQLite exports instead of BigQuery. 
- Provide a migration path to handle both legacy and target snapshot payload formats in the UI. 
- Keep production BigQuery flows unchanged while adding local-data fallbacks for snapshots and logs.

### Description

- Add backend local data helpers in `backend/app/services/local_data.py` and local log search in `backend/app/local_logs.py` to select and validate SQLite sources and query event logs. 
- Wire demo flow routing into API endpoints by updating `backend/app/api/analytics.py` (`/api/search-events`) and `backend/app/api/snapshots.py` (`/api/snapshots/latest`) to use local SQLite via `fetch_latest_snapshot_from_sqlite` and `search_events_from_sqlite` when a demo session is detected. 
- Extend `backend/app/snapshots.py` with `fetch_latest_snapshot_from_sqlite` and SQLite table discovery logic, and raise `LocalDataError` on missing/invalid local DBs. 
- Update frontend to propagate a `siteView` parameter to snapshot and event requests and add `frontend/src/lib/siteView.ts`; overhaul snapshot payload handling in `snapshotPayload.ts` to normalize legacy and target rollup layouts and update KPI, traffic and site-flow mapping accordingly. 

### Testing

- Added `backend/tests/test_local_data_migration.py` covering `resolve_site_view`, `snapshot_db_for_site`, `fetch_latest_snapshot_from_sqlite`, and `search_events_from_sqlite`, and ran the new tests with `python -m unittest backend.tests.test_local_data_migration`, which passed. 
- Existing API behavior for BigQuery paths was left intact and no BigQuery-dependent tests were modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69dfee43e550832c879b0376e68c07e2)