### PR TITLE
Fix All Sites mobile sidebar transition & scope Event Logs device dropdown

### DIFF
--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -883,6 +883,9 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     event.stopPropagation();
     const isSameRoute = isSameMobileRoute(targetPath);
     if (isSameRoute && isRowActive) {
+      if (panel === "site" && mobileSidebarOpen === "site") {
+        closeMobileDrawer();
+      }
       return;
     }
     if (mobileSidebarOpen !== panel) {

--- a/frontend/src/components/VRMLayout.tsx
+++ b/frontend/src/components/VRMLayout.tsx
@@ -286,6 +286,23 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
     setMobileDrawer({ kind: "closed" });
     setMobileSidebarOpen(null);
   };
+  const handleMobileAllSitesSelection = (event: React.MouseEvent<HTMLElement>) => {
+    if (!isMobileViewport || !isAuthenticated) {
+      return false;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    const nextSiteId = allSitesOption.id;
+    setSecondaryModeMemory("site-menu");
+    setMobileDrawer({ kind: "site-menu", siteId: nextSiteId });
+    setMobileSidebarOpen("site");
+    navigate(
+      getNavigationPath(`${siteRoutePrefix}/${nextSiteId}/dashboard`, {
+        panel: undefined,
+      }),
+    );
+    return true;
+  };
   useEffect(() => {
     if (typeof window === "undefined") {
       return;
@@ -1415,6 +1432,9 @@ const VRMLayout: React.FC<VRMLayoutProps> = ({
                 }
                 onTap={(event) =>
                   (() => {
+                    if (handleMobileAllSitesSelection(event)) {
+                      return;
+                    }
                     setSecondaryModeMemory(
                       isMobileViewport ? "site-menu" : "selector",
                     );

--- a/frontend/src/features/events/EventLogsPage.css
+++ b/frontend/src/features/events/EventLogsPage.css
@@ -114,6 +114,21 @@
   touch-action: pan-y;
 }
 
+.event-devices-empty {
+  color: var(--vrm-text-secondary);
+  font-size: var(--vrm-typography-font-size-body-sm);
+  line-height: 1.35;
+  padding: var(--vrm-spacing-2) var(--vrm-spacing-3);
+}
+
+.event-devices-empty p {
+  margin: 0;
+}
+
+.event-devices-empty p + p {
+  margin-top: var(--vrm-spacing-1);
+}
+
 .event-devices-option {
   align-items: center;
   background: transparent;

--- a/frontend/src/features/events/EventLogsPage.tsx
+++ b/frontend/src/features/events/EventLogsPage.tsx
@@ -1,13 +1,16 @@
 import React from "react";
+import { useParams } from "react-router-dom";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 import { Credentials } from "../../types/credentials";
 import { useEventLogsQuery } from "./hooks/useEventLogsQuery";
 import type { searchEvents } from "./transport/searchEvents";
 import DevicesMultiSelect from "./components/DevicesMultiSelect";
+import { getEventDeviceOptionsForSiteId } from "./utils/eventDevices";
 import type { EventData } from "./utils/eventTypes";
 import "./EventLogsPage.css";
 import { demoNow, formatDemoTimestamp, parseDemoTimestamp } from "../../lib/demoTime";
+import { isDemoSessionActive } from "../../lib/demoSession";
 import { installEventLogsRuntimeProof, runEventLogsRuntimeProofSuite, type RuntimeProofSuite } from "./runtimeProof";
 interface EventLogsPageProps {
   credentials: Credentials;
@@ -21,6 +24,12 @@ const EventLogsPage: React.FC<EventLogsPageProps> = ({
   viewTokenOverride,
   clientIdOverride,
 }) => {
+  const { siteId } = useParams();
+  const isDemoSession = isDemoSessionActive();
+  const deviceOptions = React.useMemo(
+    () => (isDemoSession ? undefined : getEventDeviceOptionsForSiteId(siteId)),
+    [isDemoSession, siteId],
+  );
   const {
     events,
     loading,
@@ -516,6 +525,7 @@ const EventLogsPage: React.FC<EventLogsPageProps> = ({
               </label>
               <DevicesMultiSelect
                 id="event-devices-filter"
+                options={deviceOptions}
                 value={draftFilters.deviceTokens}
                 onChange={(deviceTokens) =>
                   setDraftFilters((prev) => ({

--- a/frontend/src/features/events/components/DevicesMultiSelect.tsx
+++ b/frontend/src/features/events/components/DevicesMultiSelect.tsx
@@ -144,24 +144,31 @@ const DevicesMultiSelect: React.FC<DevicesMultiSelectProps> = ({
               role="listbox"
               style={menuStyle}
             >
-              {options.map((option) => {
-                const isSelected = selectedTokens.has(option.token);
-                return (
-                  <button
-                    aria-selected={isSelected}
-                    className={`event-devices-option${isSelected ? " event-devices-option--selected" : ""}`}
-                    key={option.token}
-                    onClick={() => toggleToken(option.token)}
-                    role="option"
-                    type="button"
-                  >
-                    <span aria-hidden="true" className="event-devices-option__check">
-                      {isSelected ? "✓" : ""}
-                    </span>
-                    <span className="event-devices-option__text">{option.label}</span>
-                  </button>
-                );
-              })}
+              {options.length === 0 ? (
+                <div className="event-devices-empty" role="status">
+                  <p>No devices connected.</p>
+                  <p>Please add a site and connect a device.</p>
+                </div>
+              ) : (
+                options.map((option) => {
+                  const isSelected = selectedTokens.has(option.token);
+                  return (
+                    <button
+                      aria-selected={isSelected}
+                      className={`event-devices-option${isSelected ? " event-devices-option--selected" : ""}`}
+                      key={option.token}
+                      onClick={() => toggleToken(option.token)}
+                      role="option"
+                      type="button"
+                    >
+                      <span aria-hidden="true" className="event-devices-option__check">
+                        {isSelected ? "✓" : ""}
+                      </span>
+                      <span className="event-devices-option__text">{option.label}</span>
+                    </button>
+                  );
+                })
+              )}
             </div>,
             portalTarget,
           )

--- a/frontend/src/features/events/components/DevicesMultiSelect.tsx
+++ b/frontend/src/features/events/components/DevicesMultiSelect.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import {
   EVENT_DEVICE_OPTIONS,
   summarizeEventDeviceSelection,
+  type EventDeviceOption,
   type EventDeviceToken,
 } from "../utils/eventDevices";
 
@@ -11,9 +12,15 @@ interface DevicesMultiSelectProps {
   id?: string;
   value: EventDeviceToken[];
   onChange: (value: EventDeviceToken[]) => void;
+  options?: EventDeviceOption[];
 }
 
-const DevicesMultiSelect: React.FC<DevicesMultiSelectProps> = ({ id, value, onChange }) => {
+const DevicesMultiSelect: React.FC<DevicesMultiSelectProps> = ({
+  id,
+  value,
+  onChange,
+  options = EVENT_DEVICE_OPTIONS,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const [menuStyle, setMenuStyle] = useState<React.CSSProperties | undefined>();
   const wrapperRef = useRef<HTMLDivElement | null>(null);
@@ -22,7 +29,7 @@ const DevicesMultiSelect: React.FC<DevicesMultiSelectProps> = ({ id, value, onCh
   const buttonId = id ?? generatedButtonId;
   const menuId = useId();
   const selectedTokens = new Set(value);
-  const summary = summarizeEventDeviceSelection(value);
+  const summary = summarizeEventDeviceSelection(value, options);
   const portalTarget = wrapperRef.current?.closest(".demo-overlay") ?? document.body;
 
   const updateMenuPosition = () => {
@@ -137,7 +144,7 @@ const DevicesMultiSelect: React.FC<DevicesMultiSelectProps> = ({ id, value, onCh
               role="listbox"
               style={menuStyle}
             >
-              {EVENT_DEVICE_OPTIONS.map((option) => {
+              {options.map((option) => {
                 const isSelected = selectedTokens.has(option.token);
                 return (
                   <button

--- a/frontend/src/features/events/utils/eventDevices.ts
+++ b/frontend/src/features/events/utils/eventDevices.ts
@@ -25,6 +25,21 @@ export const EVENT_DEVICE_OPTIONS: EventDeviceOption[] = [
   { token: "site-b:cam-2", label: "TT: Back Door Camera", siteId: 1, cameraId: 2, kind: "camera" },
 ];
 
+const EVENT_DEVICE_SITE_TOKEN_PREFIX: Record<string, string> = {
+  "site-a": "site-a",
+  "site-b": "site-b",
+};
+
+export const getEventDeviceOptionsForSiteId = (
+  siteId?: string | null,
+): EventDeviceOption[] => {
+  const tokenPrefix = siteId ? EVENT_DEVICE_SITE_TOKEN_PREFIX[siteId] : undefined;
+  if (!tokenPrefix) {
+    return [];
+  }
+  return EVENT_DEVICE_OPTIONS.filter((option) => option.token.startsWith(`${tokenPrefix}:`));
+};
+
 const EVENT_DEVICE_TOKEN_SET = new Set(EVENT_DEVICE_OPTIONS.map((option) => option.token));
 
 export const isEventDeviceToken = (value: string): value is EventDeviceToken =>
@@ -47,12 +62,15 @@ export const normalizeEventDeviceTokens = (values: unknown): EventDeviceToken[] 
   return tokens;
 };
 
-export const summarizeEventDeviceSelection = (tokens: EventDeviceToken[]): string => {
+export const summarizeEventDeviceSelection = (
+  tokens: EventDeviceToken[],
+  options: EventDeviceOption[] = EVENT_DEVICE_OPTIONS,
+): string => {
   if (tokens.length === 0) {
     return "All Devices";
   }
   if (tokens.length === 1) {
-    return EVENT_DEVICE_OPTIONS.find((option) => option.token === tokens[0])?.label ?? "1 device selected";
+    return options.find((option) => option.token === tokens[0])?.label ?? "1 device selected";
   }
   return `${tokens.length} devices selected`;
 };


### PR DESCRIPTION
### Motivation
- Ensure authenticated touch/mobile users who tap `All Sites` immediately see the In-Site navigation (Dashboard, Event Logs, Alarm Logs, Device List, Reports) without extra interactions. 
- Ensure the Event Logs `Devices` dropdown reflects the current authenticated site context by showing no devices when operating under `All Sites` while preserving demo behaviour for demo sessions. 
- Limit changes to the two reported regressions and avoid modifying demo, desktop, or unrelated routes/logic. 

### Description
- Added a mobile-specific handler `handleMobileAllSitesSelection` in `VRMLayout.tsx` that keeps the secondary panel open, switches the secondary drawer into `site-menu`, clears the `panel` query, and navigates to the All Sites dashboard as part of the same tap interaction; wired the All Sites primary onTap to use this handler. (file: `frontend/src/components/VRMLayout.tsx`) 
- Scoped device options for Event Logs by introducing `getEventDeviceOptionsForSiteId` and returning an empty array for `all`/unknown site contexts, and changed `summarizeEventDeviceSelection` to accept a custom option list. (file: `frontend/src/features/events/utils/eventDevices.ts`) 
- Updated `EventLogsPage` to compute `deviceOptions` from the current `siteId` and pass that list to the devices multi-select, so All Sites yields an empty dropdown while individual sites still display their devices. (file: `frontend/src/features/events/EventLogsPage.tsx`) 
- Made `DevicesMultiSelect` accept an `options` prop and render only the provided options (defaulting to the previous full list), and adjusted selection summary to use the supplied options. (file: `frontend/src/features/events/components/DevicesMultiSelect.tsx`) 

### Testing
- Built the frontend with `npm --prefix frontend run build` and the build completed successfully. 
- Installed Playwright browsers and dependencies with `npx playwright install chromium` and `npx playwright install-deps chromium`; both completed successfully. 
- Ran an automated Playwright runtime verification script (`node scripts/verify-auth-sidebar-repair.mjs`) using a touch viewport (iPhone 12 emulation) which exercised: open primary `Sites`, tap `All Sites`, verify the secondary panel switched to In-Site Navigation immediately (Test A), open `All Sites → Event Logs` and confirm the `Devices` dropdown contains zero entries (Test B), then verify site-specific Event Logs still show devices (Test C); the script reported both Issue 1 = PASS and Issue 2 = PASS and produced screenshots under `frontend/test-results/auth-sidebar-repair/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2152f4bfc4833183a42edc204d6b7a)