### PR TITLE
Refine demo alarm log history

### DIFF
--- a/frontend/src/features/alarms/AlarmLogsPage.css
+++ b/frontend/src/features/alarms/AlarmLogsPage.css
@@ -1,0 +1,87 @@
+.alarm-logs-table-scroll {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  display: block;
+  overflow-x: auto;
+  overflow-y: visible;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+  overscroll-behavior-y: auto;
+}
+
+@media (max-width: 1024px) {
+  .alarm-logs-page,
+  .alarm-logs-table-scroll {
+    min-width: 0;
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .alarm-logs-table-scroll {
+    max-width: 100%;
+    display: block;
+    overflow-x: auto;
+    overflow-y: visible;
+    overscroll-behavior-x: contain;
+    overscroll-behavior-y: auto;
+    touch-action: pan-x pan-y;
+  }
+
+  .alarm-logs-table {
+    border-collapse: collapse;
+    border-spacing: 0;
+    max-width: none;
+    table-layout: fixed;
+  }
+
+  .alarm-logs-active-table {
+    min-width: 1040px;
+    width: 1040px;
+  }
+
+  .alarm-logs-history-table {
+    min-width: 980px;
+    width: 980px;
+  }
+
+  .alarm-logs-table th,
+  .alarm-logs-table td {
+    white-space: nowrap;
+  }
+
+  .alarm-logs-col-site {
+    min-width: 150px;
+    width: 150px;
+  }
+
+  .alarm-logs-col-device {
+    min-width: 170px;
+    width: 170px;
+  }
+
+  .alarm-logs-col-type {
+    min-width: 260px;
+    width: 260px;
+  }
+
+  .alarm-logs-col-timestamp {
+    min-width: 170px;
+    width: 170px;
+  }
+
+  .alarm-logs-col-status {
+    min-width: 110px;
+    width: 110px;
+  }
+
+  .alarm-logs-col-severity {
+    min-width: 130px;
+    width: 130px;
+  }
+
+  .alarm-logs-col-actions {
+    min-width: 150px;
+    width: 150px;
+  }
+}

--- a/frontend/src/features/alarms/AlarmLogsPage.tsx
+++ b/frontend/src/features/alarms/AlarmLogsPage.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Credentials } from "../../types/credentials";
 import { useAlarmLogs } from "./hooks/useAlarmLogs";
+import { isDemoSessionActive } from "../../lib/demoSession";
 import { getSeverityClass, getSeverityText } from "./utils/severityFormatters";
 interface AlarmLogsPageProps {
   credentials: Credentials;
@@ -20,6 +21,9 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
     clearedAlarms,
     refreshAlarms,
   } = useAlarmLogs(credentials);
+  const isDemoRoute =
+    isDemoSessionActive() ||
+    (typeof window !== "undefined" && window.location.pathname.startsWith("/demo/"));
   if (loading) {
     return (
       <div
@@ -166,6 +170,11 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
               Active Alarms ({activeAlarms.length})
             </h3>
             <div className="vrm-card-actions">
+              {isDemoRoute && (
+                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm">
+                  Filter
+                </button>
+              )}
               <button className="vrm-btn vrm-btn-secondary vrm-btn-sm">
                 Clear All
               </button>
@@ -248,9 +257,20 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
             Alarm History ({alarms.length} total){" "}
           </h3>
           <div className="vrm-card-actions">
-            <button className="vrm-btn vrm-btn-secondary vrm-btn-sm">
-              Export CSV
-            </button>
+            {isDemoRoute ? (
+              <>
+                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm">
+                  Filter
+                </button>
+                <button className="vrm-btn vrm-btn-secondary vrm-btn-sm">
+                  Clear All
+                </button>
+              </>
+            ) : (
+              <button className="vrm-btn vrm-btn-secondary vrm-btn-sm">
+                Export CSV
+              </button>
+            )}
             <button
               className="vrm-btn vrm-btn-sm"
               onClick={refreshAlarms}

--- a/frontend/src/features/alarms/AlarmLogsPage.tsx
+++ b/frontend/src/features/alarms/AlarmLogsPage.tsx
@@ -18,8 +18,6 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
     clientUsers,
     activeAlarms,
     clearedAlarms,
-    highSeverityAlarms,
-    mediumSeverityAlarms,
     refreshAlarms,
   } = useAlarmLogs(credentials);
   if (loading) {
@@ -124,7 +122,7 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
         </div>
       )}{" "}
       {}{" "}
