### PR TITLE
Fix Manage Access phone layout and empty-site invite guardrail

### DIFF
--- a/frontend/src/features/settings/SettingsPages.css
+++ b/frontend/src/features/settings/SettingsPages.css
@@ -150,6 +150,10 @@
   font-size: 12px;
 }
 
+.settings-form-error {
+  white-space: pre-line;
+}
+
 .settings-table-wrap {
   width: 100%;
   overflow-x: auto;
@@ -318,4 +322,10 @@
 
 .settings-manage-access-save-message {
   padding: 0 16px 14px;
+}
+
+@media (max-width: 600px) and (orientation: portrait) {
+  .settings-manage-access-card .settings-table {
+    min-width: 680px;
+  }
 }

--- a/frontend/src/features/settings/pages/ManageAccessPage.tsx
+++ b/frontend/src/features/settings/pages/ManageAccessPage.tsx
@@ -15,6 +15,9 @@ import UsersTable from "../components/UsersTable";
 import type { AccessLevel, ManagedUser, PendingInvite, SettingsUser } from "../types";
 import "../SettingsPages.css";
 
+const EMPTY_ALL_SITES_INVITE_MESSAGE =
+  "All Sites has no sites.\n\nPlease add a site to invite a member to your workspace.";
+
 const ManageAccessPage: React.FC = () => {
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [invites, setInvites] = useState<PendingInvite[]>([]);
@@ -29,6 +32,7 @@ const ManageAccessPage: React.FC = () => {
   const siteOptions = [
     { id: "all-sites", label: "All Sites" },
   ];
+  const hasInviteableSites = siteOptions.some((site) => site.id !== "all-sites");
 
   const isDirty = useMemo(() => {
     const left = [...baselineCurrentUserSites].sort().join("|");
@@ -84,6 +88,10 @@ const ManageAccessPage: React.FC = () => {
     site: string;
     accessLevel: AccessLevel;
   }) => {
+    if (!hasInviteableSites && payload.site === "all-sites") {
+      throw new Error(EMPTY_ALL_SITES_INVITE_MESSAGE);
+    }
+
     try {
       await inviteUser(payload);
     } catch (error) {
@@ -114,7 +122,7 @@ const ManageAccessPage: React.FC = () => {
         }
       />
 
-      <div className="vrm-card">
+      <div className="vrm-card settings-manage-access-card">
         <div className="vrm-card-header settings-users-card-header">
           <button
             type="button"
@@ -138,7 +146,7 @@ const ManageAccessPage: React.FC = () => {
         </div>
       </div>
 
-      <div className="vrm-card">
+      <div className="vrm-card settings-manage-access-card">
         <div className="vrm-card-header">
           <h2 className="vrm-card-title">Pending invitations</h2>
         </div>


### PR DESCRIPTION
### Motivation

- Prevent Manage Access table content from being crushed on portrait phones by enabling internal horizontal scrolling inside the page card rather than the whole app shell.
- Provide a clear, contextual error message when the invite flow is attempted but there are no inviteable sites (workspace effectively empty), instead of surfacing the generic "Not implemented yet" error.

### Description

- Added a page-specific card class `settings-manage-access-card` to the Manage Access cards in `frontend/src/features/settings/pages/ManageAccessPage.tsx` so mobile-only layout rules can be scoped to this page.
- Introduced a minimum table width for portrait phones in `frontend/src/features/settings/SettingsPages.css` under `@media (max-width: 600px) and (orientation: portrait)` so the `.settings-table` inside `.settings-manage-access-card` is horizontally scrollable instead of being squeezed.
- Added an invite guardrail to `handleInviteSubmit` in `ManageAccessPage.tsx` that throws a contextual error message `EMPTY_ALL_SITES_INVITE_MESSAGE` when only `All Sites` exists, preventing the code path that previously produced "Not implemented yet".
- Preserved multiline formatting for invite errors by adding `white-space: pre-line` to `.settings-form-error` in `SettingsPages.css` so the two-paragraph message renders with the required blank line.

### Testing

- Built the frontend with `npm run build` and verified the build completed successfully (production assets generated). — Success.
- Installed Playwright browsers and OS deps with `npx playwright install chromium` and `npx playwright install-deps chromium` to enable runtime checks. — Success.
- Started the backend (`uvicorn backend.fastapi_app:app`) and frontend dev server (`npm run dev`) and executed the runtime verification scripts with Playwright: `node /tmp/verify_manage_access.mjs` and `node /tmp/verify_phone_sidebar.mjs`, which simulated phone-portrait interactions and validated layout and invite messaging; both checks passed and observed outputs matched the required message. — Success (BigQuery credential warnings observed on startup were non-blocking for the tests).
- Regression smoke: desktop Manage Access and My Account rendered as expected during checks (no regressions observed). — Success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225209f2b48328a72a625c75d5a94f)