### PR TITLE
Fix auth mobile secondary sidebar parity

### DIFF
--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -836,6 +836,15 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     if (target.closest("[data-mobile-sidebar-row='true']")) {
       return;
     }
+    if (target.closest(".vrm-secondary-search")) {
+      return;
+    }
+    if (mobileSidebarOpen === panel) {
+      event.preventDefault();
+      event.stopPropagation();
+      closeMobileDrawer();
+      return;
+    }
     if (mobileSidebarOpen !== panel) {
       event.preventDefault();
       event.stopPropagation();
@@ -880,21 +889,8 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
       openPrimaryDrawer();
       return;
     }
-    if (isSitesRoute) {
-      openSiteSelectorDrawer();
-      return;
-    }
-    const resolvedSiteId = siteId ?? getStoredSiteId() ?? "all";
-    setSecondaryModeMemory("site-menu");
-    setMobileDrawer({ kind: "site-menu", siteId: resolvedSiteId });
-    setMobileSidebarOpen("site");
-    navigate(
-      {
-        pathname: `${siteRoutePrefix}/${resolvedSiteId}/dashboard`,
-        search: buildSearch({ panel: undefined }),
-      },
-      { replace: isDemoSession },
-    );
+    openSiteSelectorDrawer();
+    openSitesSelector();
   };
   const handleMobileSettingsPrimaryTap = (event: React.MouseEvent<HTMLElement>) => {
     if (!isMobileViewport) return;

--- a/frontend/src/styles/VRMNavigation.css
+++ b/frontend/src/styles/VRMNavigation.css
@@ -702,9 +702,6 @@ button.vrm-nav-row {
     cursor: default;
   }
 
-  .vrm-layout--mobile.vrm-layout--mobile-site-open .mobile-sidebar-blank-collapse-zone {
-    display: none;
-  }
 
   .vrm-layout--mobile .vrm-nav-list,
   .vrm-layout--mobile .vrm-primary-nav,


### PR DESCRIPTION
```text
RUNTIME VERIFICATION SUMMARY

ISSUE 1 (Secondary blank-space close behaviour)
BEFORE:
Phone and tablet portrait secondary blank-space taps did not close the open secondary drawer; blank taps left the secondary expanded and rows visible.
AFTER:
Phone and tablet portrait blank-space taps now close the open secondary drawer for site selector, site navigation and settings secondaries (secondary reports `aria-expanded="false"`).
RESULT: PASS

ISSUE 2 (Sites opens wrong secondary context)
BEFORE:
Tapping primary `Sites` on mobile sometimes opened the inside-site navigation (`Dashboard`, `Event Logs`, `Reports`) immediately, bypassing the site selector.
AFTER:
Tapping primary `Sites` on mobile opens the site selector (`All Sites` / `Add site` or empty state) via `?panel=sites` and never immediately opens inside-site navigation.
RESULT: PASS
```

### Motivation

- Restore parity between Auth and Demo mobile sidebars so Auth inherits Demo behaviour for touch interactions and route-driven selector lifecycle.
- Ensure blank unused area taps close a visible secondary drawer on touch devices like the primary rail already does.
- Prevent the Auth primary `Sites` row from jumping straight into an inside-site navigation context without first showing the site selector.

### Description

- Added mobile panel pointer handling in `frontend/src/components/VRMLayout.tsx` to ignore taps on protected elements (`[data-mobile-sidebar-row]`, explicit close buttons, and the secondary search) while closing the open drawer when the user taps secondary background (`handleMobilePanelPointerDown`).
- Changed `handleMobileSitesPrimaryTap` to open the site selector flow (`openSiteSelectorDrawer()` + `openSitesSelector()`) instead of immediately opening a site-menu/dashboard context for Auth mobile taps.
- Restored availability of the secondary blank collapse zone by removing the rule that hid it when the secondary drawer was open in `frontend/src/styles/VRMNavigation.css` so unused secondary vertical space can collapse the drawer.
- No changes to Demo behaviour, routing, or desktop interactions beyond making Auth follow Demo's mobile lifecycle.

### Testing

- Built the frontend with `npm --prefix frontend run build` and the build completed successfully.
- Executed automated runtime proof scripts (Playwright-based checks executed via `frontend/sidebar-proof.mjs` and `frontend/desktop-proof.mjs`) that mocked `/api/me` and validated phone and tablet-portrait touch flows and a desktop click flow, and all scripted checks passed as shown in the runtime evidence above.
- All automated checks (build + runtime proof scripts) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2125af921c832895ead7684c5e1995)