### PR TITLE
Fix Event Logs mobile overflow containment in portrait layouts

### DIFF
--- a/frontend/src/features/events/EventLogsPage.css
+++ b/frontend/src/features/events/EventLogsPage.css
@@ -118,10 +118,10 @@
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-results-table {
     border-collapse: separate;
     border-spacing: 0;
-    max-width: none !important;
+    max-width: none;
     min-width: 720px;
     table-layout: fixed;
-    width: max-content !important;
+    width: max-content;
   }
 
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-results-table th,

--- a/frontend/src/features/events/EventLogsPage.css
+++ b/frontend/src/features/events/EventLogsPage.css
@@ -106,6 +106,7 @@
     max-width: 100%;
     overflow-x: auto;
     overflow-y: hidden;
+    display: block;
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
   }
@@ -117,10 +118,10 @@
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-results-table {
     border-collapse: separate;
     border-spacing: 0;
-    max-width: none;
+    max-width: none !important;
     min-width: 720px;
     table-layout: fixed;
-    width: 960px;
+    width: max-content !important;
   }
 
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-results-table th,

--- a/frontend/src/features/events/EventLogsPage.css
+++ b/frontend/src/features/events/EventLogsPage.css
@@ -99,6 +99,7 @@
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-table-scroll {
     min-width: 0;
     width: 100%;
+    max-width: 100%;
   }
 
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-table-scroll {
@@ -119,7 +120,7 @@
     max-width: none;
     min-width: 720px;
     table-layout: fixed;
-    width: max-content;
+    width: 960px;
   }
 
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-results-table th,

--- a/frontend/src/features/events/EventLogsPage.css
+++ b/frontend/src/features/events/EventLogsPage.css
@@ -95,10 +95,18 @@
 }
 
 @media (max-width: 768px) {
+  .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-page,
+  .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-table-scroll {
+    min-width: 0;
+    width: 100%;
+  }
+
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-table-scroll {
     max-width: 100%;
     overflow-x: auto;
+    overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
   }
 
   .event-devices-menu {
@@ -111,7 +119,7 @@
     max-width: none;
     min-width: 720px;
     table-layout: fixed;
-    width: 100%;
+    width: max-content;
   }
 
   .vrm-layout--mobile .vrm-content--mobile-lane .event-logs-results-table th,

--- a/frontend/src/styles/VRMNavigation.css
+++ b/frontend/src/styles/VRMNavigation.css
@@ -555,7 +555,7 @@ button.vrm-nav-row {
     box-sizing: border-box;
   }
 
-  .vrm-layout--mobile .vrm-content--mobile-lane table,
+  .vrm-layout--mobile .vrm-content--mobile-lane table:not(.event-logs-results-table),
   .vrm-layout--mobile .vrm-content--mobile-lane .vrm-table {
     width: 100%;
     max-width: 100%;


### PR DESCRIPTION
### Motivation
- On phone-portrait layouts the Event Logs results table could expand its intrinsic width after a search and leak that width into the page, locking horizontal ownership to the viewport and breaking scroll/navigation.

### Description
- Add `min-width: 0` and `width: 100%` to `.event-logs-page` and `.event-logs-table-scroll` inside the mobile lane to prevent ancestor width expansion from affecting the page.
- Restrict horizontal scroll ownership to the table scroller by keeping `overflow-x: auto`, adding `overflow-y: hidden`, and adding `overscroll-behavior-x: contain` on `.event-logs-table-scroll`.
- Change the mobile table sizing to `width: max-content` (keeping `min-width: 720px`) so the table can grow inside the local scroller rather than forcing layout-wide expansion.

### Testing
- Ran `cd frontend && npm run build` which completed successfully.
- Launched the app locally and executed automated Playwright checks using the `iPhone 13` device against `/demo/site-b/event-logs` and `/demo/site-a/event-logs`, and exercised the Search action.
- Playwright navigation and runtime checks completed without errors but the demo datasets returned `0` rows in this environment, so the exact post-search row-overflow visual state could not be observed; the containment and build verifications passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c380606ec8326817ac433d740d2b7)