-      <div className="vrm-grid vrm-grid-4" style={{ marginBottom: "24px" }}>
+      <div className="vrm-grid vrm-grid-2" style={{ marginBottom: "24px" }}>
         <div className="vrm-card">
           <div className="vrm-card-body" style={{ textAlign: "center" }}>
             <div
@@ -135,47 +133,10 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
                 marginBottom: "8px",
               }}
             >
-              {" "}
-              {activeAlarms.length}{" "}
+              {activeAlarms.length}
             </div>
             <p style={{ color: "var(--vrm-text-secondary)", fontSize: "14px" }}>
               Active Alarms
-            </p>
-          </div>
-        </div>
-        <div className="vrm-card">
-          <div className="vrm-card-body" style={{ textAlign: "center" }}>
-            <div
-              style={{
-                fontSize: "36px",
-                fontWeight: "700",
-                color: "#8b3a2f",
-                marginBottom: "8px",
-              }}
-            >
-              {" "}
-              {highSeverityAlarms}{" "}
-            </div>
-            <p style={{ color: "var(--vrm-text-secondary)", fontSize: "14px" }}>
-              High Severity
-            </p>
-          </div>
-        </div>
-        <div className="vrm-card">
-          <div className="vrm-card-body" style={{ textAlign: "center" }}>
-            <div
-              style={{
-                fontSize: "36px",
-                fontWeight: "700",
-                color: "#8b6321",
-                marginBottom: "8px",
-              }}
-            >
-              {" "}
-              {mediumSeverityAlarms}{" "}
-            </div>
-            <p style={{ color: "var(--vrm-text-secondary)", fontSize: "14px" }}>
-              Medium Severity
             </p>
           </div>
         </div>
@@ -189,8 +150,7 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
                 marginBottom: "8px",
               }}
             >
-              {" "}
-              {clearedAlarms.length}{" "}
+              {clearedAlarms.length}
             </div>
             <p style={{ color: "var(--vrm-text-secondary)", fontSize: "14px" }}>
               Cleared Alarms

--- a/frontend/src/features/alarms/AlarmLogsPage.tsx
+++ b/frontend/src/features/alarms/AlarmLogsPage.tsx
@@ -3,6 +3,7 @@ import { Credentials } from "../../types/credentials";
 import { useAlarmLogs } from "./hooks/useAlarmLogs";
 import { isDemoSessionActive } from "../../lib/demoSession";
 import { getSeverityClass, getSeverityText } from "./utils/severityFormatters";
+import "./AlarmLogsPage.css";
 interface AlarmLogsPageProps {
   credentials: Credentials;
 }
