### PR TITLE
Fix alarm log portrait headers

### DIFF
--- a/frontend/src/features/alarms/AlarmLogsPage.css
+++ b/frontend/src/features/alarms/AlarmLogsPage.css
@@ -85,3 +85,49 @@
     width: 150px;
   }
 }
+
+.alarm-logs-section-title-mobile {
+  display: none;
+}
+
+@media (max-width: 600px) and (orientation: portrait) {
+  .alarm-logs-section-header {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .alarm-logs-section-title {
+    width: 100%;
+  }
+
+  .alarm-logs-section-title-desktop {
+    display: none;
+  }
+
+  .alarm-logs-section-title-mobile {
+    align-items: center;
+    display: flex;
+    gap: 12px;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .alarm-logs-section-header .vrm-card-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 8px;
+    justify-content: flex-start;
+    width: 100%;
+  }
+
+  .alarm-logs-section-header .vrm-card-actions .vrm-btn {
+    flex: 0 0 auto;
+  }
+
+  .alarm-logs-section-title-mobile > span:last-child {
+    flex: 0 0 auto;
+    text-align: right;
+  }
+}

--- a/frontend/src/features/alarms/AlarmLogsPage.tsx
+++ b/frontend/src/features/alarms/AlarmLogsPage.tsx
@@ -166,9 +166,15 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
       {}{" "}
       {activeAlarms.length > 0 && (
         <div className="vrm-card" style={{ marginBottom: "24px" }}>
-          <div className="vrm-card-header">
-            <h3 className="vrm-card-title">
-              Active Alarms ({activeAlarms.length})
+          <div className="vrm-card-header alarm-logs-section-header">
+            <h3 className="vrm-card-title alarm-logs-section-title">
+              <span className="alarm-logs-section-title-desktop">
+                Active Alarms ({activeAlarms.length})
+              </span>
+              <span className="alarm-logs-section-title-mobile">
+                <span>Active Alarms</span>
+                <span>{activeAlarms.length}</span>
+              </span>
             </h3>
             <div className="vrm-card-actions">
               {isDemoRoute && (
@@ -261,10 +267,15 @@ const AlarmLogsPage: React.FC<AlarmLogsPageProps> = ({
       )}{" "}
       {}{" "}
       <div className="vrm-card">
-        <div className="vrm-card-header">
-          <h3 className="vrm-card-title">
-            {" "}
-            Alarm History ({alarms.length} total){" "}
+        <div className="vrm-card-header alarm-logs-section-header">
+          <h3 className="vrm-card-title alarm-logs-section-title">
+            <span className="alarm-logs-section-title-desktop">
+              Alarm History ({alarms.length} total)
+            </span>
+            <span className="alarm-logs-section-title-mobile">
+              <span>Alarm History</span>
+              <span>{alarms.length}</span>
+            </span>
           </h3>
           <div className="vrm-card-actions">
             {isDemoRoute ? (


### PR DESCRIPTION
### Motivation
- On phone portrait the Alarm Logs section headers (Active Alarms and Alarm History) were visually cramped with title, count and action buttons all on one row causing wrapping and clutter. 
- The goal is a minimal, responsive fix that keeps desktop and landscape unchanged while splitting the portrait header into a title/count row and a dedicated action-button row. 

### Description
- Added small markup variants in `frontend/src/features/alarms/AlarmLogsPage.tsx` to provide a desktop title/count span and a mobile title/count span for both the Active Alarms and Alarm History headers. 
- Added portrait-only CSS rules to `frontend/src/features/alarms/AlarmLogsPage.css` scoped to `@media (max-width: 600px) and (orientation: portrait)` that stack the header (`.alarm-logs-section-header`) into two rows and hide the desktop title variant while showing the mobile title/count variant and placing the `.vrm-card-actions` on its own row. 
- Changes are limited to header markup and CSS and do not alter alarm data, table layout or button behavior on desktop/landscape. 
- Files modified: `frontend/src/features/alarms/AlarmLogsPage.tsx`, `frontend/src/features/alarms/AlarmLogsPage.css`; commit: `5a64fe0e05d553d9706ae35838e9bde36a8acb2d`. 

### Testing
- `npm install` completed successfully. 
- `npm run dev` started the Vite dev server (backend API proxy warnings observed because the backend was not running), and HMR picked up the changes. 
- Playwright runtime checks were executed to simulate phone portrait, landscape and desktop views and validated that portrait headers stack into two rows with the title/count on the first row and action buttons on the second, while landscape and desktop remain unchanged (portrait: PASS, landscape: PASS, desktop: PASS). 
- `npm run build` completed successfully to ensure the production bundle includes the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef88167ec8327a9c978ecb18b2729)