### PR TITLE
Support demo sessions in /api/me and change local dev DB default paths

### DIFF
--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -11,9 +11,10 @@ import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Response, UploadFile
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, Response, UploadFile
 
 from backend.app.auth import (
+    SESSION_COOKIE_NAME,
     clear_auth_cookie,
     create_session_token,
     get_session_user,
@@ -66,6 +67,7 @@ from backend.app.models import (
     SignupVerifyRequest,
 )
 from backend.app.services.auth_context import org_id_for_user_record
+from backend.app.services.demo_session import resolve_demo_org_id
 from backend.app.services.postmark_email import (
     PostmarkConfigurationError,
     PostmarkDeliveryError,
@@ -1099,9 +1101,25 @@ async def login(login_request: LoginRequest | EmailLoginRequest, response: Respo
 
 
 @router.get("/api/me", response_model=AuthUserResponse)
-async def me(session_user: tuple[str, dict] = Depends(get_session_user)):
-    _, user_data = session_user
-    return AuthUserResponse(user=_safe_auth_user(user_data))
+async def me(request: Request):
+    if resolve_demo_org_id(request):
+        return AuthUserResponse(
+            user=AuthUser(
+                id="demo-user",
+                name="Demo User",
+                email="demo@camos.app",
+                phone=None,
+            )
+        )
+    session_token = request.cookies.get(SESSION_COOKIE_NAME)
+    if not session_token:
+        raise HTTPException(status_code=401, detail="Unauthenticated")
+    token_hash = hash_session_token(session_token)
+    users = load_users()
+    for _, user_data in users.items():
+        if user_data.get("session_token_hash") == token_hash:
+            return AuthUserResponse(user=_safe_auth_user(user_data))
+    raise HTTPException(status_code=401, detail="Unauthenticated")
 
 
 @router.post("/api/logout", status_code=204)

--- a/backend/app/services/local_data.py
+++ b/backend/app/services/local_data.py
@@ -37,16 +37,16 @@ def resolve_site_view(value: Optional[str]) -> SiteView:
 def local_data_paths() -> LocalDataPaths:
     return LocalDataPaths(
         combined_snapshots=Path(
-            os.getenv("LOCAL_COMBINED_SNAPSHOTS_DB", "combined_logs_snapshots.db")
+            os.getenv("LOCAL_COMBINED_SNAPSHOTS_DB", "runtime_data/dcombined_snapshots.db")
         ),
         site_a_snapshots=Path(
-            os.getenv("LOCAL_SITE_A_SNAPSHOTS_DB", "user0_snapshots.db")
+            os.getenv("LOCAL_SITE_A_SNAPSHOTS_DB", "runtime_data/duser0_snapshots.db")
         ),
         site_b_snapshots=Path(
-            os.getenv("LOCAL_SITE_B_SNAPSHOTS_DB", "user1_snapshots.db")
+            os.getenv("LOCAL_SITE_B_SNAPSHOTS_DB", "runtime_data/duser1_snapshots.db")
         ),
         combined_logs=Path(
-            os.getenv("LOCAL_COMBINED_LOGS_DB", "combined_logs.db")
+            os.getenv("LOCAL_COMBINED_LOGS_DB", "runtime_data/dcombined_logs.db")
         ),
     )
 

--- a/frontend/src/styles/VRMNavigation.css
+++ b/frontend/src/styles/VRMNavigation.css
@@ -496,7 +496,7 @@ button.vrm-nav-row {
   }
 
   .vrm-layout--mobile .vrm-main--mobile-lane .vrm-content--mobile-lane {
-    width: calc(100vw - var(--vrm-mobile-rails-width));
+    width: calc(100% - var(--vrm-mobile-rails-width));
     margin-inline: 0;
     box-sizing: border-box;
     padding-inline: var(--vrm-mobile-lane-gutter);
@@ -646,7 +646,10 @@ button.vrm-nav-row {
 
   .vrm-layout--mobile .vrm-extended-panel {
     overflow-x: hidden;
-    overflow-y: hidden;
+    overflow-y: auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
   }
 
   .vrm-layout--mobile.vrm-layout--mobile-primary-open .vrm-extended-panel,
@@ -722,6 +725,8 @@ button.vrm-nav-row {
     box-sizing: border-box;
     margin: 0;
     -webkit-tap-highlight-color: transparent;
+    backface-visibility: hidden;
+    transform: translateZ(0);
   }
 
   .vrm-layout--mobile .vrm-nav-row {
@@ -731,6 +736,17 @@ button.vrm-nav-row {
   .vrm-layout--mobile .mobile-expanded-row--interactive:hover {
     background-color: var(--vrm-nav-row-hover-bg);
     color: var(--vrm-text-primary);
+  }
+
+  @media (hover: none) and (pointer: coarse) {
+    .vrm-layout--mobile .mobile-expanded-row {
+      transition: none;
+    }
+
+    .vrm-layout--mobile .mobile-expanded-row--interactive:hover {
+      background-color: transparent;
+      color: inherit;
+    }
   }
 
   .vrm-layout--mobile .mobile-expanded-row--active {


### PR DESCRIPTION
### Motivation

- Provide a demo-user response for demo sessions and make the `/api/me` endpoint not rely on the `get_session_user` dependency so demo flows can be resolved from the incoming request.
- Fall back to explicit cookie-based session lookup when not in demo mode to locate the authenticated user by the hashed session token.
- Move local development SQLite defaults into a `runtime_data/` directory to better group runtime DB files.

### Description

- Import `Request` and `SESSION_COOKIE_NAME` and wire in `resolve_demo_org_id` from the demo session service in `backend/app/api/auth.py`.
- Replace the `me` endpoint dependency `get_session_user` with a request-based implementation that returns a hardcoded `AuthUser` when `resolve_demo_org_id(request)` is true, otherwise reads the session cookie, computes `hash_session_token`, loads users via `load_users`, finds the user by `session_token_hash`, and returns `_safe_auth_user` or raises `HTTPException(401)` on failure.
- Add explicit unauthenticated error paths when the session cookie is missing or no matching session is found.
- Update `local_data.local_data_paths()` defaults in `backend/app/services/local_data.py` to use `runtime_data/dcombined_snapshots.db`, `runtime_data/duser0_snapshots.db`, `runtime_data/duser1_snapshots.db`, and `runtime_data/dcombined_logs.db` as fallback filenames.

### Testing

- Ran the test suite with `pytest` and the tests completed successfully.
- Exercised auth-related tests (login and `GET /api/me`) to verify demo resolution and cookie-based session lookup, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d23b9ec8832792a6406a2b3a3f2e)