@@ -71,7 +72,7 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
     );
   }
   return (
-    <div>
+    <div className="alarm-logs-page">
       {" "}
       {}{" "}
       <div style={{ marginBottom: "24px" }}>
@@ -187,8 +188,17 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
             </div>
           </div>
           <div className="vrm-card-body" style={{ padding: 0 }}>
-            <div style={{ overflowX: "auto" }}>
-              <table className="vrm-table">
+            <div className="vrm-table-scroll alarm-logs-table-scroll">
+              <table className="vrm-table alarm-logs-table alarm-logs-active-table">
+                <colgroup>
+                  <col className="alarm-logs-col-site" />
+                  <col className="alarm-logs-col-device" />
+                  <col className="alarm-logs-col-type" />
+                  <col className="alarm-logs-col-timestamp" />
+                  <col className="alarm-logs-col-status" />
+                  <col className="alarm-logs-col-severity" />
+                  <col className="alarm-logs-col-actions" />
+                </colgroup>
                 <thead>
                   <tr>
                     <th>Site</th>
@@ -282,8 +292,16 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
         <div className="vrm-card-body" style={{ padding: 0 }}>
           {" "}
           {alarms.length > 0 ? (
-            <div style={{ overflowX: "auto" }}>
-              <table className="vrm-table">
+            <div className="vrm-table-scroll alarm-logs-table-scroll">
+              <table className="vrm-table alarm-logs-table alarm-logs-history-table">
+                <colgroup>
+                  <col className="alarm-logs-col-timestamp" />
+                  <col className="alarm-logs-col-severity" />
+                  <col className="alarm-logs-col-site" />
+                  <col className="alarm-logs-col-device" />
+                  <col className="alarm-logs-col-type" />
+                  <col className="alarm-logs-col-status" />
+                </colgroup>
                 <thead>
                   <tr>
                     <th>Timestamp</th>

--- a/frontend/src/features/alarms/demoAlarmLogs.ts
+++ b/frontend/src/features/alarms/demoAlarmLogs.ts
@@ -79,6 +79,18 @@ const formatAlarmDate = (date: Date) => {
 const addMinutes = (date: Date, minutes: number) =>
   new Date(date.getTime() + minutes * 60 * 1000);
 
+const getYesterdayAtUtcTime = (time: string) => {
+  const [hours, minutes] = time.split(":").map(Number);
+  const now = new Date();
+  return new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() - 1,
+    hours,
+    minutes,
+  ));
+};
+
 const resolveAlarmSiteScope = (siteId?: string | null): "site-a" | "site-b" | "all" => {
   switch ((siteId || "all").toLowerCase()) {
     case "ab":
@@ -168,16 +180,15 @@ const buildHistoricalAlarms = () => {
     alarms.push(buildAlarm({ index: index + 1, device, catalogKey, startedAt, clearMinutes }));
   }
 
-  const activeStartedBase = addMinutes(end, -74);
   const activeDefinitions: Array<{
     device: DemoAlarmDevice;
     catalogKey: AlarmCatalogKey;
-    minutesAgo: number;
+    time: string;
   }> = [
-    { device: DEMO_ALARM_DEVICES[1], catalogKey: "videoLost", minutesAgo: 18 },
-    { device: DEMO_ALARM_DEVICES[2], catalogKey: "queueThreshold", minutesAgo: 43 },
-    { device: DEMO_ALARM_DEVICES[5], catalogKey: "occupancyThreshold", minutesAgo: 67 },
-    { device: DEMO_ALARM_DEVICES[6], catalogKey: "cameraOffline", minutesAgo: 96 },
+    { device: DEMO_ALARM_DEVICES[1], catalogKey: "videoLost", time: "11:24" },
+    { device: DEMO_ALARM_DEVICES[2], catalogKey: "queueThreshold", time: "10:59" },
+    { device: DEMO_ALARM_DEVICES[5], catalogKey: "occupancyThreshold", time: "10:35" },
+    { device: DEMO_ALARM_DEVICES[6], catalogKey: "cameraOffline", time: "10:06" },
   ];
 
   activeDefinitions.forEach((definition, activeIndex) => {
@@ -185,7 +196,7 @@ const buildHistoricalAlarms = () => {
       index: totalHistorical + activeIndex + 1,
       device: definition.device,
       catalogKey: definition.catalogKey,
-      startedAt: addMinutes(activeStartedBase, 74 - definition.minutesAgo),
+      startedAt: getYesterdayAtUtcTime(definition.time),
       active: true,
     }));
   });

--- a/frontend/src/features/alarms/demoAlarmLogs.ts
+++ b/frontend/src/features/alarms/demoAlarmLogs.ts
@@ -1,23 +1,23 @@
 import type { AlarmEvent } from "./types";
 
 const ALARM_CATALOG = {
-  storageWarning: { description: "Storage utilisation exceeded 80%", severity: "medium" },
-  storageCritical: { description: "Storage utilisation exceeded 95%", severity: "high" },
-  gatewayOffline: { description: "Gateway heartbeat lost", severity: "high" },
-  gatewayRestored: { description: "Gateway connection restored", severity: "low" },
-  recordingRestarted: { description: "Recording service restarted", severity: "medium" },
-  databaseMaintenance: { description: "Database maintenance completed", severity: "low" },
-  cameraOffline: { description: "Device heartbeat lost", severity: "high" },
-  cameraRestored: { description: "Device connection restored", severity: "low" },
-  videoLost: { description: "Video stream unavailable", severity: "high" },
-  videoRestored: { description: "Video stream restored", severity: "low" },
-  deviceRestarted: { description: "Device restarted", severity: "medium" },
-  occupancyThreshold: { description: "Occupancy threshold exceeded", severity: "medium" },
-  queueThreshold: { description: "Queue threshold exceeded", severity: "medium" },
-  analyticsDelay: { description: "Event processing delay detected", severity: "medium" },
-  analyticsRestart: { description: "Analytics service restarted", severity: "medium" },
-  repeatedAccess: { description: "Repeated access activity detected", severity: "medium" },
-  restrictedArea: { description: "Restricted area activity detected", severity: "high" },
+  storageWarning: { description: "Capacity Exceeds 75%", severity: "medium" },
+  storageCritical: { description: "Capacity Exceeds 90%", severity: "high" },
+  gatewayOffline: { description: "Gateway Connection Lost", severity: "high" },
+  gatewayRestored: { description: "Gateway Connection Restored", severity: "low" },
+  recordingRestarted: { description: "Recording Service Restarted", severity: "medium" },
+  databaseMaintenance: { description: "Database Maintenance Completed", severity: "low" },
+  cameraOffline: { description: "Device Connection Lost", severity: "high" },
+  cameraRestored: { description: "Device Connection Restored", severity: "low" },
+  videoLost: { description: "Video Stream Unavailable", severity: "high" },
+  videoRestored: { description: "Video Stream Restored", severity: "low" },
+  deviceRestarted: { description: "Device Restarted", severity: "medium" },
+  occupancyThreshold: { description: "Occupancy Threshold Exceeded", severity: "medium" },
+  queueThreshold: { description: "Dwell Threshold Exceeded", severity: "medium" },
+  analyticsDelay: { description: "Event Processing Delay Detected", severity: "medium" },
+  analyticsRestart: { description: "Analytics Service Restarted", severity: "medium" },
+  repeatedAccess: { description: "Repeated Access Activity Detected", severity: "medium" },
+  restrictedArea: { description: "Restricted Area Activity Detected", severity: "high" },
 } as const;
 
 type AlarmCatalogKey = keyof typeof ALARM_CATALOG;
@@ -46,6 +46,8 @@ const CAMERA_ALARM_ROTATION: AlarmCatalogKey[] = [
   "queueThreshold",
   "cameraOffline",
   "cameraRestored",
+  "occupancyThreshold",
+  "queueThreshold",
   "deviceRestarted",
   "videoLost",
   "videoRestored",
@@ -64,6 +66,7 @@ const GATEWAY_ALARM_ROTATION: AlarmCatalogKey[] = [
   "storageWarning",
   "gatewayRestored",
   "analyticsDelay",
+  "storageWarning",
   "storageCritical",
   "gatewayOffline",
 ];
@@ -174,6 +177,7 @@ const buildHistoricalAlarms = () => {
     { device: DEMO_ALARM_DEVICES[1], catalogKey: "videoLost", minutesAgo: 18 },
     { device: DEMO_ALARM_DEVICES[2], catalogKey: "queueThreshold", minutesAgo: 43 },
     { device: DEMO_ALARM_DEVICES[5], catalogKey: "occupancyThreshold", minutesAgo: 67 },
+    { device: DEMO_ALARM_DEVICES[6], catalogKey: "cameraOffline", minutesAgo: 96 },
   ];
 
   activeDefinitions.forEach((definition, activeIndex) => {

--- a/frontend/src/features/alarms/hooks/useAlarmLogs.ts
+++ b/frontend/src/features/alarms/hooks/useAlarmLogs.ts
@@ -20,8 +20,6 @@ type AlarmLogsState = {
   clientUsers: Array<[string, AlarmUser]>;
   activeAlarms: AlarmEvent[];
   clearedAlarms: AlarmEvent[];
-  highSeverityAlarms: number;
-  mediumSeverityAlarms: number;
   refreshAlarms: () => void;
 };
 
@@ -125,15 +123,6 @@ export const useAlarmLogs = (
     [alarms],
   );
 
-  const highSeverityAlarms = useMemo(
-    () => alarms.filter((alarm) => alarm.severity === "high").length,
-    [alarms],
-  );
-
-  const mediumSeverityAlarms = useMemo(
-    () => alarms.filter((alarm) => alarm.severity === "medium").length,
-    [alarms],
-  );
 
   const refreshAlarms = useCallback(() => {
     if (isAdmin && selectedClient) {
@@ -153,8 +142,6 @@ export const useAlarmLogs = (
     clientUsers,
     activeAlarms,
     clearedAlarms,
-    highSeverityAlarms,
-    mediumSeverityAlarms,
     refreshAlarms,
   };
 };


### PR DESCRIPTION
### Motivation

- Populate the Alarm Logs demo with a believable, continuous history spanning 4 January 2024 → present and owned only by the existing demo devices. 
- Replace legacy/older alarm wording with an approved, final alarm taxonomy so runtime language is consistent and customer-facing.
- Make the Alarm Logs summary reflect operational reality by keeping only `Active Alarms` and `Cleared Alarms` KPI tiles while preserving severity on individual records.

### Description

- Replaced the demo alarm catalog in `frontend/src/features/alarms/demoAlarmLogs.ts` with the approved alarm descriptions and severities and adjusted camera/gateway rotation rules; the generator now produces a continuous timeline starting 2024-01-04 and a large historical set plus a small set of active alarms. 
- Updated `demoAlarmLogs.ts` to ensure only the existing demo inventory devices (TT/AB devices) own generated alarms and added an extra active alarm to improve realism. 
- Removed the top-level `High Severity` and `Medium Severity` KPI cards by changing `frontend/src/features/alarms/AlarmLogsPage.tsx` layout to a 2-card grid (Active / Cleared) and keeping severity badges inside alarm rows. 
- Removed the derived severity count fields from the hook interface by updating `frontend/src/features/alarms/hooks/useAlarmLogs.ts` so counts are no longer exposed for the removed KPI tiles while preserving `activeAlarms` and `clearedAlarms` state for the page.

### Testing

- Ran `npm ci` and `npm run build` successfully and rebuilt the frontend artifacts without errors. 
- Launched the local frontend (Vite) and backend (Uvicorn) and exercised the demo flow, starting a demo session via the demo API before navigation. 
- Verified runtime using headless Playwright checks in three viewports (Desktop 1440×900, Portrait 390×844, Landscape 844×390); all three checks passed and confirmed the Alarm Logs page is populated, shows active and cleared alarms, has severity visible in rows, and no `High Severity`/`Medium Severity` KPI tiles are present. 
- Observed runtime counts for the default demo site (`site-b` / Tokis Takeout): `Total alarms: 440`, `Active alarms: 2`, `Cleared alarms: 438`, and confirmed the implemented alarm catalog contains the exact approved labels.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ea3256a748326897134f85090e893)