### PR TITLE
Add demo alarm logs, site scoping and UI updates for Alarms and Device List

### DIFF
--- a/frontend/src/features/alarms/AlarmLogsPage.tsx
+++ b/frontend/src/features/alarms/AlarmLogsPage.tsx
@@ -211,9 +211,7 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
               </button>
               <button
                 className="vrm-btn vrm-btn-sm"
-                onClick={() =>
-                  fetchAlarmLogs(isAdmin ? selectedClient : undefined)
-                }
+                onClick={refreshAlarms}
               >
                 Refresh
               </button>
@@ -224,10 +222,11 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
               <table className="vrm-table">
                 <thead>
                   <tr>
-                    <th>Instance</th>
+                    <th>Site</th>
                     <th>Device</th>
-                    <th>Description</th>
-                    <th>Alarm Started At</th>
+                    <th>Alarm Type</th>
+                    <th>Timestamp</th>
+                    <th>Status</th>
                     <th>Severity</th>
                     <th>Actions</th>
                   </tr>
@@ -236,19 +235,7 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
                   {" "}
                   {activeAlarms.map((alarm) => (
                     <tr key={alarm.id}>
-                      <td>
-                        <code
-                          style={{
-                            backgroundColor: "var(--vrm-bg-tertiary)",
-                            padding: "2px 6px",
-                            borderRadius: "3px",
-                            fontSize: "12px",
-                          }}
-                        >
-                          {" "}
-                          {alarm.instance}{" "}
-                        </code>
-                      </td>
+                      <td>{alarm.site || alarm.instance}</td>
                       <td>{alarm.device}</td>
                       <td>
                         <div
@@ -262,6 +249,9 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
                         </div>
                       </td>
                       <td>{alarm.alarmStartedAt}</td>
+                      <td>
+                        <span style={{ color: "#8b3a2f" }}>Active</span>
+                      </td>
                       <td>
                         <div
                           className={`vrm-status ${getSeverityClass(alarm.severity)}`}
@@ -303,9 +293,7 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
             </button>
             <button
               className="vrm-btn vrm-btn-sm"
-              onClick={() =>
-                fetchAlarmLogs(isAdmin ? selectedClient : undefined)
-              }
+              onClick={refreshAlarms}
             >
               Refresh
             </button>
@@ -318,31 +306,28 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
               <table className="vrm-table">
                 <thead>
                   <tr>
-                    <th>Instance</th>
-                    <th>Device</th>
-                    <th>Description</th>
-                    <th>Alarm Started At</th>
-                    <th>Alarm Cleared After</th>
+                    <th>Timestamp</th>
                     <th>Severity</th>
+                    <th>Site</th>
+                    <th>Device</th>
+                    <th>Alarm Type</th>
+                    <th>Status</th>
                   </tr>
                 </thead>
                 <tbody>
                   {" "}
                   {alarms.map((alarm) => (
                     <tr key={alarm.id}>
+                      <td>{alarm.alarmStartedAt}</td>
                       <td>
-                        <code
-                          style={{
-                            backgroundColor: "var(--vrm-bg-tertiary)",
-                            padding: "2px 6px",
-                            borderRadius: "3px",
-                            fontSize: "12px",
-                          }}
+                        <div
+                          className={`vrm-status ${getSeverityClass(alarm.severity)}`}
                         >
-                          {" "}
-                          {alarm.instance}{" "}
-                        </code>
+                          <div className="vrm-status-dot"></div>{" "}
+                          {getSeverityText(alarm.severity)}{" "}
+                        </div>
                       </td>
+                      <td>{alarm.site || alarm.instance}</td>
                       <td>{alarm.device}</td>
                       <td>
                         <div
@@ -355,26 +340,12 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
                           <span>{alarm.description}</span>
                         </div>
                       </td>
-                      <td>{alarm.alarmStartedAt}</td>
                       <td>
-                        {" "}
                         {alarm.alarmClearedAfter ? (
-                          <span style={{ color: "#44644b" }}>
-                            {alarm.alarmClearedAfter}
-                          </span>
+                          <span style={{ color: "#44644b" }}>Cleared</span>
                         ) : (
-                          <span style={{ color: "#8b3a2f" }}>
-                            Still active
-                          </span>
-                        )}{" "}
-                      </td>
-                      <td>
-                        <div
-                          className={`vrm-status ${getSeverityClass(alarm.severity)}`}
-                        >
-                          <div className="vrm-status-dot"></div>{" "}
-                          {getSeverityText(alarm.severity)}{" "}
-                        </div>
+                          <span style={{ color: "#8b3a2f" }}>Active</span>
+                        )}
                       </td>
                     </tr>
                   ))}{" "}

--- a/frontend/src/features/alarms/demoAlarmLogs.ts
+++ b/frontend/src/features/alarms/demoAlarmLogs.ts
@@ -1,0 +1,205 @@
+import type { AlarmEvent } from "./types";
+
+const ALARM_CATALOG = {
+  storageWarning: { description: "Storage utilisation exceeded 80%", severity: "medium" },
+  storageCritical: { description: "Storage utilisation exceeded 95%", severity: "high" },
+  gatewayOffline: { description: "Gateway heartbeat lost", severity: "high" },
+  gatewayRestored: { description: "Gateway connection restored", severity: "low" },
+  recordingRestarted: { description: "Recording service restarted", severity: "medium" },
+  databaseMaintenance: { description: "Database maintenance completed", severity: "low" },
+  cameraOffline: { description: "Device heartbeat lost", severity: "high" },
+  cameraRestored: { description: "Device connection restored", severity: "low" },
+  videoLost: { description: "Video stream unavailable", severity: "high" },
+  videoRestored: { description: "Video stream restored", severity: "low" },
+  deviceRestarted: { description: "Device restarted", severity: "medium" },
+  occupancyThreshold: { description: "Occupancy threshold exceeded", severity: "medium" },
+  queueThreshold: { description: "Queue threshold exceeded", severity: "medium" },
+  analyticsDelay: { description: "Event processing delay detected", severity: "medium" },
+  analyticsRestart: { description: "Analytics service restarted", severity: "medium" },
+  repeatedAccess: { description: "Repeated access activity detected", severity: "medium" },
+  restrictedArea: { description: "Restricted area activity detected", severity: "high" },
+} as const;
+
+type AlarmCatalogKey = keyof typeof ALARM_CATALOG;
+
+type DemoAlarmDevice = {
+  siteId: "site-a" | "site-b";
+  siteName: string;
+  device: string;
+  gateway: boolean;
+};
+
+const DEMO_ALARM_DEVICES: DemoAlarmDevice[] = [
+  { siteId: "site-b", siteName: "Tokis Takeout", device: "TT Gateway", gateway: true },
+  { siteId: "site-b", siteName: "Tokis Takeout", device: "TT Main Door", gateway: false },
+  { siteId: "site-b", siteName: "Tokis Takeout", device: "TT Delivery Door", gateway: false },
+  { siteId: "site-b", siteName: "Tokis Takeout", device: "TT Back Door", gateway: false },
+  { siteId: "site-a", siteName: "Ali’s Barber", device: "AB Gateway", gateway: true },
+  { siteId: "site-a", siteName: "Ali’s Barber", device: "AB Main Door", gateway: false },
+  { siteId: "site-a", siteName: "Ali’s Barber", device: "AB Back Door", gateway: false },
+];
+
+const CAMERA_ALARM_ROTATION: AlarmCatalogKey[] = [
+  "cameraOffline",
+  "cameraRestored",
+  "occupancyThreshold",
+  "queueThreshold",
+  "cameraOffline",
+  "cameraRestored",
+  "deviceRestarted",
+  "videoLost",
+  "videoRestored",
+  "analyticsDelay",
+  "occupancyThreshold",
+  "queueThreshold",
+  "repeatedAccess",
+  "analyticsRestart",
+  "restrictedArea",
+];
+
+const GATEWAY_ALARM_ROTATION: AlarmCatalogKey[] = [
+  "storageWarning",
+  "databaseMaintenance",
+  "recordingRestarted",
+  "storageWarning",
+  "gatewayRestored",
+  "analyticsDelay",
+  "storageCritical",
+  "gatewayOffline",
+];
+
+const formatAlarmDate = (date: Date) => {
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())} ${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}`;
+};
+
+const addMinutes = (date: Date, minutes: number) =>
+  new Date(date.getTime() + minutes * 60 * 1000);
+
+const resolveAlarmSiteScope = (siteId?: string | null): "site-a" | "site-b" | "all" => {
+  switch ((siteId || "all").toLowerCase()) {
+    case "ab":
+    case "site-a":
+      return "site-a";
+    case "tt":
+    case "site-b":
+      return "site-b";
+    default:
+      return "all";
+  }
+};
+
+const buildAlarm = ({
+  index,
+  device,
+  catalogKey,
+  startedAt,
+  active = false,
+  clearMinutes = 28,
+}: {
+  index: number;
+  device: DemoAlarmDevice;
+  catalogKey: AlarmCatalogKey;
+  startedAt: Date;
+  active?: boolean;
+  clearMinutes?: number;
+}): AlarmEvent => {
+  const alarm = ALARM_CATALOG[catalogKey];
+  return {
+    id: `demo-alarm-${String(index).padStart(4, "0")}`,
+    instance: `${device.siteId.toUpperCase()}-${String(index).padStart(4, "0")}`,
+    site: device.siteName,
+    device: device.device,
+    description: alarm.description,
+    alarmStartedAt: formatAlarmDate(startedAt),
+    alarmClearedAfter: active ? null : formatAlarmDate(addMinutes(startedAt, clearMinutes)),
+    severity: alarm.severity,
+  };
+};
+
+const REQUIRED_CATALOG_SEEDS: AlarmCatalogKey[] = [
+  "storageWarning",
+  "storageCritical",
+  "gatewayOffline",
+  "gatewayRestored",
+  "recordingRestarted",
+  "databaseMaintenance",
+  "cameraOffline",
+  "cameraRestored",
+  "videoLost",
+  "videoRestored",
+  "deviceRestarted",
+  "occupancyThreshold",
+  "queueThreshold",
+  "analyticsDelay",
+  "analyticsRestart",
+  "repeatedAccess",
+  "restrictedArea",
+];
+
+const buildHistoricalAlarms = () => {
+  const start = new Date(Date.UTC(2024, 0, 4, 8, 15));
+  const end = new Date();
+  const totalHistorical = 756;
+  const duration = end.getTime() - start.getTime();
+  const alarms: AlarmEvent[] = [];
+
+  for (let index = 0; index < totalHistorical; index += 1) {
+    const seededCatalogKey = REQUIRED_CATALOG_SEEDS[index];
+    const seededNeedsGateway = seededCatalogKey
+      ? seededCatalogKey.startsWith("gateway") ||
+        seededCatalogKey.startsWith("storage") ||
+        seededCatalogKey === "recordingRestarted" ||
+        seededCatalogKey === "databaseMaintenance"
+      : false;
+    const device = seededCatalogKey
+      ? DEMO_ALARM_DEVICES.find((candidate) => candidate.gateway === seededNeedsGateway) || DEMO_ALARM_DEVICES[0]
+      : DEMO_ALARM_DEVICES[index % DEMO_ALARM_DEVICES.length];
+    const rotation = device.gateway ? GATEWAY_ALARM_ROTATION : CAMERA_ALARM_ROTATION;
+    const catalogKey = seededCatalogKey || rotation[(index * 5 + (device.gateway ? 1 : 3)) % rotation.length];
+    const offset = Math.floor((duration * index) / totalHistorical);
+    const hourJitter = ((index * 37) % 11) * 60 * 60 * 1000;
+    const minuteJitter = ((index * 17) % 53) * 60 * 1000;
+    const startedAt = new Date(start.getTime() + offset + hourJitter + minuteJitter);
+    const clearMinutes = 8 + ((index * 19) % 175);
+    alarms.push(buildAlarm({ index: index + 1, device, catalogKey, startedAt, clearMinutes }));
+  }
+
+  const activeStartedBase = addMinutes(end, -74);
+  const activeDefinitions: Array<{
+    device: DemoAlarmDevice;
+    catalogKey: AlarmCatalogKey;
+    minutesAgo: number;
+  }> = [
+    { device: DEMO_ALARM_DEVICES[1], catalogKey: "videoLost", minutesAgo: 18 },
+    { device: DEMO_ALARM_DEVICES[2], catalogKey: "queueThreshold", minutesAgo: 43 },
+    { device: DEMO_ALARM_DEVICES[5], catalogKey: "occupancyThreshold", minutesAgo: 67 },
+  ];
+
+  activeDefinitions.forEach((definition, activeIndex) => {
+    alarms.push(buildAlarm({
+      index: totalHistorical + activeIndex + 1,
+      device: definition.device,
+      catalogKey: definition.catalogKey,
+      startedAt: addMinutes(activeStartedBase, 74 - definition.minutesAgo),
+      active: true,
+    }));
+  });
+
+  return alarms.sort(
+    (a, b) => new Date(b.alarmStartedAt).getTime() - new Date(a.alarmStartedAt).getTime(),
+  );
+};
+
+const DEMO_ALARM_LOGS = buildHistoricalAlarms();
+
+export const getDemoAlarmLogsForScope = (siteId?: string | null): AlarmEvent[] => {
+  const scope = resolveAlarmSiteScope(siteId);
+  if (scope === "all") {
+    return DEMO_ALARM_LOGS;
+  }
+  return DEMO_ALARM_LOGS.filter((alarm) => {
+    const device = DEMO_ALARM_DEVICES.find((candidate) => candidate.device === alarm.device);
+    return device?.siteId === scope;
+  });
+};

--- a/frontend/src/features/alarms/hooks/useAlarmLogs.ts
+++ b/frontend/src/features/alarms/hooks/useAlarmLogs.ts
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
 import type { Credentials } from "../../../types/credentials";
 import { isDemoSessionActive } from "../../../lib/demoSession";
 import { getViewTokenFromLocation } from "../../../lib/viewToken";
 import { fetchAlarmLogs } from "../transport/fetchAlarmLogs";
 import { fetchAlarmUsers } from "../transport/fetchAlarmUsers";
 import type { AlarmEvent, AlarmUser } from "../types";
+import { getDemoAlarmLogsForScope } from "../demoAlarmLogs";
 
 type AlarmUsersMap = Record<string, AlarmUser>;
 
@@ -26,6 +28,7 @@ type AlarmLogsState = {
 export const useAlarmLogs = (
   credentials: Credentials,
 ): AlarmLogsState => {
+  const { siteId = "all" } = useParams<{ siteId: string }>();
   const [alarms, setAlarms] = useState<AlarmEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -34,7 +37,10 @@ export const useAlarmLogs = (
   const [isAdmin, setIsAdmin] = useState(false);
 
   const viewToken = getViewTokenFromLocation();
-  const isDemoSession = isDemoSessionActive();
+  const isDemoSession =
+    isDemoSessionActive() ||
+    (typeof window !== "undefined" &&
+      window.location.pathname.startsWith("/demo/"));
 
   const loadUsers = useCallback(async () => {
     try {
@@ -59,6 +65,11 @@ export const useAlarmLogs = (
     async (clientId?: string) => {
       try {
         setLoading(true);
+        if (isDemoSession) {
+          setAlarms(getDemoAlarmLogsForScope(siteId));
+          setError(null);
+          return;
+        }
         const result = await fetchAlarmLogs({
           credentials,
           viewToken,
@@ -77,7 +88,7 @@ export const useAlarmLogs = (
         setLoading(false);
       }
     },
-    [credentials, isAdmin, viewToken],
+    [credentials, isAdmin, isDemoSession, siteId, viewToken],
   );
 
   useEffect(() => {

--- a/frontend/src/features/alarms/types.ts
+++ b/frontend/src/features/alarms/types.ts
@@ -1,6 +1,7 @@
 export interface AlarmEvent {
   id: string;
   instance: string;
+  site?: string;
   device: string;
   description: string;
   alarmStartedAt: string;

--- a/frontend/src/features/devices/DeviceListPage.css
+++ b/frontend/src/features/devices/DeviceListPage.css
@@ -132,25 +132,6 @@
   min-width: 0;
 }
 
-.device-runtime-site-heading {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  color: var(--vrm-text-secondary);
-  font-size: 13px;
-  font-weight: 800;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-}
-
-.device-runtime-site-count {
-  color: var(--vrm-text-muted);
-  font-size: 12px;
-  font-weight: 700;
-  text-transform: none;
-}
-
 .device-runtime-device-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -322,10 +303,10 @@
   background: color-mix(in srgb, var(--surface-panel) 72%, white 28%);
 }
 
-.device-runtime-records-value-row {
+.device-runtime-records-value-stack {
   display: flex;
-  align-items: baseline;
-  gap: 8px;
+  flex-direction: column;
+  align-items: flex-start;
   min-width: 0;
 }
 
@@ -455,10 +436,6 @@
 
   .device-runtime-status {
     justify-self: start;
-  }
-
-  .device-runtime-records-value-row {
-    flex-wrap: wrap;
   }
 
   .device-runtime-device-name {

--- a/frontend/src/features/devices/DeviceListPage.tsx
+++ b/frontend/src/features/devices/DeviceListPage.tsx
@@ -22,6 +22,82 @@ const siteNameForScope = (activeSiteId: string) => {
   }
 };
 
+const displayDeviceType = (type: string) =>
+  type === "Gateway" ? "Gateway" : "Camera";
+
+const DEVICE_LIST_SESSION_STARTED_AT_KEY = "camOS_device_list_session_started_at";
+
+const getDeviceListSessionStartedAt = () => {
+  const now = Date.now();
+
+  if (typeof window === "undefined") {
+    return now;
+  }
+
+  const storedStartedAt = Number(
+    window.sessionStorage.getItem(DEVICE_LIST_SESSION_STARTED_AT_KEY),
+  );
+  if (
+    Number.isFinite(storedStartedAt) &&
+    storedStartedAt > 0 &&
+    storedStartedAt <= now
+  ) {
+    return storedStartedAt;
+  }
+
+  window.sessionStorage.setItem(DEVICE_LIST_SESSION_STARTED_AT_KEY, String(now));
+  return now;
+};
+
+const formatRelativeTime = (elapsedMs: number) => {
+  const elapsedSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+
+  if (elapsedSeconds < 10) {
+    return "Just now";
+  }
+
+  if (elapsedSeconds < 60) {
+    return `${elapsedSeconds} seconds ago`;
+  }
+
+  const elapsedMinutes = Math.floor(elapsedSeconds / 60);
+  if (elapsedMinutes < 60) {
+    return elapsedMinutes === 1 ? "1 minute ago" : `${elapsedMinutes} minutes ago`;
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60);
+  if (elapsedHours < 24) {
+    return elapsedHours === 1 ? "1 hour ago" : `${elapsedHours} hours ago`;
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24);
+  return elapsedDays === 1 ? "1 day ago" : `${elapsedDays} days ago`;
+};
+
+const formatOfflineLastSeen = (lastSeen: string, now: number) => {
+  const lastSeenTime = new Date(lastSeen).getTime();
+  if (!Number.isFinite(lastSeenTime)) {
+    return "Unknown";
+  }
+
+  return formatRelativeTime(now - lastSeenTime);
+};
+
+const isLiveStatus = (status: string) =>
+  status === "online" || status === "connected";
+
+const formatDeviceLastSeen = (
+  device: { lastSeen: string; lastSeenLabel?: string; status: string },
+  now: number,
+  lastCheckedInAt: number,
+) => {
+  if (isLiveStatus(device.status)) {
+    return formatRelativeTime(now - lastCheckedInAt);
+  }
+
+  return device.lastSeenLabel || formatOfflineLastSeen(device.lastSeen, now);
+};
+
 const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
   const {
     devices,
@@ -37,6 +113,39 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
     isDemoSession,
     activeSiteId,
   } = useDeviceList(credentials);
+
+  const [sessionStartedAt] = React.useState(getDeviceListSessionStartedAt);
+  const [now, setNow] = React.useState(() => Date.now());
+  const [deviceLastSeenAt, setDeviceLastSeenAt] = React.useState<Record<string, number>>({});
+
+  React.useEffect(() => {
+    const intervalId = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(intervalId);
+  }, []);
+
+  const resetDeviceLastSeen = React.useCallback((deviceId: string) => {
+    const resetAt = Date.now();
+    setNow(resetAt);
+    setDeviceLastSeenAt((current) => ({ ...current, [deviceId]: resetAt }));
+  }, []);
+
+  const resetAllOnlineLastSeen = React.useCallback(() => {
+    const resetAt = Date.now();
+    const resetDevices = devices.reduce<Record<string, number>>((resets, device) => {
+      if (isLiveStatus(device.status)) {
+        resets[device.id] = resetAt;
+      }
+      return resets;
+    }, {});
+
+    setNow(resetAt);
+    setDeviceLastSeenAt((current) => ({ ...current, ...resetDevices }));
+  }, [devices]);
+
+  const handleRefreshAll = React.useCallback(() => {
+    resetAllOnlineLastSeen();
+    refreshDevices();
+  }, [refreshDevices, resetAllOnlineLastSeen]);
 
   if (loading) {
     return (
@@ -169,7 +278,7 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
               <span className="device-runtime-scope-dot" />
               {scopeName}
             </div>
-            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={refreshDevices}>
+            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm" onClick={handleRefreshAll}>
               Refresh All
             </button>
           </div>
@@ -177,12 +286,6 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
         <div className="device-runtime-groups">
           {Object.entries(siteGroups).map(([siteName, siteDevices]) => (
             <section className="device-runtime-site-group" key={siteName} aria-label={`${siteName} devices`}>
-              <div className="device-runtime-site-heading">
-                <span>{siteName}</span>
-                <span className="device-runtime-site-count">
-                  {siteDevices.length} {siteDevices.length === 1 ? "device" : "devices"}
-                </span>
-              </div>
               <div className="device-runtime-device-grid">
                 {siteDevices.map((device) => (
                   <article className="device-runtime-card" key={device.id} tabIndex={0}>
@@ -196,15 +299,16 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
                       <div className="device-runtime-meta">
                         <span className="device-runtime-meta-label">Last Seen</span>
                         <span className="device-runtime-meta-value">
-                          {new Date(device.lastSeen).toLocaleTimeString([], {
-                            hour: "2-digit",
-                            minute: "2-digit",
-                          })}
+                          {formatDeviceLastSeen(
+                            device,
+                            now,
+                            deviceLastSeenAt[device.id] ?? sessionStartedAt,
+                          )}
                         </span>
                       </div>
                       <div className="device-runtime-meta">
                         <span className="device-runtime-meta-label">Device Type</span>
-                        <span className="device-runtime-meta-value">{device.type}</span>
+                        <span className="device-runtime-meta-value">{displayDeviceType(device.type)}</span>
                       </div>
                       <div className="device-runtime-meta">
                         <span className="device-runtime-meta-label">Location</span>
@@ -212,7 +316,7 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
                       </div>
                       <div className="device-runtime-meta device-runtime-meta--records">
                         <span className="device-runtime-meta-label">Records</span>
-                        <div className="device-runtime-records-value-row">
+                        <div className="device-runtime-records-value-stack">
                           <span className="device-runtime-meta-value">{device.recordCount?.toLocaleString() ?? "-"}</span>
                           <button
                             type="button"
@@ -237,7 +341,12 @@ const DeviceListPage: React.FC<DeviceListPageProps> = ({ credentials }) => {
                         type="button"
                         className="device-runtime-icon-action"
                         aria-label={`Refresh ${device.name}`}
-                        onClick={refreshDevices}
+                        onClick={() => {
+                          if (isLiveStatus(device.status)) {
+                            resetDeviceLastSeen(device.id);
+                          }
+                          refreshDevices();
+                        }}
                       >
                         <RefreshCw size={14} strokeWidth={2.4} aria-hidden="true" />
                         <span>Refresh</span>

--- a/frontend/src/features/devices/demoDevices.ts
+++ b/frontend/src/features/devices/demoDevices.ts
@@ -1,4 +1,3 @@
-import { countDemoRuntimeEvents } from "./demoRuntimeEvents";
 import type { DemoEventToken } from "./demoRuntimeEvents";
 import type { DeviceInfo } from "./types";
 
@@ -11,6 +10,21 @@ export type DemoDevice = {
   location: string;
   online: boolean;
   eventTokens: DemoEventToken[];
+};
+
+const DEMO_RECORD_COUNTS: Record<string, number> = {
+  "gateway-ab": 36_836,
+  "main-door-ab": 33_237,
+  "back-door-ab": 3_599,
+  "gateway-tt": 982_639,
+  "main-door-tt": 582_015,
+  "delivery-door-tt": 301_975,
+  "back-door-tt": 98_659,
+};
+
+const DEMO_OFFLINE_LAST_SEEN_LABELS: Record<string, string> = {
+  "back-door-ab": "1 day ago",
+  "back-door-tt": "14:22",
 };
 
 export const DEMO_DEVICES: DemoDevice[] = [
@@ -50,7 +64,7 @@ export const DEMO_DEVICES: DemoDevice[] = [
     siteName: "Tokis Takeout",
     label: "TT Gateway",
     type: "gateway",
-    location: "Kitchen Network",
+    location: "Office",
     online: true,
     eventTokens: ["site-b:cam-0", "site-b:cam-1", "site-b:cam-2"],
   },
@@ -130,8 +144,11 @@ export const toDeviceInfo = (device: DemoDevice): DeviceInfo => ({
   lastSeen: device.online
     ? new Date("2026-05-28T18:24:00Z").toISOString()
     : new Date("2026-05-28T16:48:00Z").toISOString(),
+  lastSeenLabel: device.online
+    ? undefined
+    : DEMO_OFFLINE_LAST_SEEN_LABELS[device.id],
   location: device.location,
-  recordCount: countDemoRuntimeEvents(device.eventTokens),
+  recordCount: DEMO_RECORD_COUNTS[device.id],
   siteId: device.siteId,
   siteName: device.siteName,
 });

--- a/frontend/src/features/devices/types.ts
+++ b/frontend/src/features/devices/types.ts
@@ -4,6 +4,7 @@ export interface DeviceInfo {
   type: "Camera" | "Sensor" | "Gateway" | "Door";
   status: "online" | "offline" | "maintenance";
   lastSeen: string;
+  lastSeenLabel?: string;
   dataSource?: string;
   location?: string;
   recordCount?: number;


### PR DESCRIPTION
### Motivation
- Provide realistic demo alarm data and allow the alarms view to be scoped by site for demo sessions.
- Surface richer alarm metadata in the UI (site, alarm type, timestamp, status) and simplify instance labeling.
- Improve device list UX by showing relative last-seen times, per-session timing, and a safer refresh that resets live-device "last seen" timings.
- Tidy up demo device data with realistic record counts and offline labels for better demo presentation.

### Description
- Added `demoAlarmLogs.ts` which seeds a catalog of alarm types and builds a historical and active demo alarm dataset, and exported `getDemoAlarmLogsForScope` for site-scoped demo data.
- Updated `useAlarmLogs` to read `siteId` from `useParams`, treat `/demo/` paths as demo sessions, and return demo alarms when in demo mode; also added `site?: string` to the `AlarmEvent` type.
- Modified `AlarmLogsPage` to rename and reorder columns (`Site`, `Alarm Type`, `Timestamp`, `Status`), show `alarm.site` where available, render severity/status elements, and wire refresh buttons to `refreshAlarms`.
- Enhanced device demo data in `demoDevices.ts` with `DEMO_RECORD_COUNTS` and `DEMO_OFFLINE_LAST_SEEN_LABELS`, adjusted a device location, and updated `toDeviceInfo` to include `lastSeenLabel` and use the new counts.
- Reworked `DeviceListPage` to compute a session `startedAt` key, format relative times via `formatRelativeTime`, expose `resetDeviceLastSeen` and `resetAllOnlineLastSeen`, and change refresh behavior so per-device refresh resets live-device last-seen timestamps and the main "Refresh All" triggers both resets and a fetch; also normalized device type display and updated markup to match CSS changes.
- Updated `DeviceInfo` type to include optional `lastSeenLabel` and applied small CSS renames/adjustments in `DeviceListPage.css` to support vertical stacking and removed site heading elements.

### Testing
- Ran TypeScript type-check via `tsc --noEmit` which succeeded. 
- Executed frontend unit tests via `yarn test` which completed successfully. 
- Ran linter via `yarn lint` with no errors reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d912f61248322bd6a579945c4a6d6)