### PR TITLE
Show relative Last Seen times, improve refresh/reset behavior, and update demo data

### DIFF
--- a/frontend/src/features/devices/DeviceListPage.css
+++ b/frontend/src/features/devices/DeviceListPage.css
@@ -132,25 +132,6 @@
   min-width: 0;
 }
 
-.device-runtime-site-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  color: var(--vrm-text-secondary);
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-.device-runtime-site-count {
-  color: var(--vrm-text-muted);
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: none;
-}
-
 .device-runtime-device-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -322,10 +303,10 @@
   background: color-mix(in srgb, var(--surface-panel) 72%, white 28%);
 }
 
-.device-runtime-records-value-row {
+.device-runtime-records-value-stack {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-start;
   min-width: 0;
 }
 
@@ -455,10 +436,6 @@
 
   .device-runtime-status {
     justify-self: start;
-  }
-
-  .device-runtime-records-value-row {
-    flex-wrap: wrap;
   }
 
   .device-runtime-device-name {

--- a/frontend/src/features/devices/DeviceListPage.tsx
+++ b/frontend/src/features/devices/DeviceListPage.tsx
@@ -22,6 +22,82 @@ const siteNameForScope = (activeSiteId: string) => {
   }
 };
 
+const displayDeviceType = (type: string) =>
+  type === "Gateway" ? "Gateway" : "Camera";
+
+const DEVICE_LIST_SESSION_STARTED_AT_KEY = "camOS_device_list_session_started_at";
+
+const getDeviceListSessionStartedAt = () => {
+  const now = Date.now();
+
+  if (typeof window === "undefined") {
+    return now;
+  }
+
+  const storedStartedAt = Number(
+    window.sessionStorage.getItem(DEVICE_LIST_SESSION_STARTED_AT_KEY),
+  );
+  if (
+    Number.isFinite(storedStartedAt) &&
+    storedStartedAt > 0 &&
+    storedStartedAt <= now
+  ) {
+    return storedStartedAt;
+  }
+
+  window.sessionStorage.setItem(DEVICE_LIST_SESSION_STARTED_AT_KEY, String(now));
+  return now;
+};
+
+const formatRelativeTime = (elapsedMs: number) => {
+  const elapsedSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+
+  if (elapsedSeconds < 10) {
+    return "Just now";
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds} seconds ago`;
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) {
+    return elapsedMinutes === 1 ? "1 minute ago" : `${elapsedMinutes} minutes ago`;
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) {
+    return elapsedHours === 1 ? "1 hour ago" : `${elapsedHours} hours ago`;
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  return elapsedDays === 1 ? "1 day ago" : `${elapsedDays} days ago`;
+};
+
+const formatOfflineLastSeen = (lastSeen: string, now: number) => {
+  const lastSeenTime = new Date(lastSeen).getTime();
+  if (!Number.isFinite(lastSeenTime)) {
+    return "Unknown";
+  }
+
+  return formatRelativeTime(now - lastSeenTime);
+};
+
+const isLiveStatus = (status: string) =>
+  status === "online" || status === "connected";
+
+const formatDeviceLastSeen = (
+  device: { lastSeen: string; lastSeenLabel?: string; status: string },
+  now: number,
+  lastCheckedInAt: number,
+) => {
+  if (isLiveStatus(device.status)) {
+    return formatRelativeTime(now - lastCheckedInAt);
+  }
+
+  return device.lastSeenLabel || formatOfflineLastSeen(device.lastSeen, now);
+};
+
 const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
   const {
     devices,
@@ -37,6 +113,39 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
     isDemoSession,
     activeSiteId,
   } = useDeviceList(credentials);
+
+  const [sessionStartedAt] = React.useState(getDeviceListSessionStartedAt);
+  const [now, setNow] = React.useState(() => Date.now());
+  const [deviceLastSeenAt, setDeviceLastSeenAt] = React.useState<Record<string, number>>({});
+
+  React.useEffect(() => {
+    const intervalId = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const resetDeviceLastSeen = React.useCallback((deviceId: string) => {
+    const resetAt = Date.now();
+    setNow(resetAt);
+    setDeviceLastSeenAt((current) => ({ ...current, [deviceId]: resetAt }));
+  }, []);
+
+  const resetAllOnlineLastSeen = React.useCallback(() => {
+    const resetAt = Date.now();
+    const resetDevices = devices.reduce<Record<string, number>>((resets, device) => {
+      if (isLiveStatus(device.status)) {
+        resets[device.id] = resetAt;
+      }
+      return resets;
+    }, {});
+
+    setNow(resetAt);
+    setDeviceLastSeenAt((current) => ({ ...current, ...resetDevices }));
+  }, [devices]);
+
+  const handleRefreshAll = React.useCallback(() => {
+    resetAllOnlineLastSeen();
+    refreshDevices();
+  }, [refreshDevices, resetAllOnlineLastSeen]);
 
   if (loading) {
     return (
@@ -169,7 +278,7 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
               <span className="device-runtime-scope-dot" />
               {scopeName}
             </div>
-            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={refreshDevices}>
+            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleRefreshAll}>
               Refresh All
             </button>
           </div>
@@ -177,12 +286,6 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
         <div className="device-runtime-groups">
           {Object.entries(siteGroups).map(([siteName, siteDevices]) => (
             <section className="device-runtime-site-group" key={siteName} aria-label={`${siteName} devices`}>
-              <div className="device-runtime-site-heading">
-                <span>{siteName}</span>
-                <span className="device-runtime-site-count">
-                  {siteDevices.length} {siteDevices.length === 1 ? "device" : "devices"}
-                </span>
-              </div>
               <div className="device-runtime-device-grid">
                 {siteDevices.map((device) => (
                   <article className="device-runtime-card" key={device.id} tabIndex={0}>
@@ -196,15 +299,16 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
                       <div className="device-runtime-meta">
                         <span className="device-runtime-meta-label">Last Seen</span>
                         <span className="device-runtime-meta-value">
-                          {new Date(device.lastSeen).toLocaleTimeString([], {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
+                          {formatDeviceLastSeen(
+                            device,
+                            now,
+                            deviceLastSeenAt[device.id] ?? sessionStartedAt,
+                          )}
                         </span>
                       </div>
                       <div className="device-runtime-meta">
                         <span className="device-runtime-meta-label">Device Type</span>
-                        <span className="device-runtime-meta-value">{device.type}</span>
+                        <span className="device-runtime-meta-value">{displayDeviceType(device.type)}</span>
                       </div>
                       <div className="device-runtime-meta">
                         <span className="device-runtime-meta-label">Location</span>
@@ -212,7 +316,7 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
                       </div>
                       <div className="device-runtime-meta device-runtime-meta--records">
                         <span className="device-runtime-meta-label">Records</span>
-                        <div className="device-runtime-records-value-row">
+                        <div className="device-runtime-records-value-stack">
                           <span className="device-runtime-meta-value">{device.recordCount?.toLocaleString() ?? "-"}</span>
                           <button
                             type="button"
@@ -237,7 +341,12 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
                         type="button"
                         className="device-runtime-icon-action"
                         aria-label={`Refresh ${device.name}`}
-                        onClick={refreshDevices}
+                        onClick={() => {
+                          if (isLiveStatus(device.status)) {
+                            resetDeviceLastSeen(device.id);
+                          }
+                          refreshDevices();
+                        }}
                       >
                         <RefreshCw size={14} strokeWidth={2.4} aria-hidden="true" />
                         <span>Refresh</span>

--- a/frontend/src/features/devices/demoDevices.ts
+++ b/frontend/src/features/devices/demoDevices.ts
@@ -1,4 +1,3 @@
-import { countDemoRuntimeEvents } from "./demoRuntimeEvents";
 import type { DemoEventToken } from "./demoRuntimeEvents";
 import type { DeviceInfo } from "./types";
 
@@ -11,6 +10,21 @@ export type DemoDevice = {
   location: string;
   online: boolean;
   eventTokens: DemoEventToken[];
+};
+
+const DEMO_RECORD_COUNTS: Record<string, number> = {
+  "gateway-ab": 36_836,
+  "main-door-ab": 33_237,
+  "back-door-ab": 3_599,
+  "gateway-tt": 982_639,
+  "main-door-tt": 582_015,
+  "delivery-door-tt": 301_975,
+  "back-door-tt": 98_659,
+};
+
+const DEMO_OFFLINE_LAST_SEEN_LABELS: Record<string, string> = {
+  "back-door-ab": "1 day ago",
+  "back-door-tt": "14:22",
 };
 
 export const DEMO_DEVICES: DemoDevice[] = [
@@ -50,7 +64,7 @@ export const DEMO_DEVICES: DemoDevice[] = [
     siteName: "Tokis Takeout",
     label: "TT Gateway",
     type: "gateway",
-    location: "Kitchen Network",
+    location: "Office",
     online: true,
     eventTokens: ["site-b:cam-0", "site-b:cam-1", "site-b:cam-2"],
   },
@@ -130,8 +144,11 @@ export const toDeviceInfo = (device: DemoDevice): DeviceInfo => ({
   lastSeen: device.online
     ? new Date("2026-05-28T18:24:00Z").toISOString()
     : new Date("2026-05-28T16:48:00Z").toISOString(),
+  lastSeenLabel: device.online
+    ? undefined
+    : DEMO_OFFLINE_LAST_SEEN_LABELS[device.id],
   location: device.location,
-  recordCount: countDemoRuntimeEvents(device.eventTokens),
+  recordCount: DEMO_RECORD_COUNTS[device.id],
   siteId: device.siteId,
   siteName: device.siteName,
 });

--- a/frontend/src/features/devices/types.ts
+++ b/frontend/src/features/devices/types.ts
@@ -4,6 +4,7 @@ export interface DeviceInfo {
   type: "Camera" | "Sensor" | "Gateway" | "Door";
   status: "online" | "offline" | "maintenance";
   lastSeen: string;
+  lastSeenLabel?: string;
   dataSource?: string;
   location?: string;
   recordCount?: number;


### PR DESCRIPTION
### Motivation

- Improve the device list UX by showing human-friendly relative "Last Seen" labels instead of raw time strings and by keeping those labels consistent across a user session.  
- Ensure refresh operations give immediate visual feedback for online devices by resetting per-device last-seen markers when users refresh an individual device or refresh all.  
- Harmonize demo data and types so offline devices can surface an explicit `lastSeenLabel` and demo record counts are realistic.  

### Description

- Added session-scoped timestamp handling with `DEVICE_LIST_SESSION_STARTED_AT_KEY` and `getDeviceListSessionStartedAt` to anchor relative time labels for the session.  
- Implemented `formatRelativeTime`, `formatOfflineLastSeen`, `isLiveStatus`, and `formatDeviceLastSeen` and replaced direct `toLocaleTimeString` usage to render relative last-seen text in the UI.  
- Track per-device last-seen overrides in component state (`deviceLastSeenAt`) and added `resetDeviceLastSeen` and `resetAllOnlineLastSeen` to update those values when a device or all online devices are refreshed; changed the "Refresh All" button to call `handleRefreshAll`.  
- Update per-device refresh handler to reset the device last-seen timestamp when the device is live and then call `refreshDevices`.  
- Added `displayDeviceType` to normalize type labels shown in the UI and added optional `lastSeenLabel` to `DeviceInfo` in `types.ts`.  
- Updated demo data in `demoDevices.ts` to provide `DEMO_RECORD_COUNTS` and `DEMO_OFFLINE_LAST_SEEN_LABELS`, to set `recordCount` from the new map, and to supply `lastSeenLabel` for selected offline demo devices.  
- Minor CSS class/name changes in `DeviceListPage.css` to switch `.device-runtime-records-value-row` to `.device-runtime-records-value-stack` and remove the site heading count block to better match the new layout.  

### Testing

- Ran TypeScript type checking and the codebase typechecks cleanly.  
- Executed the frontend unit test suite and component tests related to the device list, and they completed successfully.  
- Ran linting and basic local UI smoke checks for the device list view to verify relative time rendering and refresh behavior, and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d912f61248322bd6a579945c4a6d